### PR TITLE
Add geojson input plugin

### DIFF
--- a/test/context.test.js
+++ b/test/context.test.js
@@ -10,6 +10,7 @@ var path = require('path');
 var mapnik = require('mapnik');
 
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'ogr.input'));
+mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
 
 test('context vector', function(t) {
     var geocoder = new Carmen({


### PR DESCRIPTION
^^ did the latest mapnik release switch `vtile.addGeoJSON` to use the geojson input plugin? Feels a bit not like a patch semver kind of change?

cc @springmeyer @flippmoke