### PR TITLE
stricter address num criteria

### DIFF
--- a/.retireignore
+++ b/.retireignore
@@ -1,1 +1,2 @@
 @semver
+@uglify-js

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -467,7 +467,7 @@ function numTokenize(text, version) {
     var numTokenized = [];
     for (var i = 0; i < text.length; i++) {
         var replaced = text.slice(0);
-        num = parseSemiNumber(address(text[i]));
+        var num = parseSemiNumber(address(text[i]));
         if (num !== null) {
             replaced[i] = version >= 3 ?
                 numTokenV3(num.toString()) :

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -467,7 +467,7 @@ function numTokenize(text, version) {
     var numTokenized = [];
     for (var i = 0; i < text.length; i++) {
         var replaced = text.slice(0);
-        var num = parseSemiNumber(text[i]);
+        num = parseSemiNumber(address(text[i]));
         if (num !== null) {
             replaced[i] = version >= 3 ?
                 numTokenV3(num.toString()) :

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -92,15 +92,8 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
                 feat._geometry = addressCluster(feat, address.addr);
                 feat._center = feat._geometry && feat._geometry.coordinates;
                 checks = checks && feat._geometry;
-            } else if (!address && (feat._cluster || feat._rangetype)) {
-                // this is a range or cluster feature e.g. '### Main St'
-                // but there is NOT room in the query for an address number (tokens are accounted for)
-                // so: it's either a street missing a number ["Main", "St"]
-                // or an incorrect partial match ["123", "Main"]
-                if (query.join(' ').indexOf(feat._text) === -1)
-                    checks = false;
-                else
-                    feat._address = null;
+            } else {
+                feat._address = null;
             }
         }
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -81,18 +81,27 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
 
         var checks = true;
 
-        if (address && feat._rangetype && source._geocoder.geocoder_address) {
-            feat._address = address.addr;
-            feat._geometry = applyAddress(feat, address.addr);
-            feat._center = feat._geometry && feat._geometry.coordinates;
-            checks = checks && feat._geometry;
-        } else if (address && feat._cluster && source._geocoder.geocoder_address) {
-            feat._address = address.addr;
-            feat._geometry = addressCluster(feat, address.addr);
-            feat._center = feat._geometry && feat._geometry.coordinates;
-            checks = checks && feat._geometry;
-        } else if (source._geocoder.geocoder_address) {
-            feat._address = null;
+        if (source._geocoder.geocoder_address) {
+            if (address && feat._rangetype) {
+                feat._address = address.addr;
+                feat._geometry = applyAddress(feat, address.addr);
+                feat._center = feat._geometry && feat._geometry.coordinates;
+                checks = checks && feat._geometry;
+            } else if (address && feat._cluster) {
+                feat._address = address.addr;
+                feat._geometry = addressCluster(feat, address.addr);
+                feat._center = feat._geometry && feat._geometry.coordinates;
+                checks = checks && feat._geometry;
+            } else if (!address && (feat._cluster || feat._rangetype)) {
+                // this is a range or cluster feature e.g. '### Main St'
+                // but there is NOT room in the query for an address number (tokens are accounted for)
+                // so: it's either a street missing a number ["Main", "St"]
+                // or an incorrect partial match ["123", "Main"]
+                if (query.join(' ').indexOf(feat._text) === -1)
+                    checks = false;
+                else
+                    feat._address = null;
+            }
         }
 
         if (checks) {

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -110,6 +110,58 @@ var addFeature = require('../lib/util/addfeature');
 
 (function() {
     var conf = {
+        postcode: new mem({maxzoom: 6 }, function() {}),
+        address: new mem({maxzoom: 6, geocoder_address: 1}, function() {})
+    };
+    var c = new Carmen(conf);
+    tape('index fake UK address range', function(t) {
+            var address = {
+                _id: 1,
+                _text:'B77',
+                _zxy:['6/32/32'],
+                _center:[0,0],
+                _rangetype:'tiger',
+                _lfromhn: '0',
+                _ltohn: '100',
+                _geometry: {
+                    type:'LineString',
+                    coordinates:[[0,0],[0,100]]
+                }
+            };
+            addFeature(conf.address, address, t.end);
+    });
+    tape('index fake UK postcode', function(t) {
+            var postcode = {
+                _id: 2,
+                _text:'B77 1AB',
+                _zxy:['6/32/32'],
+                _center:[0,0],
+                _geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [-1, -1],
+                        [101, -1],
+                        [101, 101],
+                        [-1, 101],
+                        [-1, -1]
+                    ]
+                }
+            };
+            addFeature(conf.postcode, postcode, t.end);
+    });
+    tape('test UK postcode not getting confused w/ address range', function(t) {
+        c.geocode('B77 1AB', { limit_verify: 1 }, function (err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'B77 1AB', 'found feature \'B77 1AB\'');
+            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].id.split('.')[0], 'postcode', 'feature is from layer postcode');
+            t.end();
+        });
+    });
+})();
+
+(function() {
+    var conf = {
         address: new mem({maxzoom: 6, geocoder_address: 1}, function() {})
     };
     var c = new Carmen(conf);

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -92,6 +92,17 @@ var addFeature = require('../lib/util/addfeature');
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
             t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].address, '9b', 'address number is 9b');
+            t.end();
+        });
+    });
+
+    tape('test alphanumeric address query with invalid address number', function(t) {
+        c.geocode('9bc fake street', { limit_verify: 1 }, function (err, res) {
+            t.ifError(err);
+            t.ok(res.features[0].place_name, 'fake street', 'found fake street feature');
+            t.ok((res.features[0].relevance < 0.6), 'appropriate relevance');
+            t.ok((res.features[0].address === undefined), 'address number is not defined');
             t.end();
         });
     });

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -101,7 +101,7 @@ var addFeature = require('../lib/util/addfeature');
         c.geocode('9bc fake street', { limit_verify: 1 }, function (err, res) {
             t.ifError(err);
             t.ok(res.features[0].place_name, 'fake street', 'found fake street feature');
-            t.ok((res.features[0].relevance < 0.6), 'appropriate relevance');
+            t.ok((res.features[0].relevance < 0.6), 'appropriate relevance (9bc token should not be matched)');
             t.ok((res.features[0].address === undefined), 'address number is not defined');
             t.end();
         });
@@ -150,11 +150,12 @@ var addFeature = require('../lib/util/addfeature');
             addFeature(conf.postcode, postcode, t.end);
     });
     tape('test UK postcode not getting confused w/ address range', function(t) {
-        c.geocode('B77 1AB', { limit_verify: 1 }, function (err, res) {
-            t.ifError(err);
+        c.geocode('B77 1AB', { limit_verify: 10 }, function (err, res) {
             t.equals(res.features[0].place_name, 'B77 1AB', 'found feature \'B77 1AB\'');
             t.equals(res.features[0].relevance, 0.99);
             t.equals(res.features[0].id.split('.')[0], 'postcode', 'feature is from layer postcode');
+            var addressInResultSet = res.features.some(function(feature) { return feature.id.split('.')[0] === 'address' });
+            t.ok(!addressInResultSet, 'result set does not include address feature');
             t.end();
         });
     });


### PR DESCRIPTION
Tightens up regex criteria used to match tokens as address numbers on address range features. In particular `1A` will continue to match but `1AB` will not. This is necessary to properly support UK postcodes -- e.g. `B77 1AA` -- when loaded alongside range features like `B77 ###`.

@yhahn would to hear your sense on whether included tests are adequate.