### PR TITLE
Eliminate duplicate results based on identical place_name text

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -14,6 +14,7 @@ module.exports = function(geocoder, query, options, callback) {
     options.stats = options.stats || false;
     options.limit = options.limit || 5;
     options.debug = options.debug ? {id: options.debug, grids: [], } : false;
+    options.allow_dupes = options.allow_dupes || false;
 
     //Proximity is currently not enabled
     if (options.proximity) {
@@ -210,15 +211,22 @@ function forwardGeocode(geocoder, query, options, callback) {
                 }
             }
 
-            contexts = contexts.slice(0, options.limit);
+            var place_names = {};
+            queryData.features = [];
             try {
-                queryData.features = [];
                 for (var i = 0; i < contexts.length; i++) {
-                    queryData.features.push(ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0]._dbidx]._geocoder.geocoder_address));
+                    var feature = ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0]._dbidx]._geocoder.geocoder_address);
+                    if (options.allow_dupes || !place_names[feature.place_name]) {
+                        queryData.features.push(feature);
+                        place_names[feature.place_name] = true;
+                    }
                 }
             } catch(err) {
                 return callback(err);
             }
+
+            queryData.features = queryData.features.slice(0, options.limit);
+
             stats.relev = contexts.length ? contexts[0]._relevance : 0;
             stats.totalTime = (+new Date()) - stats.totalTime;
 

--- a/test/geocode-unit.test.js
+++ b/test/geocode-unit.test.js
@@ -215,6 +215,15 @@ mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojso
             t.deepEqual(res.features[0].id, 'province.2');
             t.deepEqual(res.features[1].id, 'city.3');
             t.deepEqual(res.features[2].id, 'country.1');
+            t.deepEqual(res.features.length, 3);
+            t.end();
+        });
+    });
+    test('china (dedupe)', function(t) {
+        c.geocode('china', { limit_verify:3 }, function(err, res) {
+            t.ifError(err);
+            t.deepEqual(res.features[0].id, 'province.2');
+            t.deepEqual(res.features.length, 1);
             t.end();
         });
     });

--- a/test/geocode-unit.test.js
+++ b/test/geocode-unit.test.js
@@ -210,7 +210,7 @@ mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojso
         addFeature(conf.city, city, t.end);
     });
     test('china', function(t) {
-        c.geocode('china', { limit_verify:3 }, function(err, res) {
+        c.geocode('china', { limit_verify:3, allow_dupes: true }, function(err, res) {
             t.ifError(err);
             t.deepEqual(res.features[0].id, 'province.2');
             t.deepEqual(res.features[1].id, 'city.3');


### PR DESCRIPTION
With upcoming changes to `carmen-cache` it'll be easier to stack indexes in a way where they provide identical results (e.g. both address points + interpolated addresses). In almost all scenarios it's not desirable to users to have feature results that are largely identical (e.g. by `place_name`).

This PR adds feature deduping by `place_name` with an `options.allow_dupes` flag that can be set to `true` if you really want those dupes.