### PR TITLE
Optionally filter results by feature type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,21 @@ geocoder_shardlevel     | Deprecated. An integer order of magnitude that geocode
 ### geocode(query, options, callback)
 
 Given a `query` string, call callback with `(err, results)` of possible contexts
-represented by that string.
+represented by that string. The following are all optional and can be provided
+as part of the `options` object:
+
+- `limit` - number. Adjust the maximium number of features returned. Defaults to 5.
+- `proximity` - a `[ lon, lat ]` array to use for biasing search results.
+  Features closer to the proximity value will be given priority over those
+  further from the proximity value.
+- `types` - an array of string types. Only features matching one of the types
+  specified will be returned.
+- `allow_dupes` - boolean. If true, carmen will allow features with identical
+  place names to be returned. Defaults to false.
+- `debug` - boolean. If true, the carmen debug object will be returned as part
+  of the results.
+- `stats` - boolean. If true, the carmen stats object will be returned as part
+  of the results.
 
 ### index(from, to, pointer, callback)
 

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -22,6 +22,15 @@ module.exports = function(geocoder, query, options, callback) {
     } : false;
     options.allow_dupes = options.allow_dupes || false;
 
+    // Types option
+    if (options.types) {
+        if (!Array.isArray(options.types) || options.types.length < 1)
+            return callback(errcode('options.types must be an array with at least 1 type', 'EINVALID'));
+        var l = options.types.length;
+        while (l--) if (!geocoder.byname[options.types[l]])
+            return callback(errcode('Type "' + options.types[l] + '" is not a known type. Must be one of: ' + Object.keys(geocoder.byname).join(', '), 'EINVALID'));
+    }
+
     //Proximity is currently not enabled
     if (options.proximity) {
         if ( !options.proximity instanceof Array || options.proximity.length !== 2)

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -10,7 +10,7 @@ var sm = new (require('sphericalmercator'))(),
     Relev = require('./util/relev'),
     proximity = require('./util/proximity');
 var dedupe = require('./util/dedupe');
-
+var errcode = require('err-code');
 
 module.exports = function(geocoder, query, options, callback) {
     options = options || {};
@@ -25,11 +25,11 @@ module.exports = function(geocoder, query, options, callback) {
     //Proximity is currently not enabled
     if (options.proximity) {
         if ( !options.proximity instanceof Array || options.proximity.length !== 2)
-            return callback("Proximty must be LngLat array pair", null);
-        if (typeof options.proximity[0] !== "number" || isNaN(options.proximity[0]) || isNaN(options.proximity[1]) || typeof options.proximity[1] !== "number")
-            return callback("Proximty array must be numeric", null);
-        if (options.proximity[1] < -90 || options.proximity[1] > 90 || options.proximity[0] < -180 || options.proximity[0] > 180)
-            return callback("Proximity LngLat Pair out of bounds", null);
+            return callback(errcode('Proximity must be an array in the form [lon, lat]', 'EINVALID'));
+        if (isNaN(options.proximity[0]) || options.proximity[0] < -180 || options.proximity[0] > 180)
+            return callback(errcode('Proximity lon value must be a number between -180 and 180', 'EINVALID'));
+        if (isNaN(options.proximity[1]) || options.proximity[1] < -90 || options.proximity[1] > 90)
+            return callback(errcode('Proximity lat value must be a number between -90 and 90', 'EINVALID'));
     }
 
     // Allows user to search for specific ID

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -100,6 +100,14 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
         queryData.features = [];
         try {
             while (context.length) {
+                // filter context results by types if specified.
+                if (options.types) {
+                    var type = geocoder.byidx[context[0]._dbidx]._geocoder.name;
+                    if (options.types.indexOf(type) === -1) {
+                        context.shift();
+                        continue;
+                    }
+                }
                 queryData.features.push(ops.toFeature(context, geocoder.byidx[context[0]._dbidx]._geocoder.geocoder_address));
                 context.shift();
             }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -25,6 +25,18 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 
     options.limit_verify = options.limit_verify || 10;
 
+    // Limit features to those matching specified types.
+    if (options.types) {
+        var filtered = [];
+        for (var i = 0; i < results.length; i++) {
+            var type = geocoder.byidx[results[i][0].idx]._geocoder.name;
+            if (options.types.indexOf(type) !== -1) {
+                filtered.push(results[i]);
+            }
+        }
+        results = filtered;
+    }
+
     // Limit initial feature check to the best 20 max.
     if (results.length > 20) results = results.slice(0,20);
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "BSD",
   "dependencies": {
     "carmen-cache": "0.7.0",
+    "err-code": "0.1.2",
     "locking": "2.0.1",
     "mapnik": "3.2.0",
     "minimist": "0.0.5",

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -69,6 +69,53 @@ tape('index province', function(t) {
     addFeature(conf.province, province, t.end);
 });
 
+tape('error: invalid options.proximity type', function(t) {
+    c.geocode('province', { proximity: 'adsf' }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity must be an array in the form [lon, lat]');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+
+tape('error: invalid options.proximity length', function(t) {
+    c.geocode('province', { proximity: [0,0,0] }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity must be an array in the form [lon, lat]');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+
+tape('error: invalid options.proximity[0] type', function(t) {
+    c.geocode('province', { proximity: [{},0] }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity lon value must be a number between -180 and 180');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+
+tape('error: invalid options.proximity[0] value', function(t) {
+    c.geocode('province', { proximity: [-181,0] }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity lon value must be a number between -180 and 180');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+
+tape('error: invalid options.proximity[1] type', function(t) {
+    c.geocode('province', { proximity: [0,{}] }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity lat value must be a number between -90 and 90');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+
+tape('error: invalid options.proximity[1] value', function(t) {
+    c.geocode('province', { proximity: [0,-91] }, function (err, res) {
+        t.equal(err && err.toString(), 'Error: Proximity lat value must be a number between -90 and 90');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
 
 tape('forward country - single layer - limit', function(t) {
     c.geocode('country', { limit_verify: 1, }, function (err, res) {

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -1,0 +1,98 @@
+// Tests Windsor CT (city) vs Windsor Ct (street name)
+// Windsor CT should win via stacky bonus.
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    country: new mem(null, function() {}),
+    region: new mem(null, function() {}),
+    place: new mem(null, function() {})
+};
+var c = new Carmen(conf);
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        _id:1,
+        _text:'china',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        _id:1,
+        _text:'china',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        _id:1,
+        _text:'china',
+        _zxy:['6/32/32'],
+        _center:[0,0]
+    }, t.end);
+});
+// invalid options.types type
+tape('china', function(t) {
+    c.geocode('china', { types: 'asdf' }, function(err, res) {
+        t.equal(err && err.toString(), 'Error: options.types must be an array with at least 1 type');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+// invalid options.types length
+tape('china', function(t) {
+    c.geocode('china', { types: [] }, function(err, res) {
+        t.equal(err && err.toString(), 'Error: options.types must be an array with at least 1 type');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+// invalid options.types[0] value
+tape('china', function(t) {
+    c.geocode('china', { types: ['asdf'] }, function(err, res) {
+        t.equal(err && err.toString(), 'Error: Type "asdf" is not a known type. Must be one of: country, region, place');
+        t.equal(err && err.code, 'EINVALID');
+        t.end();
+    });
+});
+// country wins without type filter
+tape('china', function(t) {
+    c.geocode('china', { limit_verify:3 }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 3, '3 results');
+        t.deepEqual(res.features[0].id, 'country.1', 'country wins');
+        t.end();
+    });
+});
+// types: place
+tape('china', function(t) {
+    c.geocode('china', { limit_verify:3, types:['place'] }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 1, '1 result');
+        t.deepEqual(res.features[0].id, 'place.1', 'place wins');
+        t.end();
+    });
+});
+// types: region, place 
+tape('china', function(t) {
+    c.geocode('china', { limit_verify:3, types:['region','place'] }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 2, '2 results');
+        t.deepEqual(res.features[0].id, 'region.1', 'region #1');
+        t.deepEqual(res.features[1].id, 'place.1', 'place #2');
+        t.end();
+    });
+});
+
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});
+

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -91,6 +91,38 @@ tape('china', function(t) {
     });
 });
 
+// reverse without type filter
+tape('reverse', function(t) {
+    c.geocode('0,0', {}, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 3, '3 results');
+        t.deepEqual(res.features[0].id, 'place.1', 'place wins');
+        t.end();
+    });
+});
+tape('reverse: country', function(t) {
+    c.geocode('0,0', { types:['country'] }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 1, '1 result');
+        t.deepEqual(res.features[0].id, 'country.1', 'country wins');
+        t.end();
+    });
+});
+tape('reverse: country,place', function(t) {
+    c.geocode('0,0', { types:['country','place'] }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 2, '2 results');
+        t.deepEqual(res.features[0].id, 'place.1', '1: place');
+        t.deepEqual(res.features[0].context, [
+            { id:'region.1', text:'china' },
+            { id:'country.1', text:'china' },
+        ], 'preserves full context of place result (including region)');
+        t.deepEqual(res.features[1].id, 'country.1', '2: country');
+        t.deepEqual(res.features[1].context, undefined);
+        t.end();
+    });
+});
+
 tape('index.teardown', function(assert) {
     index.teardown();
     assert.end();


### PR DESCRIPTION
This adds an optional `options.types = [ <type>, <type>, ... ]` query option for filtering results to only the types specified. By default all types are allowed.

- This will bump carmen to 5.2.x
- Affects both forward + reverse geocodes
- Adds tests + documentation for this feature to the README

cc @sbma44 @ian29 @ingalls @camilleanne 