### PR TITLE
Unidecoded token replacement pairs

### DIFF
--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -4,17 +4,29 @@ module.exports.createReplacer = function(tokens) {
     var replacers = [];
 
     for (var token in tokens) {
-        var entry = {};
+        var from = token; // normalize expanded
+        var to = tokens[token];
 
-        var f = token; // normalize expanded
-        entry.from = new RegExp('(\\W|^)' + f + '(\\W|$)', 'gi');
+        for (var u = 0; u < 2; u++) {
+            if (u) {
+                var unidecoded = unidecode(from);
+                if (from === unidecoded) {
+                    continue;
+                } else {
+                    from = unidecoded;
+                }
+            }
 
-        // increment replacements indexes in `to`
-        var groupReplacements = 0;
-        tokens[token] = tokens[token].replace(/\$(\d+)/g, function(str, index) { groupReplacements++; return '$' + (parseInt(index)+1).toString();});
-        entry.to = '$1' + tokens[token] + '$' + (groupReplacements + 2).toString(); // normalize abbrev
+            var entry = {};
+            entry.from = new RegExp('(\\W|^)' + from + '(\\W|$)', 'gi');
 
-        replacers.push(entry);
+            // increment replacements indexes in `to`
+            var groupReplacements = 0;
+            to = to.replace(/\$(\d+)/g, function(str, index) { groupReplacements++; return '$' + (parseInt(index)+1).toString();});
+            entry.to = '$1' + to + '$' + (groupReplacements + 2).toString(); // normalize abbrev
+
+            replacers.push(entry);
+        }
     }
     return replacers;
 };

--- a/test/geocode-unit.unicode-replace.test.js
+++ b/test/geocode-unit.unicode-replace.test.js
@@ -1,0 +1,50 @@
+// Ensures that token replacement casts a wide (unidecoded) net for
+// left-hand side of token mapping.
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    test: new mem({
+        geocoder_tokens: {
+            'Maréchal': 'Mal'
+        },
+        maxzoom:6
+    }, function() {})
+};
+var c = new Carmen(conf);
+tape('index Maréchal', function(t) {
+    addFeature(conf.test, {
+        _id:1,
+        _text:'Maréchal',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+tape('Mal => Maréchal', function(t) {
+    c.geocode('Mal', { limit_verify:1 }, function(err, res) {
+        t.deepEqual(res.features[0].place_name, 'Maréchal');
+        t.end();
+    });
+});
+tape('Maréchal => Maréchal', function(t) {
+    c.geocode('Maréchal', { limit_verify:1 }, function(err, res) {
+        t.deepEqual(res.features[0].place_name, 'Maréchal');
+        t.end();
+    });
+});
+tape('Marechal => Maréchal', function(t) {
+    c.geocode('Marechal', { limit_verify:1 }, function(err, res) {
+        t.deepEqual(res.features[0].place_name, 'Maréchal');
+        t.end();
+    });
+});
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});
+

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -2,8 +2,7 @@ var unidecode = require('unidecode');
 var token = require('../lib/util/token');
 var test = require('tape');
 
-
-var tokens = token.createReplacer({           
+var tokens = token.createReplacer({
     "First": "1st",
     "Second": "2nd",
     "Third": "3rd",
@@ -209,3 +208,23 @@ test('token replacement', function(q) {
     q.deepEqual(token.replaceToken(tokens, 'streetwise'),'streetwise');
     q.end();
 });
+
+test('replacer', function(q) {
+    q.deepEqual(token.createReplacer({
+        'Road': 'Rd',
+        'Street': 'St'
+    }), [
+        { from: /(\W|^)Road(\W|$)/gi, to: '$1Rd$2' },
+        { from: /(\W|^)Street(\W|$)/gi, to: '$1St$2' }
+    ]);
+    q.deepEqual(token.createReplacer({
+        'Maréchal': 'Mal',
+        'Monsieur': 'M'
+    }), [
+        { from: /(\W|^)Maréchal(\W|$)/gi, to: '$1Mal$2' },
+        { from: /(\W|^)Marechal(\W|$)/gi, to: '$1Mal$2' },
+        { from: /(\W|^)Monsieur(\W|$)/gi, to: '$1M$2' }
+    ]);
+    q.end();
+});
+


### PR DESCRIPTION
Creates a second token replacement pair when the original token replacer unidecoded differs from itself.

Example -- you define a token replacement pair like:

    'Maréchal': 'Mal'

This will catch input docs with text like `Maréchal` but miss input docs or input queries with text like `Marechal`. Token replacement now defines the second pair automatically for you when it creates the replacer object.

    'Maréchal': 'Mal',
    'Marechal': 'Mal'

Note that this is different from the previous behavior which unidecoded *everything* once and expected the input text to be unidecoded as well -- which had totally horrible autocomplete behaviors.

------

This is a borderline breaking change because previously generated indexes will have missing contracted phrases but going to treat it more like a very severe bugfix in terms of semver.
