### PR TITLE
Smallworld

### DIFF
--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -15,6 +15,8 @@ function distance(proximity, center) {
 
 module.exports.center2zxy = center2zxy;
 function center2zxy(lon, lat, z) {
+    lon = Math.min(180,Math.max(-180,lon));
+    lat = Math.min(85.0511,Math.max(-85.0511,lat));
     var bbox = sm.xyz([lon,lat,lon,lat], z);
     return [ z, bbox.minX, bbox.minY ];
 }

--- a/test/proximity.test.js
+++ b/test/proximity.test.js
@@ -4,6 +4,8 @@ var test = require('tape');
 test('proximity.center2zxy', function(assert) {
     assert.deepEqual(proximity.center2zxy(0,0,5), [5,16,16]);
     assert.deepEqual(proximity.center2zxy(-90,45,5), [5,8,11]);
+    assert.deepEqual(proximity.center2zxy(-181,90.1,5), [5,0,0], 'respects world extents');
+    assert.deepEqual(proximity.center2zxy(181,-90.1,5), [5,32,32], 'respects world extents');
     assert.end();
 });
 


### PR DESCRIPTION
The proximity zxy needs to stay within the unsigned integer space as it's hopping over to unsigned ints here https://github.com/mapbox/carmen-cache/blob/master/src/binding.cpp#L792.

Enforce this at the carmen input level.

Refs https://github.com/mapbox/geocoding-example/issues/2