### PR TITLE
Retain spatialmatch sort in final feature/context sorts

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -31,13 +31,13 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     // Limit initial feature check to the best 40 max.
     if (results.length > 40) results = results.slice(0,40);
 
-    results.forEach(function(num) { q.defer(loadFeature, num); });
+    for (var i = 0; i < results.length; i++) q.defer(loadFeature, results[i], i);
 
     q.awaitAll(loadContexts);
 
     // For each result, load the feature from its Carmen index so that we can
     // then load all of the relevant contexts for that feature.
-    function loadFeature(num, callback) {
+    function loadFeature(num, pos, callback) {
         var term = new Relev(num);
         var source = geocoder.byidx[term.idx];
         feature.getFeature(source, term.id, function featureLoaded(err, features) {
@@ -82,6 +82,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                     feat._dbidx = term.idx;
                     feat._relev = term.relev;
                     feat._distance = proximity.distance(options.proximity, feat._center);
+                    feat._position = pos;
                     result.push(feat);
                 }
             }
@@ -140,6 +141,7 @@ function sortFeature(a, b) {
         ((a._geometry&&a._geometry.omitted?1:0) - (b._geometry&&b._geometry.omitted?1:0)) ||
         ((a._distance||0) - (b._distance||0)) ||
         ((b._score||0) - (a._score||0)) ||
+        ((a._position||0) - (b._position||0)) ||
         0;
 }
 
@@ -176,6 +178,10 @@ function sortContext(a, b) {
         if (a[0]._distance < b[0]._distance) return -1;
         if (a[0]._distance > b[0]._distance) return 1;
     }
+
+    // sort by spatialmatch position ("stable sort")
+    if (a[0]._position < b[0]._position) return -1;
+    if (a[0]._position > b[0]._position) return 1;
 
     // last sort by id.
     if (a[0]._id < b[0]._id) return -1;

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -3,15 +3,16 @@ var tape = require('tape');
 
 tape('verifymatch.sortFeature', function(assert) {
     var arr = [
-        { _id: 6, _relev:0.9, _address:null },
-        { _id: 5, _relev:1.0, _address:null },
-        { _id: 4, _relev:1.0, _address:'26', _geometry: { omitted: true } },
-        { _id: 3, _relev:1.0, _address:'26', _geometry: {}, _distance:5, _score: 1 },
-        { _id: 2, _relev:1.0, _address:'26', _geometry: {}, _distance:2, _score: 1 },
-        { _id: 1, _relev:1.0, _address:'26', _geometry: {}, _distance:2, _score: 2 }
+        { _id: 7, _relev:0.9, _address:null },
+        { _id: 6, _relev:1.0, _address:null },
+        { _id: 5, _relev:1.0, _address:'26', _geometry: { omitted: true } },
+        { _id: 4, _relev:1.0, _address:'26', _geometry: {}, _distance:5, _score: 1 },
+        { _id: 3, _relev:1.0, _address:'26', _geometry: {}, _distance:2, _score: 1 },
+        { _id: 2, _relev:1.0, _address:'26', _geometry: {}, _distance:2, _score: 2, _position:2 },
+        { _id: 1, _relev:1.0, _address:'26', _geometry: {}, _distance:2, _score: 2, _position:1 }
     ];
     arr.sort(verifymatch.sortFeature);
-    assert.deepEqual(arr.map(function(f) { return f._id }), [1,2,3,4,5,6]);
+    assert.deepEqual(arr.map(function(f) { return f._id }), [1,2,3,4,5,6,7]);
 
     assert.end();
 });
@@ -54,13 +55,18 @@ tape('verifymatch.sortContext (no distance)', function(assert) {
     c._typeindex = 1;
     arr.push(c);
 
-    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _score:2 }];
+    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _score:2, _position: 2 }];
+    c._relevance = 1.0;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ _id: 0, _address:'26', _cluster:{}, _geometry: {}, _score:2, _position: 1 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
 
     arr.sort(verifymatch.sortContext);
-    assert.deepEqual(arr.map(function(c) { return c[0]._id }), [1,2,3,4,5,6,7,8,9]);
+    assert.deepEqual(arr.map(function(c) { return c[0]._id }), [0,1,2,3,4,5,6,7,8,9]);
 
     assert.end();
 });


### PR DESCRIPTION
Extension of fix here: https://github.com/mapbox/carmen/pull/272.

Adds `_position` attribute to all feature docs internally to retain spatialmatch sort from cpp land. Some subtle relevance differences are lost in the `Relev => num` encoding between cpp and js land that we can still retain by keeping sort order stable.