### PR TITLE
Use loadall when indexing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,16 +82,16 @@ function update(source, docs, zoom, callback) {
     var getter = source.getGeocoderData.bind(source);
 
     // Ensures all shards are loaded.
-    if (TIMER) console.time('update:getall');
+    if (TIMER) console.time('update:loadall');
     var ids = Object.keys(freq).map(function(v) { return parseInt(v, 10); });
-    source._geocoder.getall(getter, 'freq', ids, function(err) {
+    source._geocoder.loadall(getter, 'freq', ids, function(err) {
         if (err) return callback(err);
         for (var i = 0; i < ids.length; i++) {
             var id = ids[i];
             freq[id][0] = (source._geocoder.get('freq', id) || [0])[0] + freq[id][0];
             source._geocoder.set('freq', id, freq[id]);
         }
-        if (TIMER) console.timeEnd('update:getall');
+        if (TIMER) console.timeEnd('update:loadall');
         if (TIMER) console.time('update:indexdocs');
         indexdocs(docs, freq, zoom, source._geocoder.geocoder_tokens, updateCache);
     });
@@ -124,7 +124,7 @@ function update(source, docs, zoom, callback) {
                 var ids = Object.keys(data);
                 var cache = source._geocoder;
                 if (TIMER) console.time('update:setParts:'+type);
-                cache.getall(getter, type, ids, function(err) {
+                cache.loadall(getter, type, ids, function(err) {
                     if (err) return callback(err);
                     for (var i = 0; i < ids.length; i++) {
                         var id = ids[i];


### PR DESCRIPTION
These cases only need shards loaded and don't make use of the results of getall anyway. Speeds up indexing!