### PR TITLE
Index token freq

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ function update(source, docs, zoom, callback) {
     //   documents to be indexed.
     // - Stores new frequencies.
     try {
-        var freq = generateFrequency(docs);
+        var freq = generateFrequency(docs, source._geocoder.geocoder_tokens);
     } catch(err) {
         return callback(err);
     }
@@ -153,7 +153,7 @@ function update(source, docs, zoom, callback) {
     }
 }
 
-function generateFrequency(docs) {
+function generateFrequency(docs, geocoder_tokens) {
     var freq = {};
 
     // Uses freq[0] as a convention for storing total # of docs.
@@ -164,10 +164,9 @@ function generateFrequency(docs) {
         if (!docs[i]._text) {
             throw new Error('doc has no _text');
         }
-        var texts = docs[i]._text.split(',');
+        var texts = termops.getIndexableText(geocoder_tokens, docs[i]._text);
         for (var x = 0; x < texts.length; x++) {
-            var tokens = termops.tokenize(texts[x]);
-            var terms = termops.terms(tokens);
+            var terms = termops.terms(texts[x]);
             for (var k = 0; k < terms.length; k++) {
                 var id = terms[k];
                 freq[id] = freq[id] || [0];

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -14,7 +14,6 @@ module.exports = {};
 module.exports.runChecks = runChecks;
 module.exports.loadDoc = loadDoc;
 module.exports.verifyCenter = verifyCenter;
-module.exports.getIndexableText = getIndexableText;
 
 process.on('message', function(data) {
     if (data.freq && data.zoom && data.geocoder_tokens) {
@@ -117,10 +116,16 @@ function loadDoc(patch, doc, freq, known, zoom) {
         return 'doc failed indexing, doc id:' + doc._id;
     }
 
-    var indexableText = getIndexableText(doc._text, freq, geocoder_tokens);
-    var termsets = indexableText.termsets;
-    var termsmaps = indexableText.termsmaps;
-    var tokensets = indexableText.tokensets;
+    var texts = termops.getIndexableText(geocoder_tokens, doc._text);
+    var termsets = [];
+    var termsmaps = [];
+    var tokensets = [];
+    for (var x = 0; x < texts.length; x++) {
+        var tokens = texts[x];
+        termsets.push(termops.termsWeighted(tokens, freq));
+        termsmaps.push(termops.termsMap(tokens));
+        tokensets.push(tokens);
+    }
 
     for (var x = 0; x < termsets.length; x++) {
         var terms = termsets[x];
@@ -174,33 +179,6 @@ function loadDoc(patch, doc, freq, known, zoom) {
     }
 
     patch.docs.push(doc);
-}
-
-function getIndexableText(text, freq, geocoder_tokens) {
-    var uniqTexts = {};
-    var texts = text.split(',');
-    var termsets = [];
-    var termsmaps = [];
-    var tokensets = [];
-    // Loop over all phrases.
-    for (var x = 0; x < texts.length; x++) {
-        // Loop 2x per phrase, generating a canonical version
-        // and token-mapped version. The uniqTexts hash ensures
-        // phrases are indexed uniquely.
-        for (var mapTokens = 0; mapTokens < 2; mapTokens++) {
-            var tokens = mapTokens ?
-                termops.tokenMap(geocoder_tokens, termops.tokenize(texts[x])) :
-                termops.tokenize(texts[x]);
-            var key = tokens.join(' ');
-            if (!tokens.length) continue;
-            if (uniqTexts[key]) continue;
-            uniqTexts[key] = true;
-            termsets.push(termops.termsWeighted(tokens, freq));
-            termsmaps.push(termops.termsMap(tokens));
-            tokensets.push(tokens);
-        }
-    }
-    return { termsets:termsets, termsmaps:termsmaps, tokensets:tokensets};
 }
 
 function verifyCenter(center, tiles) {

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -135,7 +135,9 @@ function tokenize(query, lonlat) {
 }
 
 // Converts tokens from a query using a `geocoder_tokens` mapping.
-module.exports.tokenMap = function(map, tokens) {
+module.exports.tokenMap = tokenMap;
+
+function tokenMap(map, tokens) {
     var mapped = [];
     for (var i = 0; i < tokens.length; i++) {
         mapped.push(map[tokens[i]] || tokens[i]);
@@ -164,3 +166,28 @@ module.exports.address = function(query) {
         return null;
     }
 };
+
+// Takes a geocoder_tokens token mapping and a text string and returns
+// an array of one or more arrays of tokens that should be indexed.
+module.exports.getIndexableText = function(map, text) {
+    var uniqTexts = {};
+    var indexableText = [];
+    var texts = text.split(',');
+    // Loop over all phrases.
+    for (var x = 0; x < texts.length; x++) {
+        // Loop 2x per phrase, generating a canonical version
+        // and token-mapped version. The uniqTexts hash ensures
+        // phrases are indexed uniquely.
+        for (var mapTokens = 0; mapTokens < 2; mapTokens++) {
+            var tokens = mapTokens ?
+                tokenMap(map, tokenize(texts[x])) :
+                tokenize(texts[x]);
+            var key = tokens.join(' ');
+            if (!tokens.length || uniqTexts[key]) continue;
+            uniqTexts[key] = true;
+            indexableText.push(tokens);
+        }
+    }
+    return indexableText;
+};
+

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,7 @@ test('index.generateFrequency', function(assert) {
     });
     // @TODO should 'main' in this case collapse down to 2?
     assert.deepEqual(index.generateFrequency(docs, geocoder_tokens), {
-        0: [ 8 ],           // 4 total
+        0: [ 8 ],           // 8 total
         1025494160: [ 1 ],  // 1 road
         1263673920: [ 1 ],  // 1 rd
         1498707680: [ 1 ],  // 1 st

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,27 @@ var UPDATE = process.env.UPDATE;
 var test = require('tape');
 var termops = require('../lib/util/termops');
 
+test('index.generateFrequency', function(assert) {
+    var docs = [{_text:'main street'},{_text:'Main Road'}];
+    var geocoder_tokens = {'street':'st','road':'rd'};
+    assert.deepEqual(index.generateFrequency(docs, {}), {
+        0: [ 4 ],           // 4 total
+        1025494160: [ 1 ],  // 1 road
+        1986331696: [ 1 ],  // 1 street
+        3935363584: [ 2 ]   // 2 main
+    });
+    // @TODO should 'main' in this case collapse down to 2?
+    assert.deepEqual(index.generateFrequency(docs, geocoder_tokens), {
+        0: [ 8 ],           // 4 total
+        1025494160: [ 1 ],  // 1 road
+        1263673920: [ 1 ],  // 1 rd
+        1498707680: [ 1 ],  // 1 st
+        1986331696: [ 1 ],  // 1 street
+        3935363584: [ 4 ]   // 4 main
+    });
+    assert.end();
+});
+
 test('index.update -- error', function(t) {
     var docs = JSON.parse(fs.readFileSync(__dirname+'/fixtures/docs.json'));
     var to = new mem(docs, null, function() {});

--- a/test/indexdocs-worker.test.js
+++ b/test/indexdocs-worker.test.js
@@ -2,64 +2,6 @@ var worker = require('../lib/indexer/indexdocs-worker.js');
 var tape = require('tape');
 var termops = require('../lib/util/termops.js');
 
-tape('worker.getIndexableText', function(assert) {
-    var freq = { 0:[2] };
-    assert.deepEqual(worker.getIndexableText('Main Street', freq, {}), {
-        termsets: [
-            [ 3935363599, 1986331711 ]
-        ],
-        termsmaps: [
-            { '1986331696': 'street', '3935363584': 'main' }
-        ],
-        tokensets: [
-            [ 'main', 'street' ]
-        ]
-    }, 'creates indexableText');
-    assert.deepEqual(worker.getIndexableText('Main Street', freq, termops.tokenizeMapping({'Street':'St'})), {
-        termsets: [
-            [ 3935363599, 1986331711 ],
-            [ 3935363599, 1263673935 ]
-        ],
-        termsmaps: [
-            { '1986331696': 'street', '3935363584': 'main' },
-            { 1263673920: 'st', 3935363584: 'main' }
-        ],
-        tokensets: [
-            [ 'main', 'street' ],
-            [ 'main', 'st' ]
-        ]
-    }, 'creates contracted phrases using geocoder_tokens');
-    assert.deepEqual(worker.getIndexableText('Main Street, main st', freq, termops.tokenizeMapping({'Street':'St'})), {
-        termsets: [
-            [ 3935363599, 1986331711 ],
-            [ 3935363599, 1263673935 ]
-        ],
-        termsmaps: [
-            { '1986331696': 'street', '3935363584': 'main' },
-            { 1263673920: 'st', 3935363584: 'main' }
-        ],
-        tokensets: [
-            [ 'main', 'street' ],
-            [ 'main', 'st' ]
-        ]
-    }, 'dedupes phrases');
-    assert.deepEqual(worker.getIndexableText('Main Street Lane', freq, termops.tokenizeMapping({'Street':'St', 'Lane':'Ln'})), {
-        termsets: [
-            [ 3935363599, 1986331711, 1860843567 ],
-            [ 3935363599, 1263673935, 1127334399 ]
-        ],
-        termsmaps: [
-            { 1860843552: 'lane', 1986331696: 'street', 3935363584: 'main' },
-            { 1127334384: 'ln', 1263673920: 'st', 3935363584: 'main' }
-        ],
-        tokensets: [
-            [ 'main', 'street', 'lane' ],
-            [ 'main', 'st', 'ln' ]
-        ]
-    }, 'dedupes phrases');
-    assert.end();
-});
-
 tape('worker.verifyCenter', function(assert) {
     assert.equal(worker.verifyCenter([0,0], [[0,0,0]]), true, 'center in tiles');
     assert.equal(worker.verifyCenter([0,-45], [[0,0,1],[1,0,1]]), false, 'center outside tiles');

--- a/test/termops.test.js
+++ b/test/termops.test.js
@@ -137,3 +137,24 @@ test('termops', function(t) {
 
     t.end();
 });
+
+test('termops.getIndexableText', function(assert) {
+    var freq = { 0:[2] };
+    assert.deepEqual(termops.getIndexableText({}, 'Main Street'), [
+        [ 'main', 'street' ]
+    ], 'creates indexableText');
+    assert.deepEqual(termops.getIndexableText(termops.tokenizeMapping({'Street':'St'}), 'Main Street'), [
+        [ 'main', 'street' ],
+        [ 'main', 'st' ]
+    ], 'creates contracted phrases using geocoder_tokens');
+    assert.deepEqual(termops.getIndexableText(termops.tokenizeMapping({'Street':'St'}), 'Main Street, main st'), [
+        [ 'main', 'street' ],
+        [ 'main', 'st' ]
+    ], 'dedupes phrases');
+    assert.deepEqual(termops.getIndexableText(termops.tokenizeMapping({'Street':'St', 'Lane':'Ln'}), 'Main Street Lane'), [
+        [ 'main', 'street', 'lane' ],
+        [ 'main', 'st', 'ln' ]
+    ], 'dedupes phrases');
+    assert.end();
+});
+


### PR DESCRIPTION
Fixes an indexing bug introduced by https://github.com/mapbox/carmen/pull/202 where alternate condensed texts were not contributing to term frequency counts (and thus term weights in the phrase index).

Adds tests for `index.generateFrequency` as well.