### PR TITLE
Use closest (1) degen for non-terminal terms

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -33,7 +33,8 @@ function getDegen(options, tokenized, callback) {
             if (err) {
                 return done(err);
             } else {
-                return done(null, degens.length && !last ? [fragment] : degens);
+                degens.sort(sortDegenDist);
+                return done(null, degens.length && !last ? degens.slice(0,1) : degens);
             }
         });
     }, i === fragments.length-1, fragments[i]);
@@ -65,6 +66,8 @@ function getDegen(options, tokenized, callback) {
         });
     });
 }
+
+function sortDegenDist(a, b) { return (a%16) - (b%16); }
 
 // For all terms match phrases that contain the terms.
 function getPhrases(options, terms, callback) {

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -1,0 +1,38 @@
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('./util/addfeature');
+
+var conf = {
+    address: new mem({maxzoom: 6, geocoder_address: '{name} {num}', geocoder_name:'address'}, function() {})
+};
+var c = new Carmen(conf);
+
+tape('index address', function(t) {
+    var address = {
+        _id:1,
+        _text:'Brehmestraße',
+        _zxy:['6/32/32'],
+        _center:[0,0],
+        _cluster: {
+            56: { type: "Point", coordinates: [0,0] }
+        }
+    };
+    addFeature(conf.address, address, t.end);
+});
+
+tape('test address', function(t) {
+    c.geocode('Brehmestr. 56', { limit_verify: 1 }, function (err, res) {
+        t.ifError(err);
+        t.equals(res.features[0] && res.features[0].place_name, 'Brehmestraße 56');
+        t.end();
+    });
+});
+
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});
+


### PR DESCRIPTION
The autoc work switched from using degens everywhere to only using them for the last term.

This pulls that approach back slightly, using the *closest* degen for every non-terminal term. So the closest matching term is used for every term except the last which is matched against a broad swath of possible matches.