### PR TITLE
Load grids at spatialmatch phase

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -34,19 +34,10 @@ module.exports = function phrasematch(source, query, callback) {
     var dictall = source._geocoder.dictall.bind(source._geocoder);
     var loadall = source._geocoder.loadall.bind(source._geocoder);
 
-    dictall(getter, 'stat', loadStats, function(err) {
-        if (err) return callback(err);
-        var toLoad = [];
-        for (var l = 0; l < loadStats.length; l++) {
-            if (source._geocoder.dict('stat', loadStats[l])) {
-                toLoad.push(loadStats[l]);
-            }
-        }
-        var q = queue();
-        q.defer(loadall, getter, 'freq', [1]);
-        q.defer(loadall, getter, 'grid', toLoad);
-        q.awaitAll(loaded);
-    });
+    var q = queue();
+    q.defer(dictall, getter, 'stat', loadStats);
+    q.defer(loadall, getter, 'freq', [1]);
+    q.awaitAll(loaded);
 
     function loaded(err) {
         if (err) return callback(err);
@@ -64,6 +55,8 @@ module.exports = function phrasematch(source, query, callback) {
             // Augment permutations with matched grids,
             // index position and weight relative to input query.
             subqueries[l].scorefactor = scorefactor;
+            subqueries[l].getter = getter;
+            subqueries[l].loadall = loadall;
             subqueries[l].cache = source._geocoder;
             subqueries[l].idx = source._geocoder.idx;
             subqueries[l].zoom = source._geocoder.zoom;

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -35,10 +35,22 @@ function spatialmatch(query, phrasematches, options, callback) {
             );
         }
 
-        q.defer(coalesceStack, stack, coalesceOpts);
+        q.defer(coalesceLoad, stack, coalesceOpts);
     }
 
     q.awaitAll(coalesceFinalize);
+
+    // Load grid indexes necessary for coalesce.
+    function coalesceLoad(stack, coalesceOpts, callback) {
+        var q = queue();
+        for (var i = 0; i < stack.length; i++) {
+            q.defer(stack[i].loadall, stack[i].getter, 'grid', [stack[i].phrase]);
+        }
+        q.awaitAll(function(err) {
+            if (err) return callback(err);
+            coalesceStack(stack, coalesceOpts, callback);
+        });
+    }
 
     // Coalesce stack, add debugging info.
     function coalesceStack(stack, coalesceOpts, callback) {


### PR DESCRIPTION
We're currently loading grids for all phrases that exist in indexes at `phrasematch`. This is a little crazy though -- immediately after `phrasematch` we build potential subquery stacks and then [carefully pick the best ones to spatialmatch](https://github.com/mapbox/carmen/pull/302), throwing out a bunch of subquery stacks that don't make the cut. At the end of this process we'll have the same or fewer phrases to consider.

This moves grid loading to immediately before spatialmatch when we know exactly what we'll be evaluating.

The I/O gains atm are modest currently (10-20%) but as we get more efficient with the number of stacks evaluated in the future these gains will increase (https://github.com/mapbox/carmen/blob/master/lib/spatialmatch.js#L11).

### Next actions

- [x] Test a bit more IRL to make sure nothing blows up