### PR TITLE
Querymask

### DIFF
--- a/lib/pure/setrelevance.js
+++ b/lib/pure/setrelevance.js
@@ -10,13 +10,8 @@
 // @returns {Number} a number representing how relevant the array
 // of reasons have made this term.
 module.exports = function(query, sets, address) {
-    // Clone original query tokens so that this function does not
-    // change them by reference. These will be crossed off one
-    // by one to ensure each query token only counts once towards
-    // the final relev.
-    query = query.slice(0);
-
     var relevance = 0,
+        querymask = 0,
         total = query.length,
         reason2db = {},
         lastdb = -1,
@@ -41,8 +36,8 @@ module.exports = function(query, sets, address) {
         for (var j = 0; j < query.length; j++) {
             if (
                 // make sure this term has not already been counted for
-                // relevance
-                query[j] &&
+                // relevance. Uses a bitmask to mark positions counted.
+                !(querymask & (1<<j)) &&
                 // if this term matches the reason bitmask for relevance
                 (1 << j & sets[i].reason)
             ) {
@@ -50,7 +45,7 @@ module.exports = function(query, sets, address) {
                 ++tally;
                 // 'check off' this term of the query so that it isn't
                 // double-counted against a different `sets` reason.
-                query[j] = false;
+                querymask += 1<<j;
                 // once a set's term count has been exhausted short circuit.
                 // this prevents a province match from grabbing both instances
                 // of 'new' and 'york' in a 'new york new york' query.

--- a/lib/pure/setrelevance.js
+++ b/lib/pure/setrelevance.js
@@ -9,10 +9,9 @@
 // @param {Array} sets: an array of reasons for matches being relevant
 // @returns {Number} a number representing how relevant the array
 // of reasons have made this term.
-module.exports = function(query, sets, address) {
+module.exports = function(queryLength, sets) {
     var relevance = 0,
         querymask = 0,
-        total = query.length,
         reason2db = {},
         lastdb = -1,
         gappy = 0,
@@ -33,7 +32,7 @@ module.exports = function(query, sets, address) {
         usage = 0;
         count = sets[i].count;
 
-        for (var j = 0; j < query.length; j++) {
+        for (var j = 0; j < queryLength; j++) {
             if (
                 // make sure this term has not already been counted for
                 // relevance. Uses a bitmask to mark positions counted.
@@ -56,11 +55,11 @@ module.exports = function(query, sets, address) {
         // If this relevant criteria matched any terms in the query,
         // increment the total relevance score.
         if (usage) {
-            relevance += sets[i].relev * (usage / total);
+            relevance += sets[i].relev * (usage / queryLength);
             reason2db[sets[i].reason] = sets[i].idx;
             if (lastdb >= 0) gappy += (Math.abs(sets[i].idx - lastdb) - 1);
             lastdb = sets[i].idx;
-            if (tally === total) break;
+            if (tally === queryLength) break;
         } else {
             sets[i] = false;
         }

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -72,7 +72,7 @@ function spatialmatch(query, stats, geocoder, feats, grids, zooms, options) {
         // Sort by db, relev such that total relev can be
         // calculated without results for the same db being summed.
         rows.sort(sortRelevReason);
-        relev = getSetRelevance(query, rows, address);
+        relev = getSetRelevance(query.length, rows);
 
         for (i = 0, l = rows.length; i < l; i++) {
             if (!rows[i]) continue;

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -44,7 +44,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 subsets[0].reason = subsets[0].reason + 1;
             }
             
-            contexts[j]._relevance = getSetRelevance(query, subsets);
+            contexts[j]._relevance = getSetRelevance(query.length, subsets);
             contexts[j]._typeindex = geocoder.nameidx[termops.id(geocoder.byname, contexts[j][0]._extid).dbname];
         }
 

--- a/test/setrelevance.test.js
+++ b/test/setrelevance.test.js
@@ -3,38 +3,38 @@ var test = require('tape');
 
 test('getSetRelevance', function(t) {
     // No matches.
-    t.equal(0.0, getSetRelevance(['georgia','vermont'], []));
+    t.equal(0.0, getSetRelevance(2, []));
     // Relev 1 match for 1 of 2 terms.
-    t.equal(0.5, getSetRelevance(['georgia','vermont'], [
+    t.equal(0.5, getSetRelevance(2, [
         { id: 153, relev: 1, reason: 1, count: 1, idx: 0, db: 'country', tmpid: 153 }
     ]));
     // Relev 1 match for 2 of 2 terms.
-    t.equal(1, getSetRelevance(['georgia','vermont'], [
+    t.equal(1, getSetRelevance(2, [
         { id: 3553, relev: 1, reason: 2, count: 1, idx: 1, db: 'province', tmpid: 100000000003553 },
         { id: 130305, relev: 1, reason: 1, count: 1, idx: 2, db: 'place', tmpid: 300000000130305 }
     ]));
     // Relev penalized for 2 of 2 terms, but with a gap in db index.
-    t.equal(0.99, getSetRelevance(['georgia','vermont'], [
+    t.equal(0.99, getSetRelevance(2, [
         { id: 3553, relev: 1, reason: 2, count: 1, idx: 1, db: 'province', tmpid: 100000000003553 },
         { id: 130305, relev: 1, reason: 1, count: 1, idx: 3, db: 'place', tmpid: 300000000130305 }
     ]));
     // Second match for the same reason does not contribute to final relevance.
-    t.equal(0.5, getSetRelevance(['georgia','vermont'], [
+    t.equal(0.5, getSetRelevance(2, [
         { id: 153, relev: 1, reason: 1, count: 1, idx: 0, db: 'country', tmpid: 153 },
         { id: 130305, relev: 1, reason: 1, count: 1, idx: 3, db: 'place', tmpid: 300000000130305 }
     ]));
     // Second match with the same DB does not contribute to final relevance.
-    t.equal(0.5, getSetRelevance(['georgia','vermont'], [
+    t.equal(0.5, getSetRelevance(2, [
         { id: 130305, relev: 1, reason: 1, count: 1, idx: 3, db: 'place', tmpid: 300000000130305 },
         { id: 8062, relev: 1, reason: 2, count: 1, idx: 3, db: 'place', tmpid: 300000000008062 }
     ]));
     // Repeated terms with fittable counts/db indexes.
-    t.equal(1, getSetRelevance(['new','york','new','york'], [
+    t.equal(1, getSetRelevance(4, [
         { id: 1, relev: 1, reason: 15, count: 2, idx: 2, db: 'province', tmpid: 300000000000001 },
         { id: 2, relev: 1, reason: 15, count: 2, idx: 3, db: 'place', tmpid: 300000000000002 }
     ]));
     // Repeated terms but match counts are exhausted.
-    t.equal(0.5, getSetRelevance(['new','york','new','york','new','york','new','york'], [
+    t.equal(0.5, getSetRelevance(8, [
         { id: 1, relev: 1, reason: 255, count: 2, idx: 2, db: 'province', tmpid: 300000000000001 },
         { id: 2, relev: 1, reason: 255, count: 2, idx: 3, db: 'place', tmpid: 300000000000002 }
     ]));
@@ -45,7 +45,7 @@ test('getSetRelevance', function(t) {
         { id: 130305, relev: 1, reason: 1, count: 1, idx: 2, db: 'place', tmpid: 300000000130305 },
         { id: 2, relev: 1, reason: 255, count: 2, idx: 3, db: 'venue', tmpid: 300000000000002 }
     ];
-    t.equal(1, getSetRelevance(['georgia','vermont'], stack));
+    t.equal(1, getSetRelevance(2, stack));
     t.equal(!!stack[0], true, 'province 0 set');
     t.equal(stack[1], false, 'province 1 false');
     t.equal(!!stack[2], true, 'place 0 set');


### PR DESCRIPTION
Small optimization: use a bitmask rather than an array to mark query terms as used.