### PR TITLE
Use geometric mean of feature scores

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -59,7 +59,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 }
 
 function verifyFeatures(query, geocoder, spatial, loaded, options) {
-    var maxScore = 0;
+    var meanScore = 1;
     var result = [];
     for (var pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
@@ -102,10 +102,15 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
             feat._distance = proximity.distance(options.proximity, feat._center);
             feat._position = pos;
             feat._spatialmatch = spatialmatch;
-            maxScore = Math.max(maxScore, feat._score);
+            meanScore *= feat._score > 0 ? feat._score : 1;
             result.push(feat);
         }
     }
+
+    // Use a geometric mean for calculating final _scoredist.
+    // This allows extremely high-scored outliers to beat local
+    // results unless within an extremely close proximity.
+    if (result.length) meanScore = Math.pow(meanScore, 1/result.length);
 
     // Set a score + distance combined heuristic.
     for (var i = 0; i < result.length; i++) {
@@ -114,7 +119,7 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
         if (options.proximity && feat._score >= 0) {
             feat._scoredist = Math.max(
                 feat._score,
-                proximity.scoredist(options.proximity, feat._center, maxScore)
+                proximity.scoredist(options.proximity, feat._center, meanScore)
             );
         } else {
             feat._scoredist = feat._score;

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -197,12 +197,12 @@ tape('forward country - multi layer', function(t) {
     });
 });
 
-//If two results are returned prox will only sort if the relev and idx are the same
-tape('forward country - repect layer presidence', function(t) {
+// Ignores idx hierarchy -- scoredist trumps all
+tape('forward country - scoredist wins', function(t) {
     c.geocode('province', { proximity: [-80,40] }, function (err, res) {
         t.ifError(err);
-        t.equals(res.features[0].place_name, 'province', 'found province');
-        t.equals(res.features[0].id, 'country.3', 'found country.3');
+        t.equals(res.features[0].place_name, 'province, country', 'found province');
+        t.equals(res.features[0].id, 'province.1', 'found province.1');
         t.equals(res.features[0].relevance, 0.99);
         t.end();
     });


### PR DESCRIPTION
Rather than max for calculating `scoredist`. Allows outlier high-scorers to beat closeby features until you're really close.