### PR TITLE
Ghost in the machine

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -45,7 +45,8 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     });
 
     q.awaitAll(function(err, res) {
-        if (err) return callback(err);
+        //if (err) return callback(err);
+        console.log(err);
         var stack = [];
         var memo = {};
 
@@ -121,7 +122,6 @@ function contextVector(source, lon, lat, full, matched, callback) {
         }, function(err, results) {
             if (err) return callback(err);
             if (!results || !results.length) return callback(null, false);
-
             var feat;
             var dist = Infinity;
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -45,8 +45,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     });
 
     q.awaitAll(function(err, res) {
-        //if (err) return callback(err);
-        console.log(err);
+        if (err) return callback(err);
         var stack = [];
         var memo = {};
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -54,8 +54,6 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 // @TODO for fully accurate results, iterate through
                 // coalesced[coord] for a matching feature id.
                 var feat = features[id];
-                // filter out altnames, scored as -1
-                if (typeof feat._score !== 'undefined' && feat._score < 0) continue;
                 var bbox = sm.xyz([feat._center[0], feat._center[1], feat._center[0], feat._center[1]], source._geocoder.zoom);
                 var c1 = (source._geocoder.zoom * mp2_28) + (bbox.minX * mp2_14) + (bbox.minY);
                 var c2 = (source._geocoder.zoom * mp2_28) + (bbox.minX * mp2_14) + (bbox.maxY);

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -7,6 +7,95 @@ var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('./util/addfeature');
 
+// Confirms that you can forward search a ghost feature and that a scored featre will always win
+(function() {
+    var conf = { place: new mem(null, function() {}) };
+    var c = new Carmen(conf);
+    tape('index place', function(t) {
+        var place = { 
+            _id:1,
+            _score: 100,
+            _text:'fairfax',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        };
+        addFeature(conf.place, place, t.end);
+    });
+    tape('index ghost place', function(t) {
+        var place = { 
+            _id:2,
+            _score: -1,
+            _text:'mclean',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        };  
+        addFeature(conf.place, place, t.end);
+    });
+    tape('index zip+4', function(t) {
+        var place = { 
+            _id:3,
+            _score: -1,
+            _text:'20009-2004',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        };  
+        addFeature(conf.place, place, t.end);
+    });
+    tape('index zip', function(t) {
+        var place = { 
+            _id:4,
+            _score: 100,
+            _text:'20009',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        };  
+        addFeature(conf.place, place, t.end);
+    });
+    tape('index ghost zip', function(t) {
+        var place = { 
+            _id:5,
+            _score: -1,
+            _text:'20009',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        };  
+        addFeature(conf.place, place, t.end);
+    });
+    tape('fairfax', function(t) {
+        c.geocode('fairfax', { limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.deepEqual(res.features[0].place_name, 'fairfax');
+            t.deepEqual(res.features[0].id, 'place.1');
+            t.end();
+        }); 
+    }); 
+    tape('mclean', function(t) {
+        c.geocode('mclean', { limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.deepEqual(res.features[0].place_name, 'mclean');
+            t.deepEqual(res.features[0].id, 'place.2');
+            t.end();
+        }); 
+    }); 
+    tape('scored feature beats ghost', function(t) {
+        c.geocode('20009', { limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.deepEqual(res.features[0].place_name, '20009');
+            t.deepEqual(res.features[0].id, 'place.4');
+            t.end();
+        }); 
+    }); 
+    tape('exact match bests score', function(t) {
+        c.geocode('20009-2004', { limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.deepEqual(res.features[0].place_name, '20009-2004');
+            t.deepEqual(res.features[0].id, 'place.3');
+            t.end();
+        }); 
+    }); 
+})();
+
+
 // Confirm that for equally relevant features across three indexes
 // the first in hierarchy beats the others. (NO SCORES)
 (function() {


### PR DESCRIPTION
This change alters the way `lib/verifyMatch.js` handles ghost features.

### Previous work:

1. @aaronlidman introduces ['ghost' features](https://github.com/mapbox/carmen/commit/906b025c9dadba8a7decc10cca301c1e47fa5c18) for alt places - [relevant devlog](https://github.com/mapbox/hey/issues/1825)
2. @yhahn allows ghost features to be [returned in context array](https://github.com/mapbox/carmen/pull/253)

### Before

- A ghost feature will never be returned in a reverse geocode
- A ghost feature can be returned in a context array _if_ the input query matches the ghost feature text

    - scored feature
    ```
    query:  7449 E River Rd Fridley
    result: 7449 E River Rd Fridley
    ```
    - ghost feature
    ````
    query:  7449 E River Rd Minneapolis
    result: 7449 E River Rd Minneapolis
    ````
    (these are the same feature)

- A ghost feature can never be directly searched for

    - scored feature
    ```
    query:  Fridley
    result: Fridley
    ```
    - ghost feature
    ````
    query:  Minneapolis
    result: null
    ````
    (these are the same feature)

### After

- A reverse geocode will never return a ghost feature
- A ghost feature can be returned in a context array
- A ghost feature can be searched for directly

### Why this change

Ghost features are currently useless if they are the lowest index. Since a ghost feature can only be returned in a context array, a ghost feature will never be returned if the query does not have an element below it. [relevant code](https://github.com/mapbox/carmen/blob/0bb5a624a26089fd50ed497ec103312ba36ecd31/lib/verifymatch.js#L57-L58).

In our places layer we have the postal polygons which one would use if they wanted to send mail. We have also ghosted in alternate places (populated places) that are useful to locals but not necessarily part of the postal service. When reverse geocoding the ghost features will ensure that the desired place is returned, however when forward geocoding one should be able to search for these populated places.


### Next up

- [x] test to see how it affects results before/after

cc/ @sbma44 @yhahn @ian29 