### PR TITLE
Generate token-replaced text when indexing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ function update(source, docs, zoom, callback) {
         }
         if (TIMER) console.timeEnd('update:getall');
         if (TIMER) console.time('update:indexdocs');
-        indexdocs(docs, freq, zoom, updateCache);
+        indexdocs(docs, freq, zoom, source._geocoder.geocoder_tokens, updateCache);
     });
 
     function updateCache(err, patch) {

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -14,6 +14,7 @@ module.exports = {};
 module.exports.runChecks = runChecks;
 module.exports.loadDoc = loadDoc;
 module.exports.verifyCenter = verifyCenter;
+module.exports.getIndexableText = getIndexableText;
 
 process.on('message', function(data) {
     if (data.freq && data.zoom && data.geocoder_tokens) {
@@ -116,29 +117,10 @@ function loadDoc(patch, doc, freq, known, zoom) {
         return 'doc failed indexing, doc id:' + doc._id;
     }
 
-    var uniqTexts = {};
-    var texts = doc._text.split(',');
-    var termsets = [];
-    var termsmaps = [];
-    var tokensets = [];
-    // Loop over all phrases.
-    for (var x = 0; x < texts.length; x++) {
-        // Loop 2x per phrase, generating a canonical version
-        // and token-mapped version. The uniqTexts hash ensures
-        // phrases are indexed uniquely.
-        for (var mapTokens = 0; mapTokens < 1; mapTokens++) {
-            var tokens = mapTokens ?
-                termops.tokenize(texts[x]) :
-                termops.tokenMap(geocoder_tokens, termops.tokenize(texts[x]));
-            var key = tokens.join(' ');
-            if (!tokens.length) continue;
-            if (uniqTexts[key]) continue;
-            uniqTexts[key] = true;
-            termsets.push(termops.termsWeighted(tokens, freq));
-            termsmaps.push(termops.termsMap(tokens));
-            tokensets.push(tokens);
-        }
-    }
+    var indexableText = getIndexableText(doc._text, freq, geocoder_tokens);
+    var termsets = indexableText.termsets;
+    var termsmaps = indexableText.termsmaps;
+    var tokensets = indexableText.tokensets;
 
     for (var x = 0; x < termsets.length; x++) {
         var terms = termsets[x];
@@ -192,6 +174,33 @@ function loadDoc(patch, doc, freq, known, zoom) {
     }
 
     patch.docs.push(doc);
+}
+
+function getIndexableText(text, freq, geocoder_tokens) {
+    var uniqTexts = {};
+    var texts = text.split(',');
+    var termsets = [];
+    var termsmaps = [];
+    var tokensets = [];
+    // Loop over all phrases.
+    for (var x = 0; x < texts.length; x++) {
+        // Loop 2x per phrase, generating a canonical version
+        // and token-mapped version. The uniqTexts hash ensures
+        // phrases are indexed uniquely.
+        for (var mapTokens = 0; mapTokens < 2; mapTokens++) {
+            var tokens = mapTokens ?
+                termops.tokenMap(geocoder_tokens, termops.tokenize(texts[x])) :
+                termops.tokenize(texts[x]);
+            var key = tokens.join(' ');
+            if (!tokens.length) continue;
+            if (uniqTexts[key]) continue;
+            uniqTexts[key] = true;
+            termsets.push(termops.termsWeighted(tokens, freq));
+            termsmaps.push(termops.termsMap(tokens));
+            tokensets.push(tokens);
+        }
+    }
+    return { termsets:termsets, termsmaps:termsmaps, tokensets:tokensets};
 }
 
 function verifyCenter(center, tiles) {

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -43,13 +43,13 @@ function runChecks(doc, zoom) {
     }
     else if(!doc._zxy || doc._zxy.length === 0) {
         if(typeof zoom != 'number') {
-            return 'index has no zoom on _id:'+doc.id;
+            return 'index has no zoom on _id:'+doc._id;
         }
         if(zoom < 0) {
-            return 'zoom must be greater than 0 --- zoom was '+zoom+' on _id:'+doc.id;
+            return 'zoom must be greater than 0 --- zoom was '+zoom+' on _id:'+doc._id;
         }
         if(zoom > 14) {
-            return 'zoom must be less than 15 --- zoom was '+zoom+' on _id:'+doc.id;
+            return 'zoom must be less than 15 --- zoom was '+zoom+' on _id:'+doc._id;
         }
     }
     if(doc._geometry && (doc._geometry.type === 'Polygon' || doc._geometry.type === 'MultiPolygon')) {

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -8,10 +8,18 @@ var DEBUG = process.env.DEBUG;
 var freq;
 var zoom;
 var known;
+var geocoder_tokens;
+
+module.exports = {};
+module.exports.runChecks = runChecks;
+module.exports.loadDoc = loadDoc;
+module.exports.verifyCenter = verifyCenter;
+
 process.on('message', function(data) {
-    if (data.freq && data.zoom) {
+    if (data.freq && data.zoom && data.geocoder_tokens) {
         freq = data.freq;
         zoom = data.zoom;
+        geocoder_tokens = data.geocoder_tokens;
         known = { term:{} };
     } else {
         var patch = { grid: {}, term: {}, phrase: {}, degen: {}, docs: [] };
@@ -108,16 +116,28 @@ function loadDoc(patch, doc, freq, known, zoom) {
         return 'doc failed indexing, doc id:' + doc._id;
     }
 
+    var uniqTexts = {};
     var texts = doc._text.split(',');
     var termsets = [];
     var termsmaps = [];
     var tokensets = [];
+    // Loop over all phrases.
     for (var x = 0; x < texts.length; x++) {
-        var tokens = termops.tokenize(texts[x]);
-        if (!tokens.length) continue;
-        termsets.push(termops.termsWeighted(tokens, freq));
-        termsmaps.push(termops.termsMap(tokens));
-        tokensets.push(tokens);
+        // Loop 2x per phrase, generating a canonical version
+        // and token-mapped version. The uniqTexts hash ensures
+        // phrases are indexed uniquely.
+        for (var mapTokens = 0; mapTokens < 1; mapTokens++) {
+            var tokens = mapTokens ?
+                termops.tokenize(texts[x]) :
+                termops.tokenMap(geocoder_tokens, termops.tokenize(texts[x]));
+            var key = tokens.join(' ');
+            if (!tokens.length) continue;
+            if (uniqTexts[key]) continue;
+            uniqTexts[key] = true;
+            termsets.push(termops.termsWeighted(tokens, freq));
+            termsmaps.push(termops.termsMap(tokens));
+            tokensets.push(tokens);
+        }
     }
 
     for (var x = 0; x < termsets.length; x++) {
@@ -186,3 +206,4 @@ function verifyCenter(center, tiles) {
     }
     return found;
 }
+

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -5,7 +5,7 @@ var workers = [];
 module.exports = indexdocs;
 module.exports.teardown = teardown;
 
-function indexdocs(docs, freq, zoom, callback) {
+function indexdocs(docs, freq, zoom, geocoder_tokens, callback) {
     if (typeof zoom != 'number')
         return callback(new Error('index has no zoom'));
     if (zoom < 0)
@@ -28,7 +28,11 @@ function indexdocs(docs, freq, zoom, callback) {
     if (TIMER) console.time('indexdocs:setup');
     for (var i = 0; i < cpus; i++) {
         workers[i] = workers[i] || fork(__dirname + '/indexdocs-worker.js');
-        workers[i].send({freq:freq, zoom:zoom});
+        workers[i].send({
+            freq:freq,
+            zoom:zoom,
+            geocoder_tokens:geocoder_tokens
+        });
         workers[i].removeAllListeners('exit');
         workers[i].on('exit', exit);
         workers[i].removeAllListeners('message');

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -237,6 +237,7 @@ test('Cache', function(t) {
         var zoom = 6;
 
         mem._geocoder = cache;
+        mem._geocoder.geocoder_tokens = {};
 
         index.update(mem, docs, zoom, function(err) {
             if (err) t.fail();

--- a/test/indexdocs-worker.test.js
+++ b/test/indexdocs-worker.test.js
@@ -1,5 +1,64 @@
 var worker = require('../lib/indexer/indexdocs-worker.js');
 var tape = require('tape');
+var termops = require('../lib/util/termops.js');
+
+tape('worker.getIndexableText', function(assert) {
+    var freq = { 0:[2] };
+    assert.deepEqual(worker.getIndexableText('Main Street', freq, {}), {
+        termsets: [
+            [ 3935363599, 1986331711 ]
+        ],
+        termsmaps: [
+            { '1986331696': 'street', '3935363584': 'main' }
+        ],
+        tokensets: [
+            [ 'main', 'street' ]
+        ]
+    }, 'creates indexableText');
+    assert.deepEqual(worker.getIndexableText('Main Street', freq, termops.tokenizeMapping({'Street':'St'})), {
+        termsets: [
+            [ 3935363599, 1986331711 ],
+            [ 3935363599, 1263673935 ]
+        ],
+        termsmaps: [
+            { '1986331696': 'street', '3935363584': 'main' },
+            { 1263673920: 'st', 3935363584: 'main' }
+        ],
+        tokensets: [
+            [ 'main', 'street' ],
+            [ 'main', 'st' ]
+        ]
+    }, 'creates contracted phrases using geocoder_tokens');
+    assert.deepEqual(worker.getIndexableText('Main Street, main st', freq, termops.tokenizeMapping({'Street':'St'})), {
+        termsets: [
+            [ 3935363599, 1986331711 ],
+            [ 3935363599, 1263673935 ]
+        ],
+        termsmaps: [
+            { '1986331696': 'street', '3935363584': 'main' },
+            { 1263673920: 'st', 3935363584: 'main' }
+        ],
+        tokensets: [
+            [ 'main', 'street' ],
+            [ 'main', 'st' ]
+        ]
+    }, 'dedupes phrases');
+    assert.deepEqual(worker.getIndexableText('Main Street Lane', freq, termops.tokenizeMapping({'Street':'St', 'Lane':'Ln'})), {
+        termsets: [
+            [ 3935363599, 1986331711, 1860843567 ],
+            [ 3935363599, 1263673935, 1127334399 ]
+        ],
+        termsmaps: [
+            { 1860843552: 'lane', 1986331696: 'street', 3935363584: 'main' },
+            { 1127334384: 'ln', 1263673920: 'st', 3935363584: 'main' }
+        ],
+        tokensets: [
+            [ 'main', 'street', 'lane' ],
+            [ 'main', 'st', 'ln' ]
+        ]
+    }, 'dedupes phrases');
+    assert.end();
+});
 
 tape('worker.verifyCenter', function(assert) {
     assert.equal(worker.verifyCenter([0,0], [[0,0,0]]), true, 'center in tiles');

--- a/test/indexdocs-worker.test.js
+++ b/test/indexdocs-worker.test.js
@@ -1,0 +1,55 @@
+var worker = require('../lib/indexer/indexdocs-worker.js');
+var tape = require('tape');
+
+tape('worker.verifyCenter', function(assert) {
+    assert.equal(worker.verifyCenter([0,0], [[0,0,0]]), true, 'center in tiles');
+    assert.equal(worker.verifyCenter([0,-45], [[0,0,1],[1,0,1]]), false, 'center outside tiles');
+    assert.end();
+});
+
+tape('worker.runChecks', function(assert) {
+    assert.equal(worker.runChecks({
+    }), 'doc has no _id');
+    assert.equal(worker.runChecks({
+        _id:1
+    }), 'doc has no _text on _id:1');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street'
+    }), 'doc has no _center or _geometry on _id:1');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0]
+    }), 'index has no zoom on _id:1');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0]
+    }, -1), 'zoom must be greater than 0 --- zoom was -1 on _id:1');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0]
+    }, 15), 'zoom must be less than 15 --- zoom was 15 on _id:1');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0],
+        _geometry: { type: 'Polygon', coordinates: [new Array(60e3)] }
+    }, 12), 'Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts.');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0],
+        _geometry: { type: 'MultiPolygon', coordinates: [[new Array(30e3)],[new Array(30e3)]] }
+    }, 12), 'Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts.');
+    assert.equal(worker.runChecks({
+        _id:1,
+        _text:'Main Street',
+        _center:[0,0],
+        _geometry: { type: 'Point', coordinates: [0,0] }
+    }, 12), '');
+    assert.end();
+});
+


### PR DESCRIPTION
New feature: if you provide a `geocoder_tokens` key when indexing, it will be used to generate a fully condensed version of document when indexing. Saves us work on the source data side -- no more need to manually do this.

Current:

    geocoder_tokens: { 'Street': 'St' }
    document text: "Main Street"
    indexed as: "Main Street"

    # we go through the extra effort outside of carmen to do this...
    document text: "Main Street, Main St"
    indexed as: "Main Street", "Main St"

Example:

    geocoder_tokens: { 'Street': 'St' }
    document text: "Main Street"
    indexed as: "Main Street", "Main St"

Will do some testing before mergetown + release.

cc @karenzshea @ingalls @sbma44 