### PR TITLE
Avoid 

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -101,7 +101,7 @@ function getGrids(options, phrases, relevs, callback) {
         // relevance order -- fast because these are now all cached.
         var grids = [];
         for (var i = 0; i < phrases.length; i++) {
-            grids.push.apply(grids, options.cache.get('grid', phrases[i]));
+            grids = grids.concat(options.cache.get('grid', phrases[i]));
         }
 
         return callback(null, {


### PR DESCRIPTION
`Array.concat` is both faster than `Array.push.apply` and also increases the number of grids a particular phrase can have before we hit `Maximum Call stack Exceeded`.

cc/ @sbma44 