### PR TITLE
Smarter dedupe

### DIFF
--- a/lib/pure/applyaddress.js
+++ b/lib/pure/applyaddress.js
@@ -346,7 +346,8 @@ function setPoint(address, start, end, coords, omitted) {
             coords[stop][1] * interp + coords[stop - 1][1] * (1 - interp)
         ].map(function(v) {
             return Math.round(v*1e6) / 1e6;
-        })
+        }),
+        interpolated: true
     };
     if (omitted) geom.omitted = true;
     return geom;

--- a/lib/util/dedupe.js
+++ b/lib/util/dedupe.js
@@ -42,7 +42,7 @@ function dedupe(features) {
         // Has address, check for a previous dupe within distance threshold.
         var address = feature.address + ' ' + feature.text;
         var previous = by_address[address];
-        if (previous && distance(previous.point, point(feature.center), 'kilometers') < 10) {
+        if (previous && distance(previous.point, point(feature.center), 'kilometers') < 5) {
             if (b[previous.index].geometry.omitted && !feature.geometry.omitted) {
                 b[previous.index] = feature;
             } else if (b[previous.index].geometry.interpolated && !feature.geometry.interpolated) {

--- a/lib/util/dedupe.js
+++ b/lib/util/dedupe.js
@@ -11,23 +11,33 @@ function dedupe(features) {
     for (var i = 0; i < features.length; i++) {
         var feature = features[i];
 
-        var place_name = feature.place_name;
-        if (by_place_name[place_name]) {
-            continue;
-        } else {
-            by_place_name[place_name] = place_name;
-        }
-
         if (feature.address) {
             var address = feature.address + ' ' + feature.text;
-            if (by_address[address] && distance(by_address[address], point(feature.center), 'kilometers') < 10) {
+            var previous = by_address[address];
+            if (previous && distance(previous.point, point(feature.center), 'kilometers') < 10) {
+                if (deduped[previous.index].geometry.omitted && !feature.geometry.omitted) {
+                    deduped[previous.index] = feature;
+                } else if (deduped[previous.index].geometry.interpolated && !feature.geometry.interpolated) {
+                    deduped[previous.index] = feature;
+                } else {
+                    continue;
+                }
+            } else {
+                by_address[address] = {
+                    point: point(feature.center),
+                    index: deduped.length
+                };
+                deduped.push(feature);
+            }
+        } else {
+            var place_name = feature.place_name;
+            if (by_place_name[place_name]) {
                 continue;
             } else {
-                by_address[address] = point(feature.center);
+                by_place_name[place_name] = place_name;
+                deduped.push(feature);
             }
         }
-
-        deduped.push(feature);
     }
 
     return deduped;

--- a/lib/util/dedupe.js
+++ b/lib/util/dedupe.js
@@ -4,41 +4,60 @@ var point = require('turf-point');
 module.exports = dedupe;
 
 function dedupe(features) {
-    var deduped = [];
-    var by_address = {};
+    // dedupe one: strictly by place name
+    var a = [];
     var by_place_name = {};
-
     for (var i = 0; i < features.length; i++) {
         var feature = features[i];
-
-        if (feature.address) {
-            var address = feature.address + ' ' + feature.text;
-            var previous = by_address[address];
-            if (previous && distance(previous.point, point(feature.center), 'kilometers') < 10) {
-                if (deduped[previous.index].geometry.omitted && !feature.geometry.omitted) {
-                    deduped[previous.index] = feature;
-                } else if (deduped[previous.index].geometry.interpolated && !feature.geometry.interpolated) {
-                    deduped[previous.index] = feature;
-                } else {
-                    continue;
-                }
+        var previous = by_place_name[feature.place_name];
+        if (previous) {
+            if (a[previous.index].geometry.omitted && !feature.geometry.omitted) {
+                a[previous.index] = feature;
+            } else if (a[previous.index].geometry.interpolated && !feature.geometry.interpolated) {
+                a[previous.index] = feature;
             } else {
-                by_address[address] = {
-                    point: point(feature.center),
-                    index: deduped.length
-                };
-                deduped.push(feature);
+                continue;
             }
         } else {
-            var place_name = feature.place_name;
-            if (by_place_name[place_name]) {
-                continue;
-            } else {
-                by_place_name[place_name] = place_name;
-                deduped.push(feature);
-            }
+            by_place_name[feature.place_name] = {
+                feature: feature,
+                index: a.length
+            };
+            a.push(feature);
         }
     }
 
-    return deduped;
+    // dedupe two: by address + distance threshold
+    var b = [];
+    var by_address = {};
+    for (var i = 0; i < a.length; i++) {
+        var feature = a[i];
+
+        // No address. Keep.
+        if (!feature.address) {
+            b.push(feature);
+            continue;
+        }
+
+        // Has address, check for a previous dupe within distance threshold.
+        var address = feature.address + ' ' + feature.text;
+        var previous = by_address[address];
+        if (previous && distance(previous.point, point(feature.center), 'kilometers') < 10) {
+            if (b[previous.index].geometry.omitted && !feature.geometry.omitted) {
+                b[previous.index] = feature;
+            } else if (b[previous.index].geometry.interpolated && !feature.geometry.interpolated) {
+                b[previous.index] = feature;
+            } else {
+                continue;
+            }
+        } else {
+            by_address[address] = {
+                point: point(feature.center),
+                index: b.length
+            };
+            b.push(feature);
+        }
+    }
+
+    return b;
 }

--- a/test/address.nearest.test.js
+++ b/test/address.nearest.test.js
@@ -14,6 +14,7 @@ test('nearest', function(t) {
         }
     }, 900), {
         coordinates: [ 0, 0 ],
+        interpolated: true,
         omitted: true, // because nearest endpoint match
         type: 'Point'
     }, 'nearest startpoint');
@@ -28,6 +29,7 @@ test('nearest', function(t) {
         }
     }, 1200), {
         coordinates: [ 0, 100 ],
+        interpolated: true,
         omitted: true, // because nearest endpoint match
         type: 'Point'
     }, 'nearest endpoint');

--- a/test/address.test.js
+++ b/test/address.test.js
@@ -202,34 +202,42 @@ test('address.calculateDistance', function(assert) {
 test('address.setPoint', function(assert) {
     assert.deepEqual(address.setPoint(2,0,8,[[0,0],[1,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0.25,0]
     }, 'x2, forward');
     assert.deepEqual(address.setPoint(2,8,0,[[0,0],[1,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0.75,0]
     }, 'x2, reverse');
     assert.deepEqual(address.setPoint(2,8,0,[[0,0],[0,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0,0]
     }, 'x2, identity (line)');
     assert.deepEqual(address.setPoint(0,0,0,[[0,0],[1,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0,0]
     }, 'x2, identity (address)');
    assert.deepEqual(address.setPoint(3,0,12,[[0,0],[1,0],[2,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0.5,0]
     }, 'x3, forward');
     assert.deepEqual(address.setPoint(9,0,12,[[0,0],[1,0],[2,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[1.5,0]
     }, 'x3, reverse');
     assert.deepEqual(address.setPoint(9,0,12,[[0,0],[0,0],[0,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0,0]
     }, 'x3, identity (line)');
     assert.deepEqual(address.setPoint(0,0,0,[[0,0],[1,0],[2,0]],false), {
         type: 'Point',
+        interpolated: true,
         coordinates:[0,0]
     }, 'x3, identity (address)');
     assert.end();
@@ -245,6 +253,7 @@ test('address interpolation - noop', function(t) {
  test('address interpolation - parity: even + both', function(t) {
     t.deepEqual({
         type:'Point',
+        interpolated: true,
         coordinates:[0,9]
     }, address({
         _rangetype:'tiger',
@@ -358,6 +367,7 @@ test('address point clustering fail', function(t) {
 test('parity: even + even', function(t) {
     t.deepEqual({
         type:'Point',
+        interpolated: true,
         coordinates:[0,10]
     }, address({
         _rangetype:'tiger',
@@ -375,6 +385,7 @@ test('parity: even + even', function(t) {
 test('parity: even + odd', function(t) {
     t.deepEqual({
         coordinates: [ 0, 9 ],
+        interpolated: true,
         omitted: true, // because parity does not match
         type: 'Point'
     }, address({
@@ -393,6 +404,7 @@ test('parity: even + odd', function(t) {
 test('parity: odd + both', function(t) {
     t.deepEqual({
         type:'Point',
+        interpolated: true,
         coordinates:[0,9]
     }, address({
         _rangetype:'tiger',
@@ -410,6 +422,7 @@ test('parity: odd + both', function(t) {
 test('parity: odd + odd', function(t) {
     t.deepEqual({
         type:'Point',
+        interpolated: true,
         coordinates:[0,9]
     }, address({
         _rangetype:'tiger',
@@ -427,6 +440,7 @@ test('parity: odd + odd', function(t) {
 test('parity: odd + even', function(t) {
     t.deepEqual({
         coordinates: [ 0, 9 ],
+        interpolated: true,
         omitted: true, // because parity does not match
         type: 'Point'
     }, address({
@@ -445,6 +459,7 @@ test('parity: odd + even', function(t) {
 test('reverse', function(t) {
     t.deepEqual({
         type: 'Point',
+        interpolated: true,
         coordinates: [0,90]
     }, address({
         _rangetype:'tiger',
@@ -462,6 +477,7 @@ test('reverse', function(t) {
 test('seminumber', function(t) {
     t.deepEqual({
         type: 'Point',
+        interpolated: true,
         coordinates: [0,10]
     }, address({
         _rangetype:'tiger',

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -98,6 +98,42 @@ tape('dedupe', function(assert) {
             text: 'main st',
             center:[0.000,0],
             geometry: {
+                type:'Point',
+                coordinates:[0.000,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00002',
+            address:100,
+            text: 'main st',
+            center:[0.001,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0.001,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[1,0],
+            geometry: {
+                type:'Point',
+                coordinates:[1,0]
+            }
+        }
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[0]
+    ], 'dedupes identical addresses + placenames when dist < 10km');
+
+    features = [
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[0.000,0],
+            geometry: {
                 interpolated: true,
                 omitted: true,
                 type:'Point',

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -63,7 +63,7 @@ tape('dedupe', function(assert) {
     assert.deepEqual(dedupe(features), [
         features[0],
         features[1],
-    ], 'dupe identical addresses when dist >= 10km');
+    ], 'dupe identical addresses when dist >= 5km');
 
     features = [
         {
@@ -89,7 +89,7 @@ tape('dedupe', function(assert) {
     ];
     assert.deepEqual(dedupe(features), [
         features[0]
-    ], 'dedupes identical addresses when dist < 10km');
+    ], 'dedupes identical addresses when dist < 5km');
 
     features = [
         {
@@ -125,7 +125,7 @@ tape('dedupe', function(assert) {
     ];
     assert.deepEqual(dedupe(features), [
         features[0]
-    ], 'dedupes identical addresses + placenames when dist < 10km');
+    ], 'dedupes identical addresses + placenames when dist < 5km');
 
     features = [
         {

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -5,9 +5,33 @@ tape('dedupe', function(assert) {
     var features;
 
     features = [
-        { place_name: 'main st springfield', text: 'main st', center:[0,0] },
-        { place_name: 'wall st springfield', text: 'wall st', center:[10,0] },
-        { place_name: 'main st springfield', text: 'main st', center:[20,0] },
+        {
+            place_name: 'main st springfield',
+            text: 'main st',
+            center:[0,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0,0]
+            }
+        },
+        {
+            place_name: 'wall st springfield',
+            text: 'wall st',
+            center:[10,0],
+            geometry: {
+                type:'Point',
+                coordinates:[10,0]
+            }
+        },
+        {
+            place_name: 'main st springfield',
+            text: 'main st',
+            center:[20,0],
+            geometry: {
+                type:'Point',
+                coordinates:[20,0]
+            }
+        },
     ];
     assert.deepEqual(dedupe(features), [
         features[0],
@@ -15,8 +39,26 @@ tape('dedupe', function(assert) {
     ], 'dedupes by place_name');
 
     features = [
-        { place_name: '100 main st springfield 00001', address:100, text: 'main st', center:[0,0] },
-        { place_name: '100 main st springfield 00002', address:100, text: 'main st', center:[20,0] },
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[0,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00002',
+            address:100,
+            text: 'main st',
+            center:[20,0],
+            geometry: {
+                type:'Point',
+                coordinates:[20,0]
+            }
+        },
     ];
     assert.deepEqual(dedupe(features), [
         features[0],
@@ -24,12 +66,110 @@ tape('dedupe', function(assert) {
     ], 'dupe identical addresses when dist >= 10km');
 
     features = [
-        { place_name: '100 main st springfield 00001', address:100, text: 'main st', center:[0.000,0] },
-        { place_name: '100 main st springfield 00002', address:100, text: 'main st', center:[0.001,0] },
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[0.000,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0.000,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00002',
+            address:100,
+            text: 'main st',
+            center:[0.001,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0.001,0]
+            }
+        },
     ];
     assert.deepEqual(dedupe(features), [
         features[0]
     ], 'dedupes identical addresses when dist < 10km');
+
+    features = [
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[0.000,0],
+            geometry: {
+                interpolated: true,
+                omitted: true,
+                type:'Point',
+                coordinates:[0.000,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00002',
+            address:100,
+            text: 'main st',
+            center:[0.002,0],
+            geometry: {
+                interpolated: true,
+                type:'Point',
+                coordinates:[0.000,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00003',
+            address:100,
+            text: 'main st',
+            center:[0.001,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0.001,0]
+            }
+        },
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[2]
+    ], 'dedupes identical addresses, prioritizes non-interpolated');
+
+    // Reverse to make sure logic works in reverse order.
+    features.reverse();
+    assert.deepEqual(dedupe(features), [
+        features[0]
+    ], 'dedupes identical addresses, prioritizes non-interpolated');
+
+    features = [
+        {
+            place_name: '100 main st springfield 00001',
+            address:100,
+            text: 'main st',
+            center:[0.000,0],
+            geometry: {
+                omitted: true,
+                interpolated: true,
+                type:'Point',
+                coordinates:[0.000,0]
+            }
+        },
+        {
+            place_name: '100 main st springfield 00002',
+            address:100,
+            text: 'main st',
+            center:[0.001,0],
+            geometry: {
+                interpolated: true,
+                type:'Point',
+                coordinates:[0.001,0]
+            }
+        },
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[1]
+    ], 'dedupes identical addresses, prioritizes non-omitted');
+
+    // Reverse to make sure logic works in reverse order.
+    features.reverse();
+    assert.deepEqual(dedupe(features), [
+        features[0]
+    ], 'dedupes identical addresses, prioritizes non-omitted');
 
     assert.end();
 });


### PR DESCRIPTION
Prioritize cluster addresses over interpolated and gappy at dedupe time, rather than relying on feature sort order (fickle and influenced by proximity and other things).