### PR TITLE
donteverchange

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -122,15 +122,25 @@ function contextVector(source, lon, lat, full, matched, callback) {
             if (err) return callback(err);
             if (!results || !results.length) return callback(null, false);
 
+            var feat;
+            var dist = Infinity;
+
+            // Grab the feature with the lowest distance + lowest id.
+            // Ensures context has stable behavior even when features
+            // are equidistant to the query point.
+            //
             // Exclude features with a negative score.
             // Exclude features with a distance > tolerance (not yet
             // enforced upstream in mapnik).
             for (var i = 0; i < results.length; i++) {
                 if (results[i].distance > 1000) continue;
+                if (results[i].distance > dist) continue;
+
                 var attr = results[i].attributes();
 
                 // If geojson has an id in properties use that otherwise use VT id
-                attr._id = attr.id || results[i].id();
+                attr._id = attr._id || attr.id || results[i].id();
+                if (feat && attr._id > feat._id) continue;
 
                 // If this feature has a score < 0 ("ghost" feature), skip
                 // it unless it has a scored Relev object as part of a
@@ -138,11 +148,16 @@ function contextVector(source, lon, lat, full, matched, callback) {
                 var tmpid = (source._geocoder.idx*mp25) + termops.feature(attr._id);
                 if (attr._score < 0 && !matched[tmpid]) continue;
 
-                return loadFeature(source, attr, full, [lon,lat], callback);
+                feat = attr;
+                dist = results[i].distance;
             }
 
+            if (feat) {
+                return loadFeature(source, feat, full, [lon,lat], callback);
             // No matching features found.
-            return callback(null, false);
+            } else {
+                return callback(null, false);
+            }
         });
     }
 }

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -298,3 +298,83 @@ test('contextVector restricts distance', function(assert) {
         });
     });
 });
+
+(function() {
+    // +-----+ <-- query is equidistant from two features
+    // |     |
+    // | o o |
+    // |  x  |
+    // |     |
+    // |     |
+    // +-----+
+
+    var geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": { "type": "Point", "coordinates": [-0.001,0.001] },
+                "properties": { "_id":1, "_text": "A" }
+            },
+            {
+                "type": "Feature",
+                "geometry": { "type": "Point", "coordinates": [0.001,0.001] },
+                "properties": { "_id":2, "_text": "B" }
+            }
+        ]
+    };
+    var vtileA = new mapnik.VectorTile(0,0,0);
+    vtileA.addGeoJSON(JSON.stringify(geojson),"data");
+
+    geojson.features.reverse();
+    var vtileB = new mapnik.VectorTile(0,0,0);
+    vtileB.addGeoJSON(JSON.stringify(geojson),"data");
+
+    test('contextVector sorts ties A', function(assert) {
+        zlib.gzip(vtileA.getData(), function(err, buffer) {
+            assert.ifError(err);
+            var source = {
+                getTile: function(z,x,y,callback) {
+                    return callback(null, buffer);
+                },
+                _geocoder: {
+                    geocoder_layer: 'data',
+                    maxzoom: 0,
+                    minzoom: 0,
+                    name: 'test',
+                    id: 'testA',
+                    idx: 0
+                }
+            };
+            context.contextVector(source, 0, 0, false, {}, function(err, data) {
+                assert.ifError(err);
+                assert.equal(data._text, 'A');
+                assert.end();
+            });
+        });
+    });
+
+    test('contextVector sorts ties A', function(assert) {
+        zlib.gzip(vtileB.getData(), function(err, buffer) {
+            assert.ifError(err);
+            var source = {
+                getTile: function(z,x,y,callback) {
+                    return callback(null, buffer);
+                },
+                _geocoder: {
+                    geocoder_layer: 'data',
+                    maxzoom: 0,
+                    minzoom: 0,
+                    name: 'test',
+                    id: 'testA',
+                    idx: 0
+                }
+            };
+            context.contextVector(source, 0, 0, false, {}, function(err, data) {
+                assert.ifError(err);
+                assert.equal(data._text, 'A');
+                assert.end();
+            });
+        });
+    });
+})();


### PR DESCRIPTION
Currently features that are equally close to a query against a vector tile will be returned in whatever order they appear in the VT.

This PR alters this to be stable based on distance + `_id`.

