### PR TITLE
Optimize feature parse from JSON shard storage

### DIFF
--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -1,19 +1,39 @@
 var queue = require('queue-async');
 
 module.exports = {};
+module.exports.seek = seek;
 module.exports.getFeature = getFeature;
 module.exports.getAllFeatures = getAllFeatures;
 module.exports.putFeature = putFeature;
 module.exports.putFeatures = putFeatures;
 
+// Seek to individual entry in JSON shard without doing a JSON.parse()
+// against the entire shard. This is a performance optimization.
+function seek(buffer, id) {
+    buffer = typeof buffer === 'string' ? buffer : buffer.toString();
+
+    var start = buffer.indexOf('"'+id+'":"{');
+    if (start === -1) return false;
+
+    start = buffer.indexOf('"{', start);
+    var end = buffer.indexOf('}"', start);
+    var entry = buffer.slice(start, end+2);
+
+    return JSON.parse(JSON.parse(entry));
+}
+
 function getFeature(source, id, callback) {
     var s = shard(source._geocoder.shardlevel, id);
+    source._geocoder.fcache = source._geocoder.fcache || {};
     source.getGeocoderData('feature', s, function(err, buffer) {
         if (err) return callback(err);
+        var data;
         try {
-            var data = buffer && buffer.length ? JSON.parse(buffer) : {};
-            return callback(null, data[id] && JSON.parse(data[id]));
-        } catch (err) { return callback(err); }
+            data = seek(buffer, id);
+        } catch(err) {
+            return callback(err);
+        }
+        return callback(null, data);
     });
 }
 

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -1,0 +1,16 @@
+var tape = require('tape');
+var feature = require('../lib/util/feature.js');
+
+tape('seek', function(assert) {
+    var shardString = JSON.stringify({
+        1: JSON.stringify({ id: 1 }),
+        2: JSON.stringify({ id: 2 }),
+    });
+    var shardBuffer = new Buffer(shardString);
+    assert.deepEqual(feature.seek(shardString, 3), false);
+    assert.deepEqual(feature.seek(shardString, 2), { id: 2 });
+    assert.deepEqual(feature.seek(shardBuffer, 3), false);
+    assert.deepEqual(feature.seek(shardBuffer, 2), { id: 2 });
+    assert.end();
+});
+


### PR DESCRIPTION
Avoids `JSON.parse` of large feature shards by seeking to individual feature entries.