### PR TITLE
scoredist (score + distance heuristic) for proximity

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -57,7 +57,7 @@ function spatialmatch(query, phrasematches, options, callback) {
 
                     // Set a score + distance combined heuristic.
                     if (options.proximity) {
-                        feature[m].scoredist = Math.max(feature[m].score, proximity.scoredist(
+                        feature[m].scoredist = Math.max(feature[m].score * feature[m].scorefactor, proximity.scoredist(
                             options.proximity,
                             [coalesceOpts.centerzxy[0], feature[m].x, feature[m].y],
                             feature[m].scorefactor

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -54,6 +54,11 @@ function spatialmatch(query, phrasematches, options, callback) {
 
                     // Re-scale score by index scorefactor.
                     feature[m].score = feature[m].score * byIdx[feature[m].idx].scorefactor;
+                    // Set a score + distance compbined heuristic.
+                    feature[m].scoredist = Math.max(
+                        feature[m].score,
+                        Math.round(byIdx[feature[m].idx].scorefactor*16/(feature[m].distance||1))
+                    );
                 }
             }
             callback(null, features);
@@ -66,11 +71,7 @@ function spatialmatch(query, phrasematches, options, callback) {
 
         var combined = [];
         combined = combined.concat.apply(combined, results);
-        if (options.proximity) {
-            combined.sort(sortByRelevDistance);
-        } else {
-            combined.sort(sortByRelev);
-        }
+        combined.sort(sortByRelev);
 
         var sets = {};
         var done = {};
@@ -159,14 +160,7 @@ function sortByZoomIdx(a, b) {
 
 function sortByRelev(a, b) {
     return (b.relev - a.relev) ||
-        (b[0].score - a[0].score) ||
-        (a[0].idx - b[0].idx);
-}
-
-function sortByRelevDistance(a, b) {
-    return (b.relev - a.relev) ||
-        (a[0].distance - b[0].distance) ||
-        (b[0].score - a[0].score) ||
+        (b[0].scoredist - a[0].scoredist) ||
         (a[0].idx - b[0].idx);
 }
 

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -53,12 +53,18 @@ function spatialmatch(query, phrasematches, options, callback) {
                     feature[m].text = byIdx[feature[m].idx].text;
 
                     // Re-scale score by index scorefactor.
-                    feature[m].score = feature[m].score * byIdx[feature[m].idx].scorefactor;
-                    // Set a score + distance compbined heuristic.
-                    feature[m].scoredist = Math.max(
-                        feature[m].score,
-                        Math.round(byIdx[feature[m].idx].scorefactor*16/(feature[m].distance||1))
-                    );
+                    feature[m].scorefactor = byIdx[feature[m].idx].scorefactor;
+
+                    // Set a score + distance combined heuristic.
+                    if (options.proximity) {
+                        feature[m].scoredist = Math.max(feature[m].score, proximity.scoredist(
+                            options.proximity,
+                            [coalesceOpts.centerzxy[0], feature[m].x, feature[m].y],
+                            feature[m].scorefactor
+                        ));
+                    } else {
+                        feature[m].scoredist = feature[m].score * feature[m].scorefactor;
+                    }
                 }
             }
             callback(null, features);

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -51,20 +51,8 @@ function spatialmatch(query, phrasematches, options, callback) {
                 while (m--) {
                     feature[m].mask = byIdx[feature[m].idx].mask;
                     feature[m].text = byIdx[feature[m].idx].text;
-
-                    // Re-scale score by index scorefactor.
-                    feature[m].scorefactor = byIdx[feature[m].idx].scorefactor;
-
-                    // Set a score + distance combined heuristic.
-                    if (options.proximity) {
-                        feature[m].scoredist = Math.max(feature[m].score * feature[m].scorefactor, proximity.scoredist(
-                            options.proximity,
-                            [coalesceOpts.centerzxy[0], feature[m].x, feature[m].y],
-                            feature[m].scorefactor
-                        ));
-                    } else {
-                        feature[m].scoredist = feature[m].score * feature[m].scorefactor;
-                    }
+                    feature[m].score = feature[m].score * byIdx[feature[m].idx].scorefactor;
+                    feature[m].scoredist = feature[m].scoredist * byIdx[feature[m].idx].scorefactor;
                 }
             }
             callback(null, features);

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -28,12 +28,27 @@ function scoredist(proximity, center, scorefactor) {
             bbox[0] + (bbox[2]-bbox[0])*0.5,
             bbox[1] + (bbox[3]-bbox[1])*0.5
         ];
-        console.log(bbox);
     }
     return _scoredist(scorefactor, distance(proximity, center));
 }
 
+// _scoredist() calculates a value from the distance which is appropriate for
+// comparison with _score values in an index.
+//
+// Some definitions:
+// - scorefactor: approximation of 1/8th of the max score for a given index
+// - dist: a distance, in miles, between the center, or approximate center,
+//   of a feature and the user's location (proximity).
+//
+// - when a feature is 40 miles from the user, it has 1/8th the max score
+// - when a feature is 5 miles from the user, it has 1x the max score
+// - when a feature is 1 mile from the user, it has 5x the max score
+// - when a feature is 0.1 miles from the user, it has 50x the max score
+//
+// Basically: once a feature is within a 5-10 mile radius of a user it starts
+// to become more relevant than other highly scored features in the index.
 module.exports._scoredist = _scoredist;
 function _scoredist(scorefactor, dist) {
-    return Math.round(scorefactor * (80/(Math.max(dist,0.0001))) * 10000) / 10000;
+    return Math.round(scorefactor * (40/(Math.max(dist,0.0001))) * 10000) / 10000;
 }
+

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -19,15 +19,21 @@ function center2zxy(lon, lat, z) {
     return [ z, bbox.minX, bbox.minY ];
 }
 
-module.exports.pxy2zxy = pxy2zxy;
-function pxy2zxy(pxy, z) {
-    // Interval between parent and target zoom level
-    var zDist = z - pxy[0];
-    if (zDist === 0) return pxy;
-    if (zDist < 0) throw new Error('Cannot translate pxy to lower zxy');
-    var zMult = zDist - 1;
-    // Midpoint length @ z for a tile at parent zoom level
-    var pMid = Math.pow(2,zDist) / 2;
-    return [ z, (pxy[1] * zMult) + pMid, (pxy[2] * zMult) + pMid ];
+module.exports.scoredist = scoredist;
+function scoredist(proximity, center, scorefactor) {
+    // if center is a z/x/y coordinate triplet, convert to lon/lat
+    if (center.length === 3) {
+        var bbox = sm.bbox(center[1], center[2], center[0]);
+        center = [
+            bbox[0] + (bbox[2]-bbox[0])*0.5,
+            bbox[1] + (bbox[3]-bbox[1])*0.5
+        ];
+        console.log(bbox);
+    }
+    return _scoredist(scorefactor, distance(proximity, center));
 }
 
+module.exports._scoredist = _scoredist;
+function _scoredist(scorefactor, dist) {
+    return Math.round(scorefactor * (80/(Math.max(dist,0.0001))) * 10000) / 10000;
+}

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -21,14 +21,6 @@ function center2zxy(lon, lat, z) {
 
 module.exports.scoredist = scoredist;
 function scoredist(proximity, center, scorefactor) {
-    // if center is a z/x/y coordinate triplet, convert to lon/lat
-    if (center.length === 3) {
-        var bbox = sm.bbox(center[1], center[2], center[0]);
-        center = [
-            bbox[0] + (bbox[2]-bbox[0])*0.5,
-            bbox[1] + (bbox[3]-bbox[1])*0.5
-        ];
-    }
     return _scoredist(scorefactor, distance(proximity, center));
 }
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -42,6 +42,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     function afterFeatures(err, loaded) {
         if (err) return callback(err);
 
+        var maxScore = 0;
         var result = [];
         for (var pos = 0; pos < loaded.length; pos++) {
             if (!loaded[pos]) continue;
@@ -84,21 +85,23 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 feat._dbidx = cover.idx;
                 feat._relev = cover.relev;
                 feat._distance = proximity.distance(options.proximity, feat._center);
-
-                // Set a score + distance combined heuristic.
-                if (options.proximity) {
-                    feat._scoredist = Math.max(feat._score, proximity.scoredist(
-                        options.proximity,
-                        feat._center,
-                        cover.scorefactor
-                    ));
-                } else {
-                    feat._scoredist = feat._score * cover.scorefactor;
-                }
-
                 feat._position = pos;
                 feat._spatialmatch = spatialmatch;
+                maxScore = Math.max(maxScore, feat._score);
                 result.push(feat);
+            }
+        }
+
+        // Set a score + distance combined heuristic.
+        for (var i = 0; i < result.length; i++) {
+            var feat = result[i];
+            if (options.proximity) {
+                feat._scoredist = Math.max(
+                    feat._score,
+                    proximity.scoredist(options.proximity, feat._center, maxScore)
+                );
+            } else {
+                feat._scoredist = feat._score;
             }
         }
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -26,8 +26,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 
     options.limit_verify = options.limit_verify || 10;
 
-    // Limit initial feature check to the best 20 max.
-    if (results.length > 20) results = results.slice(0,20);
+    // Limit initial feature check to the best 40 max.
+    if (results.length > 40) results = results.slice(0,40);
 
     for (var i = 0; i < results.length; i++) q.defer(loadFeature, results[i], i);
     q.awaitAll(afterFeatures);

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -84,6 +84,18 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 feat._dbidx = cover.idx;
                 feat._relev = cover.relev;
                 feat._distance = proximity.distance(options.proximity, feat._center);
+
+                // Set a score + distance combined heuristic.
+                if (options.proximity) {
+                    feat._scoredist = Math.max(feat._score, proximity.scoredist(
+                        options.proximity,
+                        feat._center,
+                        cover.scorefactor
+                    ));
+                } else {
+                    feat._scoredist = feat._score * cover.scorefactor;
+                }
+
                 feat._position = pos;
                 feat._spatialmatch = spatialmatch;
                 result.push(feat);
@@ -180,8 +192,7 @@ function sortFeature(a, b) {
     return (b._spatialmatch.relev - a._spatialmatch.relev) ||
         ((a._address===null?1:0) - (b._address===null?1:0)) ||
         ((a._geometry&&a._geometry.omitted?1:0) - (b._geometry&&b._geometry.omitted?1:0)) ||
-        ((a._distance||0) - (b._distance||0)) ||
-        ((b._score||0) - (a._score||0)) ||
+        ((b._scoredist||0) - (a._scoredist||0)) ||
         ((a._position||0) - (b._position||0)) ||
         0;
 }
@@ -193,18 +204,14 @@ function sortContext(a, b) {
     if (a._relevance < b._relevance) return 1;
 
     // sort by score
-    var as = a[0]._score || 0;
-    var bs = b[0]._score || 0;
+    var as = a[0]._scoredist || 0;
+    var bs = b[0]._scoredist || 0;
     if (as > bs) return -1;
     if (as < bs) return 1;
 
     // layer type
     if (a._typeindex < b._typeindex) return -1;
     if (a._typeindex > b._typeindex) return 1;
-
-    // distance
-    if (a[0]._distance < b[0]._distance) return -1;
-    if (a[0]._distance > b[0]._distance) return 1;
 
     // for address results, prefer those from point clusters
     if (a[0]._address && b[0]._address) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/closetomyheart",
+    "carmen-cache": "0.5.2",
     "locking": "2.0.1",
     "mapnik": "3.2.0",
     "minimist": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.5.1",
+    "carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/closetomyheart",
     "locking": "2.0.1",
     "mapnik": "3.2.0",
     "minimist": "0.0.5",

--- a/test/geocode-unit.scoredist.test.js
+++ b/test/geocode-unit.scoredist.test.js
@@ -1,0 +1,66 @@
+// scoredist unit test
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+var queue = require('queue-async');
+
+(function() {
+
+var conf = {
+    address: new mem(null, function() {}),
+};
+var c = new Carmen(conf);
+tape('index address (signal 1)', function(t) {
+    addFeature(conf.address, {
+        _id:200,
+        _text:'main st',
+        _zxy:['6/0/0'],
+        _score:1000,
+        _center:[-179.99,85]
+    }, t.end);
+});
+tape('index address (signal 2)', function(t) {
+    addFeature(conf.address, {
+        _id:201,
+        _text:'main st',
+        _zxy:['6/35/32'],
+        _score:1000,
+        _center:[20,0]
+    }, t.end);
+});
+tape('index address (noise)', function(t) {
+    var q = queue(1);
+    for (var i = 1; i < 100; i++) q.defer(function(i, done) {
+        addFeature(conf.address, {
+            _id:i,
+            _text:'main st',
+            _zxy:['6/32/32'],
+            _score:50,
+            _center:[0,0]
+        }, done);
+    }, i);
+    q.awaitAll(t.end);
+});
+tape('geocode proximity=10,10 => superscored', function(t) {
+    c.geocode('main st', { proximity:[10,10] }, function (err, res) {
+        t.ifError(err);
+        t.equals(res.features[0].id, 'address.200', 'found address.200');
+        t.end();
+    });
+});
+tape('geocode proximity=20,0 => nearest', function(t) {
+    c.geocode('main st', { proximity:[20,0] }, function (err, res) {
+        t.ifError(err);
+        t.equals(res.features[0].id, 'address.201', 'found address.201');
+        t.end();
+    });
+});
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});
+
+})();

--- a/test/proximity.test.js
+++ b/test/proximity.test.js
@@ -8,29 +8,30 @@ test('proximity.center2zxy', function(assert) {
 });
 
 test('proximity._scoredist', function(assert) {
-    assert.equal(proximity._scoredist(1, 80.0), 1, '80.0 miles => 1');
-    assert.equal(proximity._scoredist(1, 40.0), 2, '40.0 miles => 2');
-    assert.equal(proximity._scoredist(1, 20.0), 4, '20.0 miles => 4');
-    assert.equal(proximity._scoredist(1, 8.0),  10,   '8.0 miles => 10');
-    assert.equal(proximity._scoredist(1, 4.0),  20,   '4.0 miles => 20');
-    assert.equal(proximity._scoredist(1, 2.0),  40,   '2.0 miles => 40');
-    assert.equal(proximity._scoredist(1, 1.0),  80,   '1.0 miles => 80');
-    assert.equal(proximity._scoredist(1, 0.2),  400,  '0.2 miles => 400');
-    assert.equal(proximity._scoredist(1, 0.1),  800,  '0.1 miles => 800');
-    assert.equal(proximity._scoredist(1, 0.0),  800000, '0.0 miles => 800000');
+    assert.equal(proximity._scoredist(1, 80.0), 0.5, '80.0 miles');
+    assert.equal(proximity._scoredist(1, 40.0), 1, '40.0 miles');
+    assert.equal(proximity._scoredist(1, 20.0), 2, '20.0 miles');
+    assert.equal(proximity._scoredist(1, 8.0),  5,   '8.0 miles');
+    assert.equal(proximity._scoredist(1, 5.0),  8,   '5.0 miles = break even pt');
+    assert.equal(proximity._scoredist(1, 4.0),  10,   '4.0 miles');
+    assert.equal(proximity._scoredist(1, 2.0),  20,   '2.0 miles');
+    assert.equal(proximity._scoredist(1, 1.0),  40,   '1.0 miles');
+    assert.equal(proximity._scoredist(1, 0.2),  200,  '0.2 miles');
+    assert.equal(proximity._scoredist(1, 0.1),  400,  '0.1 miles');
+    assert.equal(proximity._scoredist(1, 0.0),  400000, '0.0 miles');
     assert.end();
 });
 
 test('proximity.scoredist', function(assert) {
     // lon/lat center
-    assert.equal(proximity.scoredist([0,0], [0,0], 1000), 8e8, 'll scoredist');
-    assert.equal(proximity.scoredist([0,0], [0.05,0], 1000), 23149.8099, 'll scoredist');
-    assert.equal(proximity.scoredist([0,0], [2.00,0], 1000), 578.7452, 'll scoredist');
-    assert.equal(proximity.scoredist([0,0], [10.00,0], 1000), 115.749, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [0,0], 1000), 4e8, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [0.05,0], 1000), 11574.905, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [2.00,0], 1000), 289.3726, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [10.00,0], 1000), 57.8745, 'll scoredist');
 
     // zxy center
-    assert.equal(proximity.scoredist([0,0], [0,0,0], 1000), 8e8, 'zxy scoredist');
-    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), 12.861, 'zxy scoredist');
+    assert.equal(proximity.scoredist([0,0], [0,0,0], 1000), 4e8, 'zxy scoredist');
+    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), 6.4305, 'zxy scoredist');
     assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), proximity.scoredist([0,0], [-90,45], 1000), 'zxy scoredist ~= ll scoredist');
 
     assert.end();

--- a/test/proximity.test.js
+++ b/test/proximity.test.js
@@ -28,12 +28,6 @@ test('proximity.scoredist', function(assert) {
     assert.equal(proximity.scoredist([0,0], [0.05,0], 1000), 11574.905, 'll scoredist');
     assert.equal(proximity.scoredist([0,0], [2.00,0], 1000), 289.3726, 'll scoredist');
     assert.equal(proximity.scoredist([0,0], [10.00,0], 1000), 57.8745, 'll scoredist');
-
-    // zxy center
-    assert.equal(proximity.scoredist([0,0], [0,0,0], 1000), 4e8, 'zxy scoredist');
-    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), 6.4305, 'zxy scoredist');
-    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), proximity.scoredist([0,0], [-90,45], 1000), 'zxy scoredist ~= ll scoredist');
-
     assert.end();
 });
 

--- a/test/proximity.test.js
+++ b/test/proximity.test.js
@@ -7,11 +7,32 @@ test('proximity.center2zxy', function(assert) {
     assert.end();
 });
 
-test('proximity.pxy2zxy', function(assert) {
-    assert.deepEqual(proximity.pxy2zxy([0,0,0], 5), [5,16,16]);
-    assert.deepEqual(proximity.pxy2zxy([1,0,0], 2), [2,1,1]);
-    assert.deepEqual(proximity.pxy2zxy([1,0,0], 3), [3,2,2]);
-    assert.deepEqual(proximity.pxy2zxy([1,0,0], 5), [5,8,8]);
+test('proximity._scoredist', function(assert) {
+    assert.equal(proximity._scoredist(1, 80.0), 1, '80.0 miles => 1');
+    assert.equal(proximity._scoredist(1, 40.0), 2, '40.0 miles => 2');
+    assert.equal(proximity._scoredist(1, 20.0), 4, '20.0 miles => 4');
+    assert.equal(proximity._scoredist(1, 8.0),  10,   '8.0 miles => 10');
+    assert.equal(proximity._scoredist(1, 4.0),  20,   '4.0 miles => 20');
+    assert.equal(proximity._scoredist(1, 2.0),  40,   '2.0 miles => 40');
+    assert.equal(proximity._scoredist(1, 1.0),  80,   '1.0 miles => 80');
+    assert.equal(proximity._scoredist(1, 0.2),  400,  '0.2 miles => 400');
+    assert.equal(proximity._scoredist(1, 0.1),  800,  '0.1 miles => 800');
+    assert.equal(proximity._scoredist(1, 0.0),  800000, '0.0 miles => 800000');
+    assert.end();
+});
+
+test('proximity.scoredist', function(assert) {
+    // lon/lat center
+    assert.equal(proximity.scoredist([0,0], [0,0], 1000), 8e8, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [0.05,0], 1000), 23149.8099, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [2.00,0], 1000), 578.7452, 'll scoredist');
+    assert.equal(proximity.scoredist([0,0], [10.00,0], 1000), 115.749, 'll scoredist');
+
+    // zxy center
+    assert.equal(proximity.scoredist([0,0], [0,0,0], 1000), 8e8, 'zxy scoredist');
+    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), 12.861, 'zxy scoredist');
+    assert.equal(proximity.scoredist([0,0], [1,0,0], 1000), proximity.scoredist([0,0], [-90,45], 1000), 'zxy scoredist ~= ll scoredist');
+
     assert.end();
 });
 

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -6,10 +6,10 @@ tape('verifymatch.sortFeature', function(assert) {
         { _id: 7, _spatialmatch:{relev:0.9}, _address:null },
         { _id: 6, _spatialmatch:{relev:1.0}, _address:null },
         { _id: 5, _spatialmatch:{relev:1.0}, _address:'26', _geometry: { omitted: true } },
-        { _id: 4, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _distance:5, _score: 1 },
-        { _id: 3, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _distance:2, _score: 1 },
-        { _id: 2, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _distance:2, _score: 2, _position:2 },
-        { _id: 1, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _distance:2, _score: 2, _position:1 }
+        { _id: 4, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _scoredist:2, },
+        { _id: 3, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _scoredist:3, },
+        { _id: 2, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _scoredist:4, _position:2 },
+        { _id: 1, _spatialmatch:{relev:1.0}, _address:'26', _geometry: {}, _scoredist:5, _position:1 }
     ];
     arr.sort(verifymatch.sortFeature);
     assert.deepEqual(arr.map(function(f) { return f._id }), [1,2,3,4,5,6,7]);
@@ -37,37 +37,37 @@ tape('verifymatch.sortContext (no distance)', function(assert) {
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ _id: 6, _address:'26', _cluster:{}, _geometry: {}, _score:1 }];
+    c = [{ _id: 6, _address:'26', _cluster:{}, _geometry: {}, _scoredist:1 }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ _id: 5, _address:'26', _cluster:{}, _geometry: {}, _score:2 }];
+    c = [{ _id: 5, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2 }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ _id: 4, _address:'26', _cluster:{}, _geometry: {}, _score:2 }];
+    c = [{ _id: 4, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2 }];
     c._relevance = 1.0;
     c._typeindex = 2;
     arr.push(c);
 
-    c = [{ _id: 3, _address:'26', _cluster:{}, _geometry: {}, _score:2 }];
+    c = [{ _id: 3, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     c._distance = 20;
     arr.push(c);
 
-    c = [{ _id: 2, _address:'26', _cluster:{}, _geometry: {}, _score:2 }];
+    c = [{ _id: 2, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     c._distance = 10;
     arr.push(c);
 
-    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _score:2, _position: 2 }];
+    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2, _position: 2 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
 
-    c = [{ _id: 0, _address:'26', _cluster:{}, _geometry: {}, _score:2, _position: 1 }];
+    c = [{ _id: 0, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2, _position: 1 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
@@ -99,12 +99,12 @@ tape('verifymatch.sortContext (with distance)', function(assert) {
     c._typeindex = 2;
     arr.push(c);
 
-    c = [{ _id: 2, _address:'26', _cluster:{}, _geometry: {}, _distance:2 }];
+    c = [{ _id: 2, _address:'26', _cluster:{}, _geometry: {}, _scoredist:1 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
 
-    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _distance:1 }];
+    c = [{ _id: 1, _address:'26', _cluster:{}, _geometry: {}, _scoredist:2 }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
@@ -123,11 +123,11 @@ tape('verifymatch.sortContext (distance vs addresstype)', function(assert) {
     c._relevance = 0.9;
     arr.push(c);
 
-    c = [{ _id: 2, _address:'26', _distance: 2, _cluster:{} }];
+    c = [{ _id: 2, _address:'26', _scoredist: 1, _cluster:{} }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ _id: 1, _address:'26', _distance: 1 }];
+    c = [{ _id: 1, _address:'26', _scoredist: 2 }];
     c._relevance = 1.0;
     arr.push(c);
 


### PR DESCRIPTION
When in proximity mode:

**master**

- Find most relevant results, then rank them by distance to the proximity point
- At the final stage of verifymatch sort by score, index type, then distance

Concretely this leads to it being very difficult to find the highest scored feature named `NNN` if you are closer to other features named `NNN`.

Example: from Washington DC, there are San Francisco's in Colorado, Colombia, El Salvador, and Venezuela that are all closer to DC than San Francisco in California (and thus outrank it).

**closetomyheart**

- Find most relevant results, then rank them by a combined score + dist heuristic score called `scoredist`. This converts each feature distance to a number that is appropriate for comparison against scores using a [basic inverse](https://en.wikipedia.org/wiki/Multiplicative_inverse). The closer you are to the proximity point the higher the `scoredist` -- falling off rapidly. (https://github.com/mapbox/carmen/blob/closetomyheart/lib/util/proximity.js#L27-L45)
- At the final stage of verifymatch sort by scoredist, index type.

Concretely this means that in proximity mode you'll consistently find a globally important feature `NNN` first no matter where you are -- except when you are reasonably close to another feature named `NNN`. In the latter case you'll likely still see the globally important `NNN` somewhere in your resultset.

Example: from Washington DC result #1 is San Francisco CA. From Cabimas in Venezuela result #1 is San Francisco Venezuela, followed by San Francisco CA.
