### PR TITLE
Limit tile-cover length to 10000

### DIFF
--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -34,10 +34,14 @@ function loadDoc(doc, freq, known, zoom) {
             console.warn('doc._zxy:    ', doc._zxy);
             doc._center = centroid(doc._geometry).geometry.coordinates;
             if(!verifyCenter(doc._center, tiles)) {
-                throw new Error('Invalid doc._center provided, and unable to calculate corrected centroid. Verify validity of doc._geometry for %s',
-                    doc._id);
+                return 'Invalid doc._center provided, and unable to calculate corrected centroid. Verify validity of doc._geometry for doc id:' + doc._id;
             }
         }
+    }
+
+    // Limit doc._zxy length
+    if (doc._zxy && doc._zxy.length > 10000) {
+        return 'doc._zxy exceeded 10000, doc id:' + doc._id;
     }
 
     doc._hash = termops.feature(doc._id.toString());
@@ -45,7 +49,7 @@ function loadDoc(doc, freq, known, zoom) {
     if (doc._zxy) for (var i = 0; i < doc._zxy.length; i++) {
         doc._grid.push(ops.zxy(doc._hash, doc._zxy[i]));
     } else {
-        throw new Error('Docs failed indexing');
+        return 'doc failed indexing, doc id:' + doc._id;
     }
 
     var texts = doc._text.split(',');

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -98,7 +98,7 @@ function loadDoc(doc, freq, known, zoom) {
         patch.term[sigid] = patch.term[sigid] || [];
         patch.term[sigid].push(phrase);
         patch.grid[phrase] = patch.grid[phrase] || [];
-        patch.grid[phrase] = patch.grid[phrase].concat(doc._grid);
+        patch.grid[phrase].push.apply(patch.grid[phrase], doc._grid);
         // Debug significant term selection.
         if (DEBUG) {
             var debug = termsmap;

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -58,7 +58,7 @@ function processPatch (patch, types, full) {
                 full[type][k] = full[type][k] || patch[type][k];
             } else if (type !== 'docs') {
                 full[type][k] = full[type][k] || [];
-                full[type][k] = full[type][k].concat(patch[type][k]);
+                full[type][k].push.apply(full[type][k], patch[type][k]);
             }
         }
     }

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -11,6 +11,12 @@ function indexdocs(docs, freq, zoom, callback) {
     var types = Object.keys(full);
     var patches = [];
 
+    function error(err) {
+        if (!callback) return;
+        callback(err);
+        callback = false;
+    }
+
     // Setup workers.
     if (TIMER) console.time('indexdocs:setup');
     for (var i = 0; i < cpus; i++) {
@@ -20,6 +26,8 @@ function indexdocs(docs, freq, zoom, callback) {
         workers[i].on('exit', exit);
         workers[i].removeAllListeners('message');
         workers[i].on('message', function(patch) {
+            if (typeof patch === 'string') return error(new Error(patch));
+
             patches.push(patch);
             if (patches.length >= 10000) {
                 if (TIMER) console.time('indexdocs:processPatch');
@@ -28,7 +36,7 @@ function indexdocs(docs, freq, zoom, callback) {
             }
             if (!--remaining) {
                 while (patches.length) processPatch(patches.shift(), types, full);
-                callback(null, full);
+                callback && callback(null, full);
             }
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -196,6 +196,30 @@ test('error -- _geometry too high resolution', function(t) {
     });
 });
 
+test('error -- _zxy too large tile-cover', function(t) {
+    var docs = [{
+        _id:2,
+        _text:'fake street',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, {
+        _id:1,
+        _text:'fake street',
+        _zxy:new Array(10001),
+        _center:[0,0]
+    }];
+    var from = new mem(docs, {maxzoom: 6}, function() {});
+    var to = new mem(docs, null, function() {});
+    var carmen = new Carmen({
+        from: from,
+        to: to
+    });
+    carmen.index(from, to, {}, function(err) {
+        t.equal('Error: doc._zxy exceeded 10000, doc id:1', err.toString());
+        t.end();
+    });
+});
+
 test('index.cleanDocs', function(assert) {
     var docs;
     var sourceWithAddress = {_geocoder:{geocoder_address:true}};


### PR DESCRIPTION
Limits tile-cover list to 10k at indexing time. Also adjusts error handling of index-workers to be non-fatal so they can be tested more easily.