### PR TITLE
slimmer caches for testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,3 +210,4 @@ Geocoder.prototype.copy = function(from, to, callback) {
 
 Geocoder.auto = loader.auto;
 Geocoder.autodir = loader.autodir;
+Geocoder.setVtCacheSize = getContext.getTile.setVtCacheSize;

--- a/lib/context.js
+++ b/lib/context.js
@@ -95,8 +95,7 @@ var getTile = Locking(function(options, unlock) {
     });
 }, { max: 1024 });
 getTile.setVtCacheSize = function(size) {
-    // replace the lru cache with a differently-sized one, using whatever copy/version of lru-cache locking is using
-    getTile.cache = require.cache[require.resolve('locking')].require('lru-cache')({ max: size, maxAge: 30e3 });
+    getTile.cache.max = size;
 }
 
 module.exports.getTile = getTile;

--- a/lib/context.js
+++ b/lib/context.js
@@ -93,7 +93,7 @@ var getTile = Locking(function(options, unlock) {
             });
         });
     });
-}, { max: 1024 });
+}, { max: 64 });
 
 module.exports.getTile = getTile;
 module.exports.contextVector = contextVector;

--- a/lib/context.js
+++ b/lib/context.js
@@ -93,7 +93,11 @@ var getTile = Locking(function(options, unlock) {
             });
         });
     });
-}, { max: 64 });
+}, { max: 1024 });
+getTile.setVtCacheSize = function(size) {
+    // replace the lru cache with a differently-sized one, using whatever copy/version of lru-cache locking is using
+    getTile.cache = require.cache[require.resolve('locking')].require('lru-cache')({ max: size, maxAge: 30e3 });
+}
 
 module.exports.getTile = getTile;
 module.exports.contextVector = contextVector;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.9.0",
+    "carmen-cache": "0.10.0",
     "err-code": "0.1.2",
     "eslint": "^1.5.0",
     "locking": "2.0.1",


### PR DESCRIPTION
applies two strategies for controlling memory consumption:
- adjustable vector tile cache size
- moves `ldict` cache in `carmen-cache` -- used for pre-I/O feature existence checking by ID -- to a 32 bit space by truncating the full 64 bit ID