### PR TITLE
Approximity2

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -151,16 +151,6 @@ function sortContext(a, b) {
     if (a._relevance > b._relevance) return -1;
     if (a._relevance < b._relevance) return 1;
 
-    // for address results, prefer those from point clusters
-    if (a[0]._address && b[0]._address) {
-        if (a[0]._cluster && !b[0]._cluster) return -1;
-        if (b[0]._cluster && !a[0]._cluster) return 1;
-    }
-
-    // omitted difference
-    var omitted = ((a[0]._geometry&&a[0]._geometry.omitted?1:0) - (b[0]._geometry&&b[0]._geometry.omitted?1:0));
-    if (omitted !== 0) return omitted;
-
     // sort by score
     var as = a[0]._score || 0;
     var bs = b[0]._score || 0;
@@ -174,6 +164,16 @@ function sortContext(a, b) {
     // distance
     if (a[0]._distance < b[0]._distance) return -1;
     if (a[0]._distance > b[0]._distance) return 1;
+
+    // for address results, prefer those from point clusters
+    if (a[0]._address && b[0]._address) {
+        if (a[0]._cluster && !b[0]._cluster) return -1;
+        if (b[0]._cluster && !a[0]._cluster) return 1;
+    }
+
+    // omitted difference
+    var omitted = ((a[0]._geometry&&a[0]._geometry.omitted?1:0) - (b[0]._geometry&&b[0]._geometry.omitted?1:0));
+    if (omitted !== 0) return omitted;
 
     // sort by spatialmatch position ("stable sort")
     if (a[0]._position < b[0]._position) return -1;

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -115,3 +115,26 @@ tape('verifymatch.sortContext (with distance)', function(assert) {
     assert.end();
 });
 
+tape('verifymatch.sortContext (distance vs addresstype)', function(assert) {
+    var c;
+    var arr = [];
+
+    c = [{ _id: 3 }];
+    c._relevance = 0.9;
+    arr.push(c);
+
+    c = [{ _id: 2, _address:'26', _distance: 2, _cluster:{} }];
+    c._relevance = 1.0;
+    arr.push(c);
+
+    c = [{ _id: 1, _address:'26', _distance: 1 }];
+    c._relevance = 1.0;
+    arr.push(c);
+
+
+    arr.sort(verifymatch.sortContext);
+    assert.deepEqual(arr.map(function(c) { return c[0]._id }), [1,2,3]);
+
+    assert.end();
+});
+


### PR DESCRIPTION
Another stopgap fix. Scenario:

- proximity: NYC
- address A: address of type cluster in Georgia
- address B: address of type range in NYC

A would beat B even though B is very close to location bias.

Fix moves the cluster vs range and omitted sorts after distance sort.

Note score is still before distance -- we'll still want to establish a combined heuristic soon.

------

### Before merge

- [x] test IRL
- [x] roll package

cc @ian29 