### PR TITLE
More aggressive deduping of addresses.

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -8,6 +8,7 @@ var sm = new (require('sphericalmercator'))(),
     queue = require('queue-async'),
     feature = require('./util/feature'),
     Relev = require('./util/relev');
+var dedupe = require('./util/dedupe');
 
 module.exports = function(geocoder, query, options, callback) {
     options = options || {};
@@ -229,19 +230,16 @@ function forwardGeocode(geocoder, query, options, callback) {
                 }
             }
 
-            var place_names = {};
             queryData.features = [];
             try {
                 for (var i = 0; i < contexts.length; i++) {
                     var feature = ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0]._dbidx]._geocoder.geocoder_address);
-                    if (options.allow_dupes || !place_names[feature.place_name]) {
-                        queryData.features.push(feature);
-                        place_names[feature.place_name] = true;
-                    }
+                    queryData.features.push(feature);
                 }
             } catch(err) {
                 return callback(err);
             }
+            if (!options.allow_dupes) queryData.features = dedupe(queryData.features);
 
             queryData.features = queryData.features.slice(0, options.limit);
 

--- a/lib/util/dedupe.js
+++ b/lib/util/dedupe.js
@@ -1,0 +1,34 @@
+var distance = require('turf-distance');
+var point = require('turf-point');
+
+module.exports = dedupe;
+
+function dedupe(features) {
+    var deduped = [];
+    var by_address = {};
+    var by_place_name = {};
+
+    for (var i = 0; i < features.length; i++) {
+        var feature = features[i];
+
+        var place_name = feature.place_name;
+        if (by_place_name[place_name]) {
+            continue;
+        } else {
+            by_place_name[place_name] = place_name;
+        }
+
+        if (feature.address) {
+            var address = feature.address + ' ' + feature.text;
+            if (by_address[address] && distance(by_address[address], point(feature.center), 'kilometers') < 10) {
+                continue;
+            } else {
+                by_address[address] = point(feature.center);
+            }
+        }
+
+        deduped.push(feature);
+    }
+
+    return deduped;
+}

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -1,0 +1,36 @@
+var dedupe = require('../lib/util/dedupe');
+var tape = require('tape');
+
+tape('dedupe', function(assert) {
+    var features;
+
+    features = [
+        { place_name: 'main st springfield', text: 'main st', center:[0,0] },
+        { place_name: 'wall st springfield', text: 'wall st', center:[10,0] },
+        { place_name: 'main st springfield', text: 'main st', center:[20,0] },
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[0],
+        features[1]
+    ], 'dedupes by place_name');
+
+    features = [
+        { place_name: '100 main st springfield 00001', address:100, text: 'main st', center:[0,0] },
+        { place_name: '100 main st springfield 00002', address:100, text: 'main st', center:[20,0] },
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[0],
+        features[1],
+    ], 'dupe identical addresses when dist >= 10km');
+
+    features = [
+        { place_name: '100 main st springfield 00001', address:100, text: 'main st', center:[0.000,0] },
+        { place_name: '100 main st springfield 00002', address:100, text: 'main st', center:[0.001,0] },
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[0]
+    ], 'dedupes identical addresses when dist < 10km');
+
+    assert.end();
+});
+


### PR DESCRIPTION
Address features may be dupes but not have identical place names. Abstract example:

    100 main st springfield 00001 (exact address point)
    100 main st springfield 00002 (interpolated point)

The place names differ because a result falls into another postal code area. These could be legitimately different addresses but in many cases they're the results of multiple results from datasets (interpolated vs exact, etc.)

In addition to deduping by `place_name` this branch adds deduping for features with `address` by `address + text` and a distance threshold of 10km as well.

cc @ingalls @karenzshea @sbma44 