### PR TITLE
Versions Are Cheap geocoder_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ attribute               | description
 ------------------------|------------
 maxzoom                 | The assumed zoom level of the zxy geocoder grid index.
 geocoder_layer          | Optional. A string in the form `layer.field`. `layer` is used to determine what layer to query for context operations. Defaults to the first layer found in a vector source.
-geocoder_address        | Optional. A flag (0/1) to indicate that an index can geocode address (house numbers) queries. Defaults to 0. Or a string containing how to format the street name and address. eg: `"{name} {num}"`. Carmen defaults to `"{num} {name}"`
+geocoder_address        | Optional. A flag (0/1) to indicate that an index can geocode address (house numbers) queries. Defaults to 0.
+geocoder_format         | Optional. A string containing how to format the resulting `place_name` field. Ie: `{address._number} {address._name} {place._name}` where `address`/`place` are the extid of a given index and `_name`/`_number` are internal carmen designators to replace with the first text value from `carmen:text` & the matched address. This string can also map to string properties on the geojson. ie `{extid.title}` would be replace with `feature.properties.title` for the indexed GeoJSON for the given extid. See `test/geocoder-unit.address-format.test.js` for more examples. 
 geocoder_resolution     | Optional. Integer bonus against maxzoom used to increase the grid index resolution when indexing. Defaults to 0.
 geocoder_group          | Optional + advanced. For indexes that share the exact same tile source, IO operations can be grouped. No default.
 geocoder_tokens         | Optional + advanced. An object with a 1:1 from => to mapping of token strings to replace in input queries. e.g. 'Streets' => 'St'.

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function Geocoder(options) {
                 source._geocoder.shardlevel = info.geocoder_shardlevel || 0;
             }
 
+            source._geocoder.geocoder_format = info.geocoder_format||false;
             source._geocoder.geocoder_layer = (info.geocoder_layer||'').split('.').shift();
             source._geocoder.geocoder_tokens = info.geocoder_tokens||{};
             source._geocoder.token_replacer = token.createReplacer(info.geocoder_tokens||{});

--- a/lib/context.js
+++ b/lib/context.js
@@ -4,11 +4,11 @@ var zlib = require('zlib'),
     termops = require('./util/termops'),
     feature = require('./util/feature'),
     ops = require('./util/ops'),
-    sm = new (require('sphericalmercator'))(),
     queue = require('queue-async'),
     Locking = require('locking'),
     addressCluster = require('./pure/addresscluster'),
     applyaddress = require('./pure/applyaddress');
+var cover = require('tile-cover');
 
 // Returns a hierarchy of features ("context") for a given lon, lat pair.
 //
@@ -104,12 +104,18 @@ module.exports.contextVector = contextVector;
 // in imaginary z-space (country, town, place, etc). When there are no more
 // to do, return that array, filtered of nulls and reversed.
 function contextVector(source, lon, lat, full, matched, callback) {
-    var xyz = sm.xyz([lon, lat, lon, lat], source._geocoder.maxzoom);
+    var tiles = cover.tiles({
+        type: 'Point',
+        coordinates: [lon,lat]
+    }, {
+        min_zoom: source._geocoder.maxzoom,
+        max_zoom: source._geocoder.maxzoom
+    });
     var options = {
         source: source,
         z: source._geocoder.maxzoom,
-        x: xyz.minX,
-        y: xyz.minY
+        x: tiles[0][0],
+        y: tiles[0][1]
     };
     options.toJSON = function() {
         return source._geocoder.id + ':' + options.z + '/' + options.x + '/' + options.y;

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -107,7 +107,7 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
                         continue;
                     }
                 }
-                queryData.features.push(ops.toFeature(context, geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder.geocoder_address));
+                queryData.features.push(ops.toFeature(context, geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder.geocoder_format));
                 context.shift();
             }
         } catch (err) {
@@ -202,7 +202,7 @@ function forwardGeocode(geocoder, query, options, callback) {
             queryData.features = [];
             try {
                 for (var i = 0; i < contexts.length; i++) {
-                    var feature = ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder.geocoder_address);
+                    var feature = ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder.geocoder_format);
                     queryData.features.push(feature);
                 }
             } catch (err) {

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -21,9 +21,16 @@ function addVT(source, doc, callback) {
 }
 
 function _addFeature(source, input, vtile_only, callback) {
-    if (input._text) {
+    if (input._text) { 
         input = feature.transform(input);
-    } else if (!input.properties['carmen:zxy']) {
+    }
+
+    input.geometry = input.geometry || {
+        type: 'Point',
+        coordinates: input.properties['carmen:center']
+    };
+
+    if (!input.properties['carmen:zxy']) {
         input.properties['carmen:zxy'] = cover.tiles(input.geometry, {min_zoom: source._info.maxzoom, max_zoom: source._info.maxzoom}).map(function(zxy) {
             return zxy[2] + '/' + zxy[0] + '/' + zxy[1]
         });

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -8,7 +8,7 @@ module.exports.toFeature = function(context, format) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
         return (f.properties['carmen:text']||'').split(',')[0];
     };
-    //Use geocoder_address to format output if applicable
+    //Use geocoder_format to format output if applicable
     if (!format || format === true || format === 1) {
         place_name = ((feat.properties['carmen:address'] ? feat.properties['carmen:address'] + ' ' : '') + context.map(gettext).join(', ')).trim();
     } else {

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -1,9 +1,8 @@
 var Point = require('turf-point');
 var Distance = require('turf-distance');
 var ops = require('./ops');
-var SphericalMercator = require('sphericalmercator');
+var cover = require('tile-cover');
 var Relev = require('./relev');
-var sm = new SphericalMercator();
 
 module.exports = {};
 
@@ -17,8 +16,14 @@ module.exports.center2zxy = center2zxy;
 function center2zxy(lon, lat, z) {
     lon = Math.min(180,Math.max(-180,lon));
     lat = Math.min(85.0511,Math.max(-85.0511,lat));
-    var bbox = sm.xyz([lon,lat,lon,lat], z);
-    return [ z, bbox.minX, bbox.minY ];
+    var tiles = cover.tiles({
+        type: 'Point',
+        coordinates: [lon,lat]
+    }, {
+        min_zoom: z,
+        max_zoom: z
+    });
+    return [ z, tiles[0][0], tiles[0][1] ];
 }
 
 module.exports.scoredist = scoredist;

--- a/test/fixtures/mem.json
+++ b/test/fixtures/mem.json
@@ -3419,6 +3419,7 @@
         "id": "to",
         "geocoder_address": false,
         "version": 4,
+        "geocoder_format": false,
         "geocoder_layer": "",
         "geocoder_tokens": {},
         "token_replacer": [],

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -12,7 +12,7 @@ var addFeature = require('../lib/util/addfeature');
 // Test geocoder_address formatting + return place_name as germany style address (address number follows name)
 (function() {
     var conf = {
-        address: new mem({maxzoom: 6,  geocoder_address: '{address._name} {address._number} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
+        address: new mem({maxzoom: 6,  geocoder_address:1, geocoder_format: '{address._name} {address._number} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
     };
     var c = new Carmen(conf);
     tape('index address', function(t) {
@@ -51,12 +51,12 @@ var addFeature = require('../lib/util/addfeature');
 //Test geocoder_address formatting for multiple layers
 (function() {
     var conf = {
-        country: new mem({ maxzoom:6,  geocoder_address: '{country._name}' }, function() {}),
-        region: new mem({maxzoom: 6,   geocoder_address: '{region._name}, {country._name}' }, function() {}),
-        postcode: new mem({maxzoom: 6, geocoder_address: '{region._name}, {postcode._name}, {country._name}' }, function() {}),
-        place: new mem({maxzoom: 6,    geocoder_address: '{place._name}, {region._name} {postcode._name}, {country._name}' }, function() {}),
-        address: new mem({maxzoom: 6,  geocoder_address: '{address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
-        poi: new mem({maxzoom: 6,      geocoder_address: '{poi._name}, {address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
+        country: new mem({ maxzoom:6,  geocoder_format: '{country._name}' }, function() {}),
+        region: new mem({maxzoom: 6,   geocoder_format: '{region._name}, {country._name}' }, function() {}),
+        postcode: new mem({maxzoom: 6, geocoder_format: '{region._name}, {postcode._name}, {country._name}' }, function() {}),
+        place: new mem({maxzoom: 6,    geocoder_format: '{place._name}, {region._name} {postcode._name}, {country._name}' }, function() {}),
+        address: new mem({maxzoom: 6,  geocoder_address: 1, geocoder_format: '{address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
+        poi: new mem({maxzoom: 6,      geocoder_format: '{poi._name}, {address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
     };
     var c = new Carmen(conf);
     tape('index country', function(t) {
@@ -266,8 +266,8 @@ var addFeature = require('../lib/util/addfeature');
 // Test to make sure cases of custom subproperties are accounted for
 (function() {
     var conf = {
-        place: new mem({maxzoom: 6,  geocoder_address: '{place._name}'}, function() {}),
-        kitten: new mem({maxzoom: 6,  geocoder_address: '{kitten._name} {kitten.version} {kitten.color}, {place._name}'}, function() {}),
+        place: new mem({maxzoom: 6,  geocoder_format: '{place._name}'}, function() {}),
+        kitten: new mem({maxzoom: 6,  geocoder_format: '{kitten._name} {kitten.version} {kitten.color}, {place._name}'}, function() {}),
     };
     var c = new Carmen(conf);
     tape('index place', function(t) {

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -7,7 +7,7 @@ var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {
-    address: new mem({maxzoom: 6, geocoder_address: '{address._name} {address._number}', geocoder_name:'address'}, function() {})
+    address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_format: '{address._name} {address._number}', geocoder_name:'address'}, function() {})
 };
 var c = new Carmen(conf);
 

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -7,7 +7,7 @@ var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {
-    test: new mem({ maxzoom:6, geocoder_address:'{name} {num}' }, function() {})
+    test: new mem({ maxzoom:6, geocoder_address: 1 }, function() {})
 };
 var c = new Carmen(conf);
 tape('index "av francisco de aguirre #"', function(t) {

--- a/test/proximity.test.js
+++ b/test/proximity.test.js
@@ -5,7 +5,7 @@ test('proximity.center2zxy', function(assert) {
     assert.deepEqual(proximity.center2zxy(0,0,5), [5,16,16]);
     assert.deepEqual(proximity.center2zxy(-90,45,5), [5,8,11]);
     assert.deepEqual(proximity.center2zxy(-181,90.1,5), [5,0,0], 'respects world extents');
-    assert.deepEqual(proximity.center2zxy(181,-90.1,5), [5,32,32], 'respects world extents');
+    assert.deepEqual(proximity.center2zxy(181,-90.1,5), [5,32,31], 'respects world extents');
     assert.end();
 });
 


### PR DESCRIPTION
Captured from chat

```
ingalls [22:09]
unintended side affects
basically really really early on the geocoder_address flag is used to determine if phrasematch should generate address permulations for a given source
for most layers this doesn’t really matter
as places/regions etc
don’t have numbers in them

heyitsgarrett [22:09] 
right

ingalls [22:09] 
so the address permutations fail and are then ignored
for postcode however
the address permutations ​_can_​ be generated
as a number is found
that is a potential housenumbers
but when it goes back to actually look up this permutation in the index
it can’t find a housenumber that matches
because the postcode indexes don’t have the additional housenumber info
which results in the postcode index hard failing and returning no results
```

cc/ @heyitsgarrett @sbma44 