### PR TITLE
Shady character (bitmask address lookup)

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -161,7 +161,7 @@ function queryAddress(query) {
         if (addr) return {addr: addr, pos: i};
     }
     return null;
-};
+}
 
 /**
  * address - finds an address giving a single string token

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -5,7 +5,6 @@ var idPattern = /^(\S+)\.([0-9]+)$/;
 var token = require('./token');
 
 module.exports.address = address;
-module.exports.queryAddress = queryAddress;
 
 //Checks if the query is requesting a specific feature by its id
 //province.### address.### etc.
@@ -144,23 +143,6 @@ function tokenize(query, lonlat) {
     }
 
     return tokens;
-}
-
-
-/**
- * queryAddress - finds a single address within a query
- *
- * @param  {Array/String} query String or Tokenized query
- * @return {Object}       A hashmap containing the address and the posion in the array or null
- */
-function queryAddress(query) {
-    query = typeof query === 'string' ? tokenize(query) : query;
-    if (query.length === 1) return null;
-    for (var i = 0; i < query.length; i++) {
-        var addr = address(query[i]);
-        if (addr) return {addr: addr, pos: i};
-    }
-    return null;
 }
 
 /**

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -5,6 +5,7 @@ var idPattern = /^(\S+)\.([0-9]+)$/;
 var token = require('./token');
 
 module.exports.address = address;
+module.exports.maskAddress = maskAddress;
 
 //Checks if the query is requesting a specific feature by its id
 //province.### address.### etc.
@@ -143,6 +144,26 @@ function tokenize(query, lonlat) {
     }
 
     return tokens;
+}
+
+/**
+ * maskAddress - finds an address given the bitmask of a query
+ * This ensures that an address is only used if it does not currently
+ * match any of the currently matched features in teh bitmask and it
+ * is a valid address
+ *
+ * @param query {Array} tokenized query
+ * @param relev {Integer} a mask for the given query
+ * @return {Object} returns an address object or null
+*/
+function maskAddress(query, mask) {
+    for (var i = 0; i < query.length; i++ ) {
+        if ((mask & Math.pow(2, i)) === 0) {
+            var addr = address(query[i]);
+            if (addr) return {addr: addr, pos: i};
+        }
+    }
+    return null;
 }
 
 /**

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -20,8 +20,6 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     var results = matched.results;
     var coalesced = matched.coalesced;
 
-    var address = termops.queryAddress(query);
-
     var contexts = [];
     var start = +new Date();
     var q = queue(10);
@@ -42,6 +40,19 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         var source = geocoder.byidx[term.idx];
         feature.getFeature(source, term.id, function featureLoaded(err, features) {
             if (err) return callback(err);
+
+            //Calculate to see if there is room for an address in the query based on bitmask
+            var address = false;
+            for (var i = 0; i < query.length; i++ ) {
+                if ((term.reason & Math.pow(2, i)) === 0) {
+                    address = termops.address(query[i]);
+                    if (address) {
+                        address = {addr: address, pos: i}
+                        break;
+                    }
+                }
+            }
+
             var result = [];
             for (var id in features) {
                 // To exclude false positives from feature hash collisions
@@ -68,6 +79,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                     checks = checks && feat._geometry;
                 }
                 if (checks) {
+                    feat._addr = address;
                     feat._extid = source._geocoder.name + '.' + id;
                     feat._tmpid = term.tmpid;
                     feat._dbidx = term.idx;
@@ -112,10 +124,9 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             for (var i = 0, cjl = contexts[j].length; i < cjl; i++) {
                 var a = contexts[j][i];
                 if (!sets[a._tmpid]) continue;
-                
-                if (subsets.length === 0 && address) {
+                if (subsets.length === 0 && a._addr) {
                     var relev = new Relev(sets[a._tmpid]);
-                    var addrMask = Math.pow(2, address.pos);
+                    var addrMask = Math.pow(2, a._addr.pos);
 
                     //Converts address position to bitmask and compares against reason
                     if ((relev.reason & addrMask) === 0 && geocoder.byidx[relev.idx]._geocoder.geocoder_address) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -20,6 +20,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     var results = matched.results;
     var coalesced = matched.coalesced;
 
+    var addrMap = {};
+
     var contexts = [];
     var start = +new Date();
     var q = queue(10);
@@ -42,7 +44,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             if (err) return callback(err);
 
             //Calculate to see if there is room for an address in the query based on bitmask
-            var address = termops.maskAddress(query, term.reason);
+            address = termops.maskAddress(query, term.reason);
 
             var result = [];
             for (var id in features) {
@@ -70,8 +72,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                     checks = checks && feat._geometry;
                 }
                 if (checks) {
-                    feat._addr = address;
                     feat._extid = source._geocoder.name + '.' + id;
+                    addrMap[feat._extid] = address;
                     feat._tmpid = term.tmpid;
                     feat._dbidx = term.idx;
                     feat._relev = term.relev;
@@ -115,9 +117,9 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             for (var i = 0, cjl = contexts[j].length; i < cjl; i++) {
                 var a = contexts[j][i];
                 if (!sets[a._tmpid]) continue;
-                if (subsets.length === 0 && a._addr) {
+                if (subsets.length === 0 && addrMap[a._extid]) {
                     var relev = new Relev(sets[a._tmpid]);
-                    var addrMask = Math.pow(2, a._addr.pos);
+                    var addrMask = Math.pow(2, addrMap[a._extid].pos);
 
                     //Converts address position to bitmask and compares against reason
                     if ((relev.reason & addrMask) === 0 && geocoder.byidx[relev.idx]._geocoder.geocoder_address) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -42,16 +42,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             if (err) return callback(err);
 
             //Calculate to see if there is room for an address in the query based on bitmask
-            var address = false;
-            for (var i = 0; i < query.length; i++ ) {
-                if ((term.reason & Math.pow(2, i)) === 0) {
-                    address = termops.address(query[i]);
-                    if (address) {
-                        address = {addr: address, pos: i}
-                        break;
-                    }
-                }
-            }
+            var address = termops.maskAddress(query, term.reason);
 
             var result = [];
             for (var id in features) {

--- a/test/geocode-unit.test.js
+++ b/test/geocode-unit.test.js
@@ -137,7 +137,7 @@ mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojso
             _zxy:['6/32/32'],
             _center:[0,0],
             _cluster: {
-                100: { type: "Point", coordinates: [0,0] },
+                100: { type: "Point", coordinates: [0,0] }
             }
         };
         addFeature(conf.address, address, t.end);

--- a/test/termops.test.js
+++ b/test/termops.test.js
@@ -95,20 +95,6 @@ test('termops', function(t) {
         q.end();
     });
 
-    t.test('address', function(q) {
-        q.deepEqual(termops.queryAddress('500 baker st'), { addr: '500', pos: 0 }, 'full address');
-        q.deepEqual(termops.queryAddress('baker st 500'), { addr: '500', pos: 2 }, 'full address');
-        q.deepEqual(termops.queryAddress(['500', 'baker', 'st']), { addr: '500', pos: 0 }, 'full address');
-        q.deepEqual(termops.queryAddress('baker st'), null, 'no housenum');
-        q.deepEqual(termops.queryAddress(['baker', 'st']), null, 'no housenum');
-        q.deepEqual(termops.queryAddress('500'), null, 'only number');
-        q.deepEqual(termops.queryAddress('500b baker st'), { addr: '500b', pos: 0 }, 'alphanumeric');
-        q.deepEqual(termops.queryAddress('baker st 500b'), { addr: '500b', pos: 2 }, 'alphanumeric');
-        q.deepEqual(termops.queryAddress('15th st'), null, 'numbered st');
-        q.deepEqual(termops.queryAddress('15 st francis drive'), { addr: '15', pos: 0 }, 'ambiguous abbr');
-        q.end();
-    });
-
     t.end();
 });
 

--- a/test/termops.test.js
+++ b/test/termops.test.js
@@ -28,10 +28,11 @@ test('termops', function(t) {
         });
         q.test('edge cases - empty string', function(r) {
             r.deepEqual(termops.tokenize(''), []);
-            r.end()
+            r.end();
         });
         q.end();
     });
+
     t.test('id - tests if searching by id', function(q) {
         var indexes = {
             country: {},
@@ -92,6 +93,15 @@ test('termops', function(t) {
         q.deepEqual(termops.phrase(['foo'], 'foo') >>> 24, 169);
         q.deepEqual(termops.phrase(['foo','street'], 'foo') >>> 24, 169);
         q.deepEqual(termops.phrase(['foo','lane'], 'foo') >>> 24, 169);
+        q.end();
+    });
+
+    t.test('maskAddress', function(q) {
+        q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100'], 7), {addr: '100', pos: 3});
+        q.deepEqual(termops.maskAddress(['100', '1', 'fake', 'street'], 6), {addr: '100', pos: 0});
+        q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100b'], 7), {addr: '100b', pos: 3});
+        q.deepEqual(termops.maskAddress(['100b', '1', 'fake', 'street'], 6), {addr: '100b', pos: 0});
+        q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100', '200'], 7), {addr: '100', pos: 3});
         q.end();
     });
 


### PR DESCRIPTION
At the moment carmen determines an address query based on the first addres-like token it encounters in a query.

This means that streets like `1 street 100` (where `100` is an address) fail as `1` is assumed to be the address. Using bitmasks prevents this as it exudes any of the currently matched text features from being used as an address.