### PR TITLE
[big-pants] relevnum

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ function Geocoder(options) {
         indexes = pairs(options);
 
     this.indexes = indexes.reduce(toObject, {});
-    this.order = {};
     this.byname = {};
     this.byidx = {};
     this.nameidx = {};
@@ -59,9 +58,6 @@ function Geocoder(options) {
             source._geocoder.id = id;
             source._geocoder.idx = i;
             source._geocoder.bounds = info.bounds || [ -180, -85, 180, 85 ];
-
-            // map id => idx
-            this.order[id] = names.indexOf(name);
 
             // add name => idx lookup
             this.nameidx[name] = names.indexOf(name);

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Geocoder(options) {
     this.indexes = indexes.reduce(toObject, {});
     this.order = {};
     this.byname = {};
+    this.byidx = {};
     this.nameidx = {};
 
     indexes.forEach(function(index) {
@@ -67,6 +68,9 @@ function Geocoder(options) {
 
             // add byname index lookup
             this.byname[name].push(source);
+
+            // add byidx index lookup
+            this.byidx[i] = source;
         }.bind(this));
 
         this.emit('open', err);

--- a/lib/context.js
+++ b/lib/context.js
@@ -24,14 +24,14 @@ var scanDirections = [
 // @param {Object} geocoder: geocoder instance
 // @param {Float} lon: input longitude
 // @param {Float} lat: input latitude
-// @param {String} maxtype: optional type of the most detailed feature to return
+// @param {String} maxidx: optional type of the most detailed feature to return
 // @param {String} full: boolean of whether to do a full load of all features
 // @param {Function} callback
-module.exports = function(geocoder, lon, lat, maxtype, full, callback) {
+module.exports = function(geocoder, lon, lat, maxidx, full, callback) {
     var context = [];
     var indexes = geocoder.indexes;
     var types = Object.keys(indexes);
-    types = types.slice(0, maxtype ? types.indexOf(maxtype) : types.length);
+    types = types.slice(0, typeof maxidx === 'number' ? maxidx : types.length);
 
     // No-op context.
     if (!types.length) return callback(null, context);

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -93,7 +93,6 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
 }
 
 var uniq = require('./util/uniq');
-var Relev = require('./util/relev');
 var idmod = Math.pow(2,25);
 
 function forwardGeocode(geocoder, tokenized, options, callback) {
@@ -108,6 +107,9 @@ function forwardGeocode(geocoder, tokenized, options, callback) {
 
     // keyword search. Find matching features.
     stats.searchTime = +new Date();
+
+    var mp25 = Math.pow(2,25);
+    var mp33 = Math.pow(2,33);
 
     // search runs `geocoder.search` over each backend with `data.query`,
     // condenses all of the results, and sorts them by potential usefulness.
@@ -136,21 +138,14 @@ function forwardGeocode(geocoder, tokenized, options, callback) {
             // associated features.
             for (var a = 0; a < phrases.length; a++) {
                 var phrase = phrases[a];
-                var relev = relevs[phrase];
+                var relev = (relevs[phrase]/mp33|0) * mp33;
                 var featgrids = dbcache.get('grid', phrase);
                 for (var b = 0; b < featgrids.length; b++) {
                     var feat = featgrids[b] % idmod;
                     var tmpid = dbidx * 1e8 + feat;
-                    if (features[tmpid] && maxrelev[tmpid] >= relev.tmprelev) continue;
-                    features[tmpid] = new Relev(feat,
-                        relev.relev,
-                        relev.reason,
-                        relev.count,
-                        dbidx,
-                        dbid,
-                        dbname,
-                        tmpid);
-                    maxrelev[tmpid] = relev.tmprelev;
+                    if (features[tmpid] && maxrelev[tmpid] >= relev) continue;
+                    features[tmpid] = relev + (dbidx*mp25) + feat;
+                    maxrelev[tmpid] = relev;
                 }
             }
         }

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -98,7 +98,7 @@ function loadDoc(doc, freq, known, zoom) {
         patch.term[sigid] = patch.term[sigid] || [];
         patch.term[sigid].push(phrase);
         patch.grid[phrase] = patch.grid[phrase] || [];
-        patch.grid[phrase].push.apply(patch.grid[phrase], doc._grid);
+        patch.grid[phrase] = patch.grid[phrase].concat(doc._grid);
         // Debug significant term selection.
         if (DEBUG) {
             var debug = termsmap;

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -58,7 +58,7 @@ function processPatch (patch, types, full) {
                 full[type][k] = full[type][k] || patch[type][k];
             } else if (type !== 'docs') {
                 full[type][k] = full[type][k] || [];
-                full[type][k].push.apply(full[type][k], patch[type][k]);
+                full[type][k] = full[type][k].concat(patch[type][k]);
             }
         }
     }

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -1,19 +1,39 @@
 var queue = require('queue-async');
 
 module.exports = {};
+module.exports.seek = seek;
 module.exports.getFeature = getFeature;
 module.exports.getAllFeatures = getAllFeatures;
 module.exports.putFeature = putFeature;
 module.exports.putFeatures = putFeatures;
 
+// Seek to individual entry in JSON shard without doing a JSON.parse()
+// against the entire shard. This is a performance optimization.
+function seek(buffer, id) {
+    buffer = typeof buffer === 'string' ? buffer : buffer.toString();
+
+    var start = buffer.indexOf('"'+id+'":"{');
+    if (start === -1) return false;
+
+    start = buffer.indexOf('"{', start);
+    var end = buffer.indexOf('}"', start);
+    var entry = buffer.slice(start, end+2);
+
+    return JSON.parse(JSON.parse(entry));
+}
+
 function getFeature(source, id, callback) {
     var s = shard(source._geocoder.shardlevel, id);
+    source._geocoder.fcache = source._geocoder.fcache || {};
     source.getGeocoderData('feature', s, function(err, buffer) {
         if (err) return callback(err);
+        var data;
         try {
-            var data = buffer && buffer.length ? JSON.parse(buffer) : {};
-            return callback(null, data[id] && JSON.parse(data[id]));
-        } catch (err) { return callback(err); }
+            data = seek(buffer, id);
+        } catch(err) {
+            return callback(err);
+        }
+        return callback(null, data);
     });
 }
 

--- a/lib/util/relev.js
+++ b/lib/util/relev.js
@@ -1,22 +1,21 @@
+var POW2_48 = Math.pow(2,48);
+var POW2_45 = Math.pow(2,45);
+var POW2_33 = Math.pow(2,33);
+var POW2_32 = Math.pow(2,32);
+var POW2_25 = Math.pow(2,25);
+var POW2_12 = Math.pow(2,12);
+var POW2_8 = Math.pow(2,8);
+var POW2_5 = Math.pow(2,5);
+var POW2_3 = Math.pow(2,3);
+
 // Prototype for relevance relevd rows of Carmen.search.
 // Defined to take advantage of V8 class performance.
-module.exports = function Relev(id, relev, reason, count, idx, dbid, dbname, tmpid) {
-    this.id = id;
-
-    // relev represents a score based on comparative term weight
-    // significance alone. If it passes this threshold check it is
-    // adjusted based on degenerate term character distance (e.g.
-    // degens of higher distance reduce relev score).
-    this.relev = relev;
-
-    // reason is a bit mask of positions of matching terms as 1s
-    this.reason = reason;
-    this.count = count;
-    this.idx = idx;
-
-    // db is actually the dbname, which is a string like `'place'`
-    this.dbid = dbid;
-    this.dbname = dbname;
-
-    this.tmpid = tmpid;
+module.exports = function Relev(num) {
+    this.id = num % POW2_25;
+    this.idx = (num / POW2_25 | 0) % POW2_8;
+    this.tmpid = (this.idx * 1e8) + this.id;
+    this.reason = (num / POW2_33 | 0) % POW2_12;
+    this.count = (num / POW2_45 | 0) % POW2_3;
+    this.relev = ((num / POW2_48 | 0) % POW2_5) / (POW2_5-1);
+    this.check = true;
 };

--- a/lib/util/relev.js
+++ b/lib/util/relev.js
@@ -19,3 +19,13 @@ module.exports = function Relev(num) {
     this.relev = ((num / POW2_48 | 0) % POW2_5) / (POW2_5-1);
     this.check = true;
 };
+
+module.exports.encode = function(r) {
+    var relev = Math.floor(r.relev * (POW2_5-1));
+    return (relev * POW2_48) +
+        (r.count * POW2_45) +
+        (r.reason * POW2_33) +
+        (r.idx * POW2_25) +
+        (r.id);
+};
+

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -6,6 +6,7 @@ var queue = require('queue-async');
 var context = require('./context');
 var termops = require('./util/termops');
 var feature = require('./util/feature');
+var Relev = require('./util/relev');
 
 var mp2_14 = Math.pow(2, 14);
 var mp2_28 = Math.pow(2, 28);
@@ -15,6 +16,8 @@ module.exports.sortFeature;
 module.exports.sortContext;
 
 function verifymatch(query, stats, geocoder, matched, options, callback) {
+    // console.log('SETS length', Object.keys(matched.sets).length);
+    // console.log('RESULTS length', matched.results.length);
     var sets = matched.sets;
     var results = matched.results;
     var coalesced = matched.coalesced;
@@ -29,14 +32,15 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     // Limit initial feature check to the best 40 max.
     if (results.length > 40) results = results.slice(0,40);
 
-    results.forEach(function(term) { q.defer(loadFeature, term); });
+    results.forEach(function(num) { q.defer(loadFeature, num); });
 
     q.awaitAll(loadContexts);
 
     // For each result, load the feature from its Carmen index so that we can
     // then load all of the relevant contexts for that feature.
-    function loadFeature(term, callback) {
-        var source = geocoder.indexes[term.dbid];
+    function loadFeature(num, callback) {
+        var term = new Relev(num);
+        var source = geocoder.byidx[term.idx];
         feature.getFeature(source, term.id, function featureLoaded(err, features) {
             if (err) return callback(err);
             var result = [];
@@ -67,7 +71,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 if (checks) {
                     feat._extid = source._geocoder.name + '.' + id;
                     feat._tmpid = term.tmpid;
-                    feat._dbid = term.dbid;
+                    feat._dbidx = term.idx;
                     feat._relev = term.relev;
                     result.push(feat);
                 }
@@ -89,7 +93,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 
         var q = queue(5);
         for (var i = 0; i < features.length; i++) q.defer(function(f, done) {
-            context(geocoder, f._center[0], f._center[1], f._dbid, false, function(err, context) {
+            context(geocoder, f._center[0], f._center[1], f._dbidx, false, function(err, context) {
                 if (err) return done(err);
                 // Push feature onto the top level.
                 context.unshift(f);
@@ -106,12 +110,12 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             subsets = [];
             for (var i = 0, cjl = contexts[j].length; i < cjl; i++) {
                 var a = contexts[j][i];
-                if (sets[a._tmpid]) subsets.push(sets[a._tmpid]);
+                if (sets[a._tmpid]) subsets.push(new Relev(sets[a._tmpid]));
             }
 
             //Update the address layer bitmask & count to include the first term (assumed to be house number)
             //@TODO this will need to be updated once we support more than US addresses
-            if (address && subsets[0].reason % 2 === 0 && geocoder.indexes[subsets[0].dbid]._geocoder.geocoder_address) {
+            if (address && subsets[0].reason % 2 === 0 && geocoder.byidx[subsets[0].idx]._geocoder.geocoder_address) {
                 subsets[0].count = subsets[0].count + 1;
                 subsets[0].reason = subsets[0].reason + 1;
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -1,0 +1,16 @@
+var tape = require('tape');
+var feature = require('../lib/util/feature.js');
+
+tape('seek', function(assert) {
+    var shardString = JSON.stringify({
+        1: JSON.stringify({ id: 1 }),
+        2: JSON.stringify({ id: 2 }),
+    });
+    var shardBuffer = new Buffer(shardString);
+    assert.deepEqual(feature.seek(shardString, 3), false);
+    assert.deepEqual(feature.seek(shardString, 2), { id: 2 });
+    assert.deepEqual(feature.seek(shardBuffer, 3), false);
+    assert.deepEqual(feature.seek(shardBuffer, 2), { id: 2 });
+    assert.end();
+});
+

--- a/test/relev.test.js
+++ b/test/relev.test.js
@@ -11,3 +11,14 @@ test('relev', function(t) {
     t.equal(r.tmpid, 200000002);
     t.end();
 });
+
+test('encode', function(t) {
+    t.deepEqual(Relev.encode({
+        id: 2,
+        relev: 1,
+        reason: 3,
+        count: 2,
+        idx: 2
+    }), 8796118859120642);
+    t.end();
+});

--- a/test/relev.test.js
+++ b/test/relev.test.js
@@ -2,14 +2,12 @@ var Relev = require('../lib/util/relev');
 var test = require('tape');
 
 test('relev', function(t) {
-    var r = new Relev(0, 1, 2, 1, 3, 'place', 'place', 5);
-    t.equal(r.id, 0);
+    var r = new Relev(8796118859120642);
+    t.equal(r.id, 2);
     t.equal(r.relev, 1);
-    t.equal(r.reason, 2);
-    t.equal(r.count, 1);
-    t.equal(r.idx, 3);
-    t.equal(r.dbid, 'place');
-    t.equal(r.dbname, 'place');
-    t.equal(r.tmpid, 5);
+    t.equal(r.reason, 3);
+    t.equal(r.count, 2);
+    t.equal(r.idx, 2);
+    t.equal(r.tmpid, 200000002);
     t.end();
 });


### PR DESCRIPTION
Corresponding PR for carmen to https://github.com/mapbox/carmen-cache/pull/8.

Main substantive change is dropping of string `dbid`/`dbname` attributes from any relev objects, as these are not easily encoded into integers. Instead, the `dbidx` takes on the role of these fields.