### PR TITLE
cache#loadall

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -77,7 +77,7 @@ function getPhrases(options, terms, callback) {
 // Filter all phrases down to ones most relevant to the query based
 // on their term term weights.
 function getRelevantPhrases(options, phrases, callback) {
-    options.cache.getall(options.getter, 'phrase', phrases, function(err, result) {
+    options.cache.loadall(options.getter, 'phrase', phrases, function(err, result) {
         if (err) return callback(err);
         options.cache.phrasematchPhraseRelev(options.queryLength, phrases, options.queryidx, options.querymask, options.querydist, function(err, ret) {
             if (err) return callback(err);
@@ -90,7 +90,7 @@ function getRelevantPhrases(options, phrases, callback) {
 // Turn each feature id in tile cover grids into a feature relev object
 // with the relev score from the phrase contributing to its match.
 function getGrids(options, phrases, relevs, callback) {
-    options.cache.getall(options.getter, 'grid', phrases, function(err, result) {
+    options.cache.loadall(options.getter, 'grid', phrases, function(err, result) {
         if (err) return callback(err);
 
         // Grid results from getall are not used directly as they are loaded

--- a/lib/util/cxxcache.js
+++ b/lib/util/cxxcache.js
@@ -106,76 +106,66 @@ Cache.prototype.get = function(type, id) {
 // @param {Array} ids an array of ids as numbers
 // @param {Function} callback a function invoked with `(error, unique results)`
 Cache.prototype.getall = function(getter, type, ids, callback) {
-    if (!ids.length) return callback(null, []);
-
-    var shardlevel = this.shardlevel,
-        cache = this,
-        queues = Cache.shards(shardlevel, ids),
-        shards = Object.keys(queues),
-        remaining = shards.length,
-        result = [];
-
-    var q = queue(10);
-
-    var i = shards.length;
-    while (i--) {
-        var shard = +shards[i];
-        q.defer(loadshard, shard, queues[shard], false);
-    }
-
-    q.awaitAll(function(err) {
+    var cache = this;
+    this.loadall(getter, type, ids, function(err, shards, queues) {
         if (err) return callback(err);
-        var uniqued = type === 'grid' ? result : uniq(result);
-        return callback(null, uniqued);
-    });
-
-    function error(err) {
-        remaining = -1;
-        return callback(err);
-    }
-
-    function loadshard(shard, queue, force, callback) {
-        // Loading results.
-        var has_shard = force || cache.has(type, shard);
-
-        if (!has_shard) {
-            return getter(type, shard, cacheloadshard);
-        }
-
-        function cacheloadshard(err, buffer) {
-            if (err) return callback(err);
-            else if (!buffer) {
-                    return immediate(function(){ 
-                        loadshard(shard, queue, true, callback);
-                    });
-                }
-            else {
-                try {
-                    // Sync load is used because async call is
-                    // experimental/not yet stable
-                    cache.loadSync(buffer, type, shard);
-                    immediate(function() { 
-                        loadshard(shard, queue, false, callback);
-                    });
-                } catch(e) {
-                    error(e);
-                }
-            }
-        }
 
         // Queue shard has been loaded into memory.
-        var a = queue.length;
+        var a = shards.length;
+        var result = [];
         while (a--) {
-            var id = queue[a];
-            // if (+id > Math.pow(2,32)) console.warn('ID %s', id);
-            var match = cache._get(type,+shard,+id);
-            if (match) {
-                var i = match.length;
-                while (i--) result.push(match[i]);
+            var shard = shards[a];
+            var queue = queues[shard];
+            var b = queue.length;
+            while (b--) {
+                var id = queue[b];
+                var match = cache._get(type,+shard,+id);
+                if (match) {
+                    var i = match.length;
+                    while (i--) result.push(match[i]);
+                }
             }
         }
 
-        callback();
+        result = type === 'grid' ? result : uniq(result);
+        callback(null, result);
+    });
+};
+
+// Load all shards for a given type/queue of ids.
+// Does not retrieve values from cache as hopping from cpp => js
+// divide can be expensive.
+Cache.prototype.loadall = function(getter, type, ids, callback) {
+    var shardlevel = this.shardlevel;
+    var cache = this;
+    var queues = Cache.shards(shardlevel, ids);
+    var shards = Object.keys(queues);
+    var remaining = shards.length;
+
+    var q = queue(10);
+    var i = shards.length;
+    while (i--) q.defer(loadshard, +shards[i]);
+
+    q.awaitAll(function(err) {
+        callback(err, shards, queues);
+    });
+
+    function loadshard(shard, callback) {
+        if (cache.has(type, shard)) return callback();
+
+        getter(type, shard, function(err, buffer) {
+            if (err) return callback(err);
+            if (!buffer) return callback();
+
+            // Sync load is used because async call is
+            // experimental/not yet stable
+            try {
+                cache.loadSync(buffer, type, shard);
+            } catch(e) {
+                return callback(e);
+            }
+            callback();
+        });
     }
 };
 


### PR DESCRIPTION
Performance optimization: add another method for loading shards into memory without getting the results from the cache. Avoids a cpp => v8 object conversion which can be expensive for large sets.
