### PR TITLE
Strictloose

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -134,59 +134,65 @@ function loadContexts(geocoder, features, sets, callback) {
 
 function verifyContexts(contexts, sets, groups) {
     for (var a = 0; a < contexts.length; a++) {
-        var gappy = 0;
-        var stacky = 0;
-        var usedmask = 0;
-        var lastmask = -1;
-        var lastgroup = -1;
-
         var context = contexts[a];
         context._relevance = 0;
         context._typeindex = groups[context[0]._dbidx];
 
-        var spatialmatch = context[0]._spatialmatch;
-
         // Create lookup for covers by tmpid.
         var verify = {};
-        for (var b = 0; b < spatialmatch.length; b++) {
-            var cover = spatialmatch[b];
+        for (var b = 0; b < context[0]._spatialmatch.length; b++) {
+            var cover = context[0]._spatialmatch[b];
             verify[cover.tmpid] = cover;
         }
 
-        // Build score for full context stack.
-        for (var c = 0; c < context.length; c++) {
-            var backy = false;
-            var feat = context[c];
-            var matched = verify[feat._tmpid] || sets[feat._tmpid];
-            if (!matched) continue;
-            if (usedmask & matched.mask) continue;
-
-            if (lastgroup > -1) {
-                stacky = 1;
-                backy = lastmask > matched.mask;
-                gappy += Math.abs(groups[feat._dbidx] - lastgroup) - 1;
-            }
-
-            usedmask = usedmask | matched.mask;
-            lastmask = matched.mask;
-            lastgroup = groups[feat._dbidx];
-            if (backy) {
-                context._relevance += matched.relev * 0.5;
-            } else {
-                context._relevance += matched.relev;
-            }
-        }
-
-        context._relevance -= 0.01;
-        context._relevance += 0.01 * stacky;
-        // Penalize stacking bonus slightly based on whether stacking matches
-        // contained "gaps" in continuity between index levels.
-        context._relevance -= 0.001 * gappy;
-        context._relevance = context._relevance > 0 ? context._relevance : 0;
+        var strictRelev = verifyContext(context, verify, {}, groups);
+        var looseRelev = verifyContext(context, verify, sets, groups);
+        context._relevance = Math.max(strictRelev, looseRelev);
     }
 
     contexts.sort(sortContext);
     return contexts;
+}
+
+function verifyContext(context, strict, loose, groups) {
+    var spatialmatch = context[0]._spatialmatch;
+    var gappy = 0;
+    var stacky = 0;
+    var usedmask = 0;
+    var lastmask = -1;
+    var lastgroup = -1;
+    var relevance = 0;
+
+    for (var c = 0; c < context.length; c++) {
+        var backy = false;
+        var feat = context[c];
+        var matched = strict[feat._tmpid] || loose[feat._tmpid];
+        if (!matched) continue;
+        if (usedmask & matched.mask) continue;
+
+        if (lastgroup > -1) {
+            stacky = 1;
+            backy = lastmask > matched.mask;
+            gappy += Math.abs(groups[feat._dbidx] - lastgroup) - 1;
+        }
+
+        usedmask = usedmask | matched.mask;
+        lastmask = matched.mask;
+        lastgroup = groups[feat._dbidx];
+        if (backy) {
+            relevance += matched.relev * 0.5;
+        } else {
+            relevance += matched.relev;
+        }
+    }
+
+    relevance -= 0.01;
+    relevance += 0.01 * stacky;
+    // Penalize stacking bonus slightly based on whether stacking matches
+    // contained "gaps" in continuity between index levels.
+    relevance -= 0.001 * gappy;
+    relevance = relevance > 0 ? relevance : 0;
+    return relevance;
 }
 
 function sortFeature(a, b) {

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -1,0 +1,55 @@
+// Tests Windsor CT (city) vs Windsor Ct (street name)
+// Windsor CT should win via stacky bonus.
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    country: new mem(null, function() {}),
+    province: new mem(null, function() {}),
+    place: new mem(null, function() {})
+};
+var c = new Carmen(conf);
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        _id:1,
+        _text:'australia',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+tape('index province', function(t) {
+    addFeature(conf.province, {
+        _id:2,
+        _text:'western australia',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        _id:3,
+        _text:'albany',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+// should reflect relevance of albany + australia (relev ~ 1), not albany + western australia (relev ~ 0.8)
+tape('albany australia', function(t) {
+    c.geocode('albany australia', {}, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'albany, western australia, australia');
+        t.deepEqual(res.features[0].relevance, 0.999);
+        t.end();
+    });
+});
+
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});
+


### PR DESCRIPTION
Fixes a bug where certain query + context stacking combinations are scored lower than they should be at the final context relevance calculation. Example:

    albany australia

Which matches the following context:

    albany, western australia, australia

Should receive a relevance of `0.99+` as all query terms are matched between `albany` and `australia`. However in `master` this feature can mistakenly receive a lower score as the context verification can use `albany` and `western australia` (query is missing `western`, so some penalty is applied).

This branch runs the context relevance calculation twice -- once in strict mode (using only the features in the matching spatialmatch stack) and once in loose mode (using all matched spatialmatch stack features) and then uses the higher of the two relevance scores.