### PR TITLE
Ghostblogger

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -82,6 +82,7 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
             // against fnv1a collisions.
             if (!termops.decollide(source._geocoder.token_replacer, feat, cover.text)) continue;
 
+            feat._score = feat._score || 0;
             feat._extid = source._geocoder.name + '.' + feat._id;
             feat._tmpid = cover.tmpid;
             feat._dbidx = cover.idx;
@@ -97,7 +98,8 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
     // Set a score + distance combined heuristic.
     for (var i = 0; i < result.length; i++) {
         var feat = result[i];
-        if (options.proximity) {
+        // ghost features don't participate
+        if (options.proximity && feat._score >= 0) {
             feat._scoredist = Math.max(
                 feat._score,
                 proximity.scoredist(options.proximity, feat._center, maxScore)
@@ -110,7 +112,20 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
     result.sort(sortFeature);
-    return result;
+
+    // Eliminate any score < 0 results if there are better-scored results
+    // with identical text.
+    var filtered = [];
+    var byText = {};
+    for (var i = 0; i < result.length; i++) {
+        var feat = result[i];
+        if (feat._scoredist >= 0 || !byText[feat._text]) {
+            filtered.push(feat);
+            byText[feat._text] = true;
+        }
+    }
+
+    return filtered;
 }
 
 function loadContexts(geocoder, features, sets, callback) {

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -35,7 +35,7 @@ var addFeature = require('../lib/util/addfeature');
         var place = { 
             _id:3,
             _score: -1,
-            _text:'20009-2004',
+            _text:'20003-2004',
             _zxy:['6/32/32'],
             _center:[0,0]
         };  
@@ -78,17 +78,18 @@ var addFeature = require('../lib/util/addfeature');
         }); 
     }); 
     tape('scored feature beats ghost', function(t) {
-        c.geocode('20009', { limit_verify:1 }, function(err, res) {
+        c.geocode('20009', { limit_verify:2 }, function(err, res) {
             t.ifError(err);
+            t.deepEqual(res.features.length, 1, 'ghost feature deduped');
             t.deepEqual(res.features[0].place_name, '20009');
             t.deepEqual(res.features[0].id, 'place.4');
             t.end();
         }); 
     }); 
     tape('exact match bests score', function(t) {
-        c.geocode('20009-2004', { limit_verify:1 }, function(err, res) {
+        c.geocode('20003-2004', { limit_verify:1 }, function(err, res) {
             t.ifError(err);
-            t.deepEqual(res.features[0].place_name, '20009-2004');
+            t.deepEqual(res.features[0].place_name, '20003-2004');
             t.deepEqual(res.features[0].id, 'place.3');
             t.end();
         }); 


### PR DESCRIPTION
Smartly dedupe ghost features out of a result set when there are real features with the same text in the same resultset.