### PR TITLE
Singleton VT cache

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -10,7 +10,6 @@ var zlib = require('zlib'),
     addressCluster = require('./pure/addresscluster');
     applyaddress = require('./pure/applyaddress');
 
-
 // Returns a hierarchy of features ("context") for a given lon, lat pair.
 //
 // This is used for reverse geocoding: given a point, it returns possible
@@ -63,6 +62,40 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     });
 };
 
+var getTile = Locking(function(options, unlock) {
+    var source = options.source;
+    var z = parseInt(options.z,10);
+    var x = parseInt(options.x,10);
+    var y = parseInt(options.y,10);
+    source.getTile(z, x, y, function(err, zpbf) {
+        if (err && err.message !== 'Tile does not exist') return unlock(err);
+        if (!zpbf) return unlock(null, false);
+
+        var compression = false;
+        if (zpbf[0] == 0x78 && zpbf[1] == 0x9C) {
+            compression = 'inflate';
+        } else if (zpbf[0] == 0x1F && zpbf[1] == 0x8B) {
+            compression = 'gunzip';
+        }
+        if (!compression) return unlock(new Error('Could not detect compression of vector tile'));
+
+        zlib[compression](zpbf, function(err, pbf) {
+            if (err) return unlock(err);
+            if (pbf.length === 0) return unlock(null, false);
+            var vt = new mapnik.VectorTile(z, x, y);
+            vt.byteSize = pbf.length;
+            vt.setData(pbf, function(err) {
+                if (err) return unlock(err);
+                vt.parse(function(err) {
+                    if (err) return unlock(err);
+                    return unlock(null, vt);
+                });
+            });
+        });
+    });
+}, { max: 1024 });
+
+module.exports.getTile = getTile;
 module.exports.contextVector = contextVector;
 
 // For each context type, load a representative tile, look around the
@@ -71,46 +104,17 @@ module.exports.contextVector = contextVector;
 // in imaginary z-space (country, town, place, etc). When there are no more
 // to do, return that array, filtered of nulls and reversed.
 function contextVector(source, lon, lat, full, matched, callback) {
-    source._geocoder.loadTile = source._geocoder.loadTile || Locking(loadTile, {
-        max: source._geocoder.maxzoom < 9 ? 512 : 64
-    });
-
     var xyz = sm.xyz([lon, lat, lon, lat], source._geocoder.maxzoom);
-    var zxy = source._geocoder.maxzoom + '/' + xyz.minX + '/' + xyz.minY;
-    source._geocoder.loadTile(zxy, query);
-
-    function loadTile(zxy, unlock) {
-        zxy = zxy.split('/');
-        var z = parseInt(zxy[0],10);
-        var x = parseInt(zxy[1],10);
-        var y = parseInt(zxy[2],10);
-        source.getTile(z, x, y, function(err, zpbf) {
-            if (err && err.message !== 'Tile does not exist') return unlock(err);
-            if (!zpbf) return unlock(null, false);
-
-            var compression = false;
-            if (zpbf[0] == 0x78 && zpbf[1] == 0x9C) {
-                compression = 'inflate';
-            } else if (zpbf[0] == 0x1F && zpbf[1] == 0x8B) {
-                compression = 'gunzip';
-            }
-            if (!compression) return unlock(new Error('Could not detect compression of vector tile'));
-
-            zlib[compression](zpbf, function(err, pbf) {
-                if (err) return unlock(err);
-                if (pbf.length === 0) return unlock(null, false);
-                var vt = new mapnik.VectorTile(z, x, y);
-                vt.byteSize = pbf.length;
-                vt.setData(pbf, function(err) {
-                    if (err) return unlock(err);
-                    vt.parse(function(err) {
-                        if (err) return unlock(err);
-                        return unlock(null, vt);
-                    });
-                });
-            });
-        });
-    }
+    var options = {
+        source: source,
+        z: source._geocoder.maxzoom,
+        x: xyz.minX,
+        y: xyz.minY
+    };
+    options.toJSON = function() {
+        return source._geocoder.id + ':' + options.z + '/' + options.x + '/' + options.y;
+    };
+    getTile(options, query);
 
     // For a loaded vector tile, query for features at the lon,lat.
     function query(err, vt) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -13,6 +13,8 @@ mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'ogr.in
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
 
 test('context vector', function(t) {
+    context.getTile.cache.reset();
+
     var geocoder = new Carmen({
         country: Carmen.auto(__dirname + '/fixtures/01-ne.country.s3'),
         province: Carmen.auto(__dirname + '/fixtures/02-ne.province.s3')
@@ -41,6 +43,8 @@ test('context vector', function(t) {
 });
 
 test('contextVector deflate', function(t) {
+    context.getTile.cache.reset();
+
     var source = {
         getTile: function(z,x,y,callback) {
             return callback(null, fs.readFileSync(__dirname + '/fixtures/0.0.0.vector.pbf'), {
@@ -70,6 +74,8 @@ test('contextVector deflate', function(t) {
 });
 
 test('contextVector gzip', function(t) {
+    context.getTile.cache.reset();
+
     var source = {
         getTile: function(z,x,y,callback) {
             return callback(null, fs.readFileSync(__dirname + '/fixtures/0.0.0.vector.pbfz'), {
@@ -99,6 +105,8 @@ test('contextVector gzip', function(t) {
 });
 
 test('contextVector badbuffer', function(t) {
+    context.getTile.cache.reset();
+
     var source = {
         getTile: function(z,x,y,callback) {
             return callback(null, new Buffer('lkzvjlkajsdf'));
@@ -120,6 +128,8 @@ test('contextVector badbuffer', function(t) {
 
 //Carmen should gracefully ignore empty VT buffers
 test('contextVector empty VT buffer', function(assert) {
+    context.getTile.cache.reset();
+
     var vtile = new mapnik.VectorTile(0,0,0);
     vtile.addGeoJSON(JSON.stringify({
         "type": "FeatureCollection",
@@ -148,6 +158,8 @@ test('contextVector empty VT buffer', function(assert) {
 });
 
 test('contextVector ignores negative score', function(assert) {
+    context.getTile.cache.reset();
+
     var vtile = new mapnik.VectorTile(0,0,0);
     vtile.addGeoJSON(JSON.stringify({
         "type": "FeatureCollection",
@@ -188,6 +200,8 @@ test('contextVector ignores negative score', function(assert) {
 });
 
 test('contextVector only negative score', function(assert) {
+    context.getTile.cache.reset();
+
     var vtile = new mapnik.VectorTile(0,0,0);
     vtile.addGeoJSON(JSON.stringify({
         "type": "FeatureCollection",
@@ -223,6 +237,8 @@ test('contextVector only negative score', function(assert) {
 });
 
 test('contextVector matched negative score', function(assert) {
+    context.getTile.cache.reset();
+
     var vtile = new mapnik.VectorTile(0,0,0);
     vtile.addGeoJSON(JSON.stringify({
         "type": "FeatureCollection",
@@ -258,6 +274,8 @@ test('contextVector matched negative score', function(assert) {
 });
 
 test('contextVector restricts distance', function(assert) {
+    context.getTile.cache.reset();
+
     var vtile = new mapnik.VectorTile(0,0,0);
     // o-----x <-- query
     // |\    |     the distance in this case is millions of miles
@@ -331,6 +349,8 @@ test('contextVector restricts distance', function(assert) {
     vtileB.addGeoJSON(JSON.stringify(geojson),"data");
 
     test('contextVector sorts ties A', function(assert) {
+        context.getTile.cache.reset();
+
         zlib.gzip(vtileA.getData(), function(err, buffer) {
             assert.ifError(err);
             var source = {
@@ -355,6 +375,8 @@ test('contextVector restricts distance', function(assert) {
     });
 
     test('contextVector sorts ties A', function(assert) {
+        context.getTile.cache.reset();
+
         zlib.gzip(vtileB.getData(), function(err, buffer) {
             assert.ifError(err);
             var source = {
@@ -379,6 +401,8 @@ test('contextVector restricts distance', function(assert) {
     });
 
     test('contextVector sorts ties B (matched)', function(assert) {
+        context.getTile.cache.reset();
+
         zlib.gzip(vtileB.getData(), function(err, buffer) {
             assert.ifError(err);
             var source = {

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -129,6 +130,7 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.address-bitmask.test.js
+++ b/test/geocode-unit.address-bitmask.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -119,6 +120,7 @@ tape('test us number street with address', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -169,6 +170,7 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -82,6 +83,7 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.backy.test.js
+++ b/test/geocode-unit.backy.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -70,6 +71,7 @@ tape('lessingstrasse 50825 koln', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.bmask.test.js
+++ b/test/geocode-unit.bmask.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.byid.test.js
+++ b/test/geocode-unit.byid.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -53,6 +54,7 @@ tape('query byid', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -65,6 +66,7 @@ tape('test reverse address query with address range', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.context-overlap.test.js
+++ b/test/geocode-unit.context-overlap.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -58,6 +59,7 @@ tape('geocoder_name dedupe', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.dataterm-only.test.js
+++ b/test/geocode-unit.dataterm-only.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -33,6 +34,7 @@ tape('test address', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.dataterm-vs-postcode.test.js
+++ b/test/geocode-unit.dataterm-vs-postcode.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -58,6 +59,7 @@ tape('test address', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -51,6 +52,7 @@ tape('test address', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -131,6 +132,7 @@ tape('west st, tonawanda, ny', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -42,6 +43,7 @@ tape.skip('test address', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.featurenoop.test.js
+++ b/test/geocode-unit.featurenoop.test.js
@@ -5,6 +5,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -30,6 +31,7 @@ tape('reverse geocode', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -38,6 +39,7 @@ tape('search: "av francisco de aguirre 2 la serena"', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -115,6 +116,7 @@ tape('new york ny', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -41,6 +42,7 @@ tape('reverse place', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.lowrelev.test.js
+++ b/test/geocode-unit.lowrelev.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -50,6 +51,7 @@ tape('fake blah blah => [fail]', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.named.test.js
+++ b/test/geocode-unit.named.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -46,6 +47,7 @@ tape('funtown', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.numeric-address.test.js
+++ b/test/geocode-unit.numeric-address.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -49,6 +50,7 @@ tape('100 17', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -1,6 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -57,6 +58,7 @@ tape('does index degens for non-numeric terms', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -232,6 +233,7 @@ tape('forward province - multilayer', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -204,6 +205,7 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.scoredist.test.js
+++ b/test/geocode-unit.scoredist.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 var queue = require('queue-async');
@@ -60,6 +61,7 @@ tape('geocode proximity=20,0 => nearest', function(t) {
 });
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.scorefactor.test.js
+++ b/test/geocode-unit.scorefactor.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -57,6 +58,7 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.spatialmatch.test.js
+++ b/test/geocode-unit.spatialmatch.test.js
@@ -5,6 +5,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -58,6 +59,7 @@ tape('test spatialmatch relev', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -64,6 +65,7 @@ tape('windsor ct windsor', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -50,6 +51,7 @@ tape('albany australia', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.tile-edge.test.js
+++ b/test/geocode-unit.tile-edge.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
 
@@ -33,6 +34,7 @@ tape('forward between tiles', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -107,5 +108,6 @@ var addFeature = require('../lib/util/addfeature');
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -125,6 +126,7 @@ tape('reverse: country,place', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.unicode-replace.test.js
+++ b/test/geocode-unit.unicode-replace.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -45,6 +46,7 @@ tape('Marechal => Maréchal', function(t) {
 });
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 

--- a/test/geocode-unit.unicode.test.js
+++ b/test/geocode-unit.unicode.test.js
@@ -4,6 +4,7 @@
 var tape = require('tape');
 var Carmen = require('..');
 var index = require('../lib/index');
+var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
@@ -116,6 +117,7 @@ tape('josé => josé', function(t) {
 
 tape('index.teardown', function(assert) {
     index.teardown();
+    context.getTile.cache.reset();
     assert.end();
 });
 


### PR DESCRIPTION
Use a single cache across sources for vector tiles to limit memory usage regardless of number of sources.

- [x] Add context cache logic testing
- [x] Test IRL