### PR TITLE
enable numbered group token replacement [vs c4]

### DIFF
--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -8,7 +8,11 @@ module.exports.createReplacer = function(tokens) {
 
         var f = unidecode(token); // normalize expanded
         entry.from = new RegExp('(\\W|^)' + f + '(\\W|$)', 'gi');
-        entry.to = unidecode('$1' + tokens[token] + '$2'); // normalize abbrev
+
+        // increment replacements indexes in `to`
+        var groupReplacements = 0;
+        tokens[token] = tokens[token].replace(/\$(\d+)/g, function(str, index) { groupReplacements++; return '$' + (parseInt(index)+1).toString();});
+        entry.to = unidecode('$1' + tokens[token] + '$' + (groupReplacements + 2).toString()); // normalize abbrev
 
         replacers.push(entry);
     }

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -75,7 +75,6 @@ var addFeature = require('../lib/util/addfeature');
 })();
 
 // RegExp captures have been put on hiatus per https://github.com/mapbox/carmen/pull/283.
-/*
 (function() {
     var conf = {
         address: new mem({
@@ -100,12 +99,11 @@ var addFeature = require('../lib/util/addfeature');
     tape('test token replacement', function(t) {
         c.geocode('qabc', { limit_verify: 1 }, function (err, res) {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token regex named group test, a-b-c => cba');
+            t.equals(res.features[0].relevance, 0.99, 'token regex numbered group test, qabc => qcba');
             t.end();
         });
     });
 })();
-*/
 
 tape('index.teardown', function(assert) {
     index.teardown();


### PR DESCRIPTION
`node bench/replaceToken.js`

**c4:** `token replace x 18,246 ops/sec ±0.91% (96 runs sampled)`
**regex-redux:** `token replace x 18,133 ops/sec ±0.82% (95 runs sampled)`