### PR TITLE
add language flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ attribute               | description
 maxzoom                 | The assumed zoom level of the zxy geocoder grid index.
 geocoder_layer          | Optional. A string in the form `layer.field`. `layer` is used to determine what layer to query for context operations. Defaults to the first layer found in a vector source.
 geocoder_address        | Optional. A flag (0/1) to indicate that an index can geocode address (house numbers) queries. Defaults to 0.
-geocoder_format         | Optional. A string containing how to format the resulting `place_name` field. Ie: `{address._number} {address._name} {place._name}` where `address`/`place` are the extid of a given index and `_name`/`_number` are internal carmen designators to replace with the first text value from `carmen:text` & the matched address. This string can also map to string properties on the geojson. ie `{extid.title}` would be replace with `feature.properties.title` for the indexed GeoJSON for the given extid. See `test/geocoder-unit.address-format.test.js` for more examples. 
+geocoder_format         | Optional. A string containing how to format the resulting `place_name` field. Ie: `{address._number} {address._name} {place._name}` where `address`/`place` are the extid of a given index and `_name`/`_number` are internal carmen designators to replace with the first text value from `carmen:text` & the matched address. This string can also map to string properties on the geojson. ie `{extid.title}` would be replace with `feature.properties.title` for the indexed GeoJSON for the given extid. By adding multiple `geocoder_format` keys with a language tag (e.g. `geocoder_format_zh`), multiple formats can be supported and engaged by using a `language` flag. See `test/geocoder-unit.address-format.test.js` for more examples.
 geocoder_resolution     | Optional. Integer bonus against maxzoom used to increase the grid index resolution when indexing. Defaults to 0.
 geocoder_group          | Optional + advanced. For indexes that share the exact same tile source, IO operations can be grouped. No default.
 geocoder_tokens         | Optional + advanced. An object with a 1:1 from => to mapping of token strings to replace in input queries. e.g. 'Streets' => 'St'.
@@ -91,6 +91,9 @@ as part of the `options` object:
   of the results.
 - `stats` - boolean. If true, the carmen stats object will be returned as part
   of the results.
+- `language` - ISO country code. If `carmen:text_{lc}` and/or `geocoder_format_{lc}`
+  are available on a features, response will be returned in that language and
+  appropriately formatted.
 
 ### index(from, to, pointer, callback)
 
@@ -154,7 +157,8 @@ as well as the following settings in the `properties` object.
 
 attribute         | description
 ------------------|------------
-`carmen:text`     | Text to index for this feature. Synonyms, translations, etc. should be separated using commas.
+`carmen:text`     | Default text to index for this feature. Synonyms, translations, etc. should be separated using commas.
+`carmen:text_{language code}`     | Localized to index for this feature. Synonyms, translations, etc. should be separated using commas and will be synonymized with `carmen:text`.
 `carmen:center`   | Optional. An array in the form [lon,lat]. center must be on the geometry surface, or the center will be recalculated.
 `carmen:score`    | Optional. A float or integer to sort equally relevant results by. Higher values appear first. Docs with negative scores can contribute to a final result but are only returned if included in matches of a forward search query.
 `carmen:addressnumber`  | Optional. Used with `geocoder_address`. An array of addresseses corresponding to the order of their geometries in the `GeometryCollection`

--- a/index.js
+++ b/index.js
@@ -63,9 +63,9 @@ function Geocoder(options) {
 
             var keys = Object.keys(info);
             for (var ix = 0; ix < keys.length; ix ++) {
-                if (/geocoder_format/.test(keys[ix])) source._geocoder[keys[ix]] = info[keys[ix]]||false;
+                if (/geocoder_format_/.test(keys[ix])) source._geocoder[keys[ix]] = info[keys[ix]]||false;
             }
-
+            source._geocoder.geocoder_format = info.geocoder_format||false;
             source._geocoder.geocoder_layer = (info.geocoder_layer||'').split('.').shift();
             source._geocoder.geocoder_tokens = info.geocoder_tokens||{};
             source._geocoder.token_replacer = token.createReplacer(info.geocoder_tokens||{});

--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ function Geocoder(options) {
                 source._geocoder.shardlevel = info.geocoder_shardlevel || 0;
             }
 
-            source._geocoder.geocoder_format = info.geocoder_format||false;
+            var keys = Object.keys(info);
+            for (var ix = 0; ix < keys.length; ix ++) {
+                if (/geocoder_format/.test(keys[ix])) source._geocoder[keys[ix]] = info[keys[ix]]||false;
+            }
+
             source._geocoder.geocoder_layer = (info.geocoder_layer||'').split('.').shift();
             source._geocoder.geocoder_tokens = info.geocoder_tokens||{};
             source._geocoder.token_replacer = token.createReplacer(info.geocoder_tokens||{});

--- a/lib/context.js
+++ b/lib/context.js
@@ -29,6 +29,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     var maxidx = typeof options.maxidx === 'number' ? options.maxidx : types.length;
     var full = options.full || false;
     var matched = options.matched || {};
+    var language = options.language || false;
 
     types = types.slice(0, maxidx);
 
@@ -41,7 +42,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
         var bounds = source._geocoder.bounds;
 
         if (lat >= bounds[1] && lat <= bounds[3] && lon >= bounds[0] && lon <= bounds[2])
-            q.defer(contextVector, source, lon, lat, full, matched);
+            q.defer(contextVector, source, lon, lat, full, matched, language);
     });
 
     q.awaitAll(function(err, res) {
@@ -106,7 +107,7 @@ module.exports.contextVector = contextVector;
 // array under an array index that represents the position of the context
 // in imaginary z-space (country, town, place, etc). When there are no more
 // to do, return that array, filtered of nulls and reversed.
-function contextVector(source, lon, lat, full, matched, callback) {
+function contextVector(source, lon, lat, full, matched, language, callback) {
     var tiles = cover.tiles({
         type: 'Point',
         coordinates: [lon,lat]
@@ -168,7 +169,7 @@ function contextVector(source, lon, lat, full, matched, callback) {
                 if (matched[tmpid]) break;
             }
             if (feat) {
-                return loadFeature(source, feat, full, [lon,lat], callback);
+                return loadFeature(source, feat, full, [lon,lat], language, callback);
             // No matching features found.
             } else {
                 return callback(null, false);
@@ -179,7 +180,7 @@ function contextVector(source, lon, lat, full, matched, callback) {
 
 // Load the full feature from geocoding data if needed, otherwise create
 // a light reference with id + text.
-function loadFeature(source, feat, full, query, callback) {
+function loadFeature(source, feat, full, query, language, callback) {
     var dbname = source._geocoder.name;
     var dbidx = source._geocoder.idx;
     if (!full) {
@@ -187,7 +188,7 @@ function loadFeature(source, feat, full, query, callback) {
         loaded.properties['carmen:extid'] = dbname + '.' + feat.id;
         loaded.properties['carmen:tmpid'] = (dbidx*mp25) + termops.feature(feat.id);
         loaded.properties['carmen:dbidx'] = dbidx;
-        loaded.properties['carmen:text'] = feat['carmen:text'] || feat.properties['carmen:text'] || feat.properties.name || feat.properties.search;
+        loaded.properties['carmen:text'] = (language ? feat.properties['carmen:text_'+language] : null) || feat['carmen:text'] || feat.properties['carmen:text'] || feat.properties.name || feat.properties.search;
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -188,7 +188,12 @@ function loadFeature(source, feat, full, query, language, callback) {
         loaded.properties['carmen:extid'] = dbname + '.' + feat.id;
         loaded.properties['carmen:tmpid'] = (dbidx*mp25) + termops.feature(feat.id);
         loaded.properties['carmen:dbidx'] = dbidx;
-        loaded.properties['carmen:text'] = (language ? feat.properties['carmen:text_'+language] : null) || feat['carmen:text'] || feat.properties['carmen:text'] || feat.properties.name || feat.properties.search;
+        loaded.properties['carmen:text'] = (language ? feat['carmen:text_'+language] ||
+                (feat.properties ? feat.properties['carmen:text_'+language]: null) : null)||
+            feat['carmen:text'] ||
+            feat.properties['carmen:text']||
+            feat.properties.name ||
+            feat.properties.search;
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }
 

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -44,7 +44,7 @@ module.exports = function(geocoder, query, options, callback) {
 
     // check that language code is valid
     if (options.language) {
-        options.language = mu.hasLanguage(options.language) ? options.language : false;
+        if (!mu.hasLanguage(options.language)) return callback(errcode('\'' + options.language + '\' is not a valid language code', 'EINVALID'));
     }
 
     // Allows user to search for specific ID

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -8,7 +8,8 @@ var sm = new (require('sphericalmercator'))(),
     queue = require('queue-async'),
     feature = require('./util/feature'),
     Relev = require('./util/relev'),
-    proximity = require('./util/proximity');
+    proximity = require('./util/proximity'),
+    mu = require('model-un');
 var dedupe = require('./util/dedupe');
 var errcode = require('err-code');
 
@@ -39,6 +40,11 @@ module.exports = function(geocoder, query, options, callback) {
             return callback(errcode('Proximity lon value must be a number between -180 and 180', 'EINVALID'));
         if (isNaN(options.proximity[1]) || options.proximity[1] < -90 || options.proximity[1] > 90)
             return callback(errcode('Proximity lat value must be a number between -90 and 90', 'EINVALID'));
+    }
+
+    // check that language code is valid
+    if (options.language) {
+        options.language = mu.hasLanguage(options.language) ? options.language : false;
     }
 
     // Allows user to search for specific ID
@@ -107,7 +113,11 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
                         continue;
                     }
                 }
-                queryData.features.push(ops.toFeature(context, geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder.geocoder_format));
+                var format;
+                var index = geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder;
+                if (options.language) format = index['geocoder_format_' + options.language];
+                if (!format) format = index.geocoder_format;
+                queryData.features.push(ops.toFeature(context, format));
                 context.shift();
             }
         } catch (err) {
@@ -202,7 +212,11 @@ function forwardGeocode(geocoder, query, options, callback) {
             queryData.features = [];
             try {
                 for (var i = 0; i < contexts.length; i++) {
-                    var feature = ops.toFeature(contexts[i], geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder.geocoder_format);
+                    var format;
+                    var index = geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder;
+                    if (options.language) format = index['geocoder_format_' + options.language];
+                    if (!format) format = index.geocoder_format;
+                    var feature = ops.toFeature(contexts[i], format);
                     queryData.features.push(feature);
                 }
             } catch (err) {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -117,7 +117,7 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
                 var index = geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder;
                 if (options.language) format = index['geocoder_format_' + options.language];
                 if (!format) format = index.geocoder_format;
-                queryData.features.push(ops.toFeature(context, format));
+                queryData.features.push(ops.toFeature(context, format, options.language));
                 context.shift();
             }
         } catch (err) {
@@ -216,7 +216,7 @@ function forwardGeocode(geocoder, query, options, callback) {
                     var index = geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder;
                     if (options.language) format = index['geocoder_format_' + options.language];
                     if (!format) format = index.geocoder_format;
-                    var feature = ops.toFeature(contexts[i], format);
+                    var feature = ops.toFeature(contexts[i], format, options.language);
                     queryData.features.push(feature);
                 }
             } catch (err) {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -113,10 +113,9 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
                         continue;
                     }
                 }
-                var format;
+                // use the display template appropriate to the language, if available
                 var index = geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder;
-                if (options.language) format = index['geocoder_format_' + options.language];
-                if (!format) format = index.geocoder_format;
+                var format = (options.language ? index['geocoder_format_' + options.language]: null) || index.geocoder_format;
                 queryData.features.push(ops.toFeature(context, format, options.language));
                 context.shift();
             }
@@ -212,10 +211,9 @@ function forwardGeocode(geocoder, query, options, callback) {
             queryData.features = [];
             try {
                 for (var i = 0; i < contexts.length; i++) {
-                    var format;
+                    // use the display template appropriate to the language, if available
                     var index = geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder;
-                    if (options.language) format = index['geocoder_format_' + options.language];
-                    if (!format) format = index.geocoder_format;
+                    var format = (options.language ? index['geocoder_format_' + options.language] : null) || index.geocoder_format;
                     var feature = ops.toFeature(contexts[i], format, options.language);
                     queryData.features.push(feature);
                 }

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -1,11 +1,12 @@
 // Reformat a context array into a GeoJSON feature.
-module.exports.toFeature = function(context, format) {
+module.exports.toFeature = function(context, format, language) {
     var feat = context[0];
     if (!feat.properties['carmen:center']&& !feat.properties['carmen:legacy']) throw new Error('Feature has no carmen:center');
     if (!feat.properties['carmen:extid'])  throw new Error('Feature has no carmen:extid');
 
     var gettext = function(f) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
+        if (language && f.properties['carmen:text_'+language]) return (f.properties['carmen:text_'+language]||'').split(',')[0];
         return (f.properties['carmen:text']||'').split(',')[0];
     };
     //Use geocoder_format to format output if applicable
@@ -35,7 +36,7 @@ module.exports.toFeature = function(context, format) {
                 if (templateProp == carmenProp) {
                     if (templateSubprop == '_name') {
                         // `name` is a hardcoded subproperty that maps to carmen:text
-                        val = (f.properties['carmen:text']||'').split(',')[0];
+                        val = gettext(f);
                         format = format.replace('{' + templateProp + '._name}',val);
                     } else if (templateSubprop == '_number') {
                         // `address` is a hardcored subproperty that maps to carmen:address

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -6,8 +6,7 @@ module.exports.toFeature = function(context, format, language) {
 
     var gettext = function(f) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
-        if (language && f.properties['carmen:text_'+language]) return (f.properties['carmen:text_'+language]||'').split(',')[0];
-        return (f.properties['carmen:text']||'').split(',')[0];
+        return (f.properties['carmen:text_'+language]||f.properties['carmen:text']||'').split(',')[0];
     };
     //Use geocoder_format to format output if applicable
     if (!format || format === true || format === 1) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -59,7 +59,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         if (err) return callback(err);
         var verified = verifyFeatures(query, geocoder, results, loaded, options);
         verified = verified.slice(0, options.limit_verify);
-        loadContexts(geocoder, verified, sets, callback);
+        loadContexts(geocoder, verified, sets, options.language, callback);
     }
 }
 
@@ -140,20 +140,21 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
     var byText = {};
     for (var i = 0; i < result.length; i++) {
         var feat = result[i];
-        if (feat.properties["carmen:scoredist"] >= 0 || !byText[feat.properties["carmen:text"]]) {
+        var text = options.language && feat.properties["carmen:text_"+options.language] ? feat.properties["carmen:text_"+options.language] : feat.properties["carmen:text"];
+        if (feat.properties["carmen:scoredist"] >= 0 || !byText[text]) {
             filtered.push(feat);
-            byText[feat.properties["carmen:text"]] = true;
+            byText[text] = true;
         }
     }
     return filtered;
 }
 
-function loadContexts(geocoder, features, sets, callback) {
+function loadContexts(geocoder, features, sets, language, callback) {
     var q = queue(5);
     for (var i = 0; i < features.length; i++) q.defer(function(f, done) {
         var name = geocoder.byidx[f.properties["carmen:dbidx"]]._geocoder.name;
         var firstidx = geocoder.byname[name][0]._geocoder.idx;
-        context(geocoder, f.properties["carmen:center"][0], f.properties["carmen:center"][1], { maxidx:firstidx, matched:sets }, function(err, context) {
+        context(geocoder, f.properties["carmen:center"][0], f.properties["carmen:center"][1], { maxidx:firstidx, matched:sets, language: language}, function(err, context) {
             if (err) return done(err);
             // Push feature onto the top level.
             context.unshift(f);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "turf-linestring": "1.0.x",
     "turf-point": "2.0.x",
     "turf-point-on-surface": "1.0.x",
-    "unidecode": "0.1.3"
+    "unidecode": "0.1.3",
+    "model-un": "0.0.3"
   },
   "devDependencies": {
     "retire": "0.4.x",

--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -20,6 +20,7 @@ if (argv.help) {
     console.log('  --proximity="lat,lng"   Favour results by proximity');
     console.log('  --types="{type},..."    Only return results of a given type');
     console.log('  --geojson               Return a geojson object');
+    console.log('  --language={ISO code}   Return responses in specified language (if available in index)');
     console.log('  --stats                 Generate Stats on the query');
     console.log('  --debug="feat id"       Follows a feature through geocode"');
     console.log('  --help                  Print this report');
@@ -55,14 +56,15 @@ if (argv.types) {
     argv.types = argv.types.split(',');
 }
 
-if (argv.debug) argv.debug = parseInt(argv.debug)
+if (argv.debug) argv.debug = parseInt(argv.debug);
 
 var load = +new Date();
-carmen.geocode(argv.query, { 'types': argv.types, 'proximity': argv.proximity, 'debug': argv.debug }, function(err, data) {
+carmen.geocode(argv.query, { 'types': argv.types, 'proximity': argv.proximity, 'debug': argv.debug, 'language': argv.language }, function(err, data) {
     if (err) throw err;
 
     load = +new Date() - load;
-    carmen.geocode(argv.query, { 'types': argv.types, 'proximity': argv.proximity, 'debug': argv.debug, stats:true }, function(err, data) {
+
+    carmen.geocode(argv.query, { 'types': argv.types, 'proximity': argv.proximity, 'debug': argv.debug, stats:true, 'language': argv.language }, function(err, data) {
         if (err) throw err;
         if (data.features.length && !argv.geojson) {
             console.log('Tokens');

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -61,7 +61,7 @@ test('contextVector deflate', function(t) {
             idx: 1
         }
     };
-    context.contextVector(source, -97.4707, 39.4362, false, {}, function(err, data) {
+    context.contextVector(source, -97.4707, 39.4362, false, {}, null, function(err, data) {
         t.ifError(err);
         t.deepEqual(data, {
             properties: {
@@ -94,7 +94,7 @@ test('contextVector gzip', function(t) {
             idx: 1
         }
     };
-    context.contextVector(source, -97.4707, 39.4362, false, {}, function(err, data) {
+    context.contextVector(source, -97.4707, 39.4362, false, {}, null, function(err, data) {
         t.ifError(err);
         t.deepEqual(data, {
             properties: {
@@ -124,7 +124,7 @@ test('contextVector badbuffer', function(t) {
             idx: 0
         }
     };
-    context.contextVector(source, -97.4707, 39.4362, false, {}, function(err, data) {
+    context.contextVector(source, -97.4707, 39.4362, false, {}, null, function(err, data) {
         t.equal(err.toString(), 'Error: Could not detect compression of vector tile');
         t.end();
     });
@@ -154,7 +154,7 @@ test('contextVector empty VT buffer', function(assert) {
                 idx: 0
             }
         };
-        context.contextVector(source, 0, 0, false, {}, function(err, data) {
+        context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
             assert.ifError(err);
             assert.end();
         });
@@ -195,7 +195,7 @@ test('contextVector ignores negative score', function(assert) {
                 idx: 0
             }
         };
-        context.contextVector(source, 0, 0, false, {}, function(err, data) {
+        context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
             assert.ifError(err);
             assert.equal(data.properties['carmen:text'], 'B');
             assert.end();
@@ -232,7 +232,7 @@ test('contextVector only negative score', function(assert) {
                 idx: 0
             }
         };
-        context.contextVector(source, 0, 0, false, {}, function(err, data) {
+        context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
             assert.ifError(err);
             assert.equal(data, false);
             assert.end();
@@ -269,7 +269,7 @@ test('contextVector matched negative score', function(assert) {
                 idx: 0
             }
         };
-        context.contextVector(source, 0, 0, false, { 1:{} }, function(err, data) {
+        context.contextVector(source, 0, 0, false, { 1:{} }, null, function(err, data) {
             assert.ifError(err);
             assert.equal(data.properties['carmen:text'], 'A');
             assert.end();
@@ -313,7 +313,7 @@ test('contextVector restricts distance', function(assert) {
                 idx: 0
             }
         };
-        context.contextVector(source, 170, 80, false, {}, function(err, data) {
+        context.contextVector(source, 170, 80, false, {}, null, function(err, data) {
             assert.ifError(err);
             assert.equal(data, false);
             assert.end();
@@ -370,7 +370,7 @@ test('contextVector restricts distance', function(assert) {
                     idx: 0
                 }
             };
-            context.contextVector(source, 0, 0, false, {}, function(err, data) {
+            context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
                 assert.ifError(err);
                 assert.equal(data.properties['carmen:text'], 'A');
                 assert.end();
@@ -396,7 +396,7 @@ test('contextVector restricts distance', function(assert) {
                     idx: 0
                 }
             };
-            context.contextVector(source, 0, 0, false, {}, function(err, data) {
+            context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
                 assert.ifError(err);
                 assert.equal(data.properties['carmen:text'], 'A');
                 assert.end();
@@ -422,7 +422,7 @@ test('contextVector restricts distance', function(assert) {
                     idx: 0
                 }
             };
-            context.contextVector(source, 0, 0, false, { 2:true }, function(err, data) {
+            context.contextVector(source, 0, 0, false, { 2:true }, null, function(err, data) {
                 assert.ifError(err);
                 assert.equal(data.properties['carmen:text'], 'B');
                 assert.end();
@@ -463,14 +463,14 @@ test('contextVector caching', function(assert) {
         var hit, miss;
         hit = context.getTile.cacheStats.hit;
         miss = context.getTile.cacheStats.miss;
-        context.contextVector(source, 0, 0, false, {}, function(err, data) {
+        context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
             assert.ifError(err);
             assert.equal(data.properties['carmen:extid'], 'test.1');
             assert.equal(context.getTile.cacheStats.hit - hit, 0, 'hits +0');
             assert.equal(context.getTile.cacheStats.miss - miss, 1, 'miss +1');
             hit = context.getTile.cacheStats.hit;
             miss = context.getTile.cacheStats.miss;
-            context.contextVector(source, 0, 0, false, {}, function(err, data) {
+            context.contextVector(source, 0, 0, false, {}, null, function(err, data) {
                 assert.ifError(err);
                 assert.equal(data.properties['carmen:extid'], 'test.1');
                 assert.equal(context.getTile.cacheStats.hit - hit, 1, 'hits +1');

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -48,6 +48,56 @@ var addFeature = require('../lib/util/addfeature');
     });
 })();
 
+// Test geocoder_address formatting with multiple formats by language
+// + return place_name as germany style address (address number follows name)
+(function() {
+    var conf = {
+        address: new mem({maxzoom: 6,  geocoder_address:1,
+            geocoder_format_de: '{address._name} {address._number} {place._name}, {region._name} {postcode._name}, {country._name}',
+            geocoder_format: '{address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, function() {}),
+    };
+    var c = new Carmen(conf);
+    tape('index address', function(t) {
+        var address = {
+            id:1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0],
+                'carmen:addressnumber': ['9','10','7']
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[0,0],[0,0]]
+            }
+        };
+        addFeature(conf.address, address, t.end);
+    });
+
+    tape('Search for germany style address', function(t) {
+        c.geocode('fake street 9', { limit_verify: 1, language: 'de' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'fake street 9');
+            t.end();
+        });
+    });
+
+    tape('Search for us style address, return with german formatting', function(t) {
+        c.geocode('fake street 9', { limit_verify: 1, language: 'de' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'fake street 9');
+            t.end();
+        });
+    });
+
+    tape('Search for us style address, return with us formatting', function(t) {
+        c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '9 fake street');
+            t.end();
+        });
+    });
+})();
+
 //Test geocoder_address formatting for multiple layers
 (function() {
     var conf = {

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -96,6 +96,14 @@ var addFeature = require('../lib/util/addfeature');
             t.end();
         });
     });
+
+    tape('Bad language code', function(t) {
+        c.geocode('9 fake street', { limit_verify: 1, language: 'zh' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '9 fake street');
+            t.end();
+        });
+    });
 })();
 
 //Test geocoder_address formatting for multiple layers

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -1,0 +1,110 @@
+//Ensure that results that have equal relev in phrasematch
+//are matched against the 0.5 relev bar instead of 0.75
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    country: new mem({ maxzoom:6 }, function() {})
+};
+var c = new Carmen(conf);
+
+tape('index country', function(t) {
+    var country = {
+        type: 'Feature',
+        properties: {
+            'carmen:center': [ 0, 0 ],
+            'carmen:zxy': [ '6/30/30' ],
+            'carmen:text': 'Russian Federation, Rossiyskaya Federatsiya',
+            'carmen:text_ru': 'Российская Федерация',
+            'carmen:text_zh_Latn': 'Elousi',
+            'carmen:text_fake': 'beetlejuice',
+            'carmen:text_es': null
+        },
+        id: 2,
+        geometry: { type: 'MultiPolygon', coordinates: [] },
+        bbox: [ -11.25, 5.615, -5.625, 11.1784 ]
+    };
+    addFeature(conf.country, country, t.end);
+});
+
+tape('russia => Russian Federation', function(t) {
+    c.geocode('russia', { limit_verify:1 }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+tape('Rossiyskaya => Russian Federation', function(t) {
+    c.geocode('Rossiyskaya', { limit_verify:1 }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+tape('Rossiyskaya => Российская Федерация - {language: "ru"}', function(t) {
+    c.geocode('Rossiyskaya', { limit_verify:1, language: 'ru' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Российская Федерация');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+// 'fake' is not a valid language code
+tape('Rossiyskaya => Russian Federation - {language: "fake"}', function(t) {
+    c.geocode('Rossiyskaya', { limit_verify:1, language: 'fake' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+// no value for 'es'
+tape('Rossiyskaya => Russian Federation - {language: "es"}', function(t) {
+    c.geocode('Rossiyskaya', { limit_verify:1, language: 'es' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+// no value for 'en'
+tape('Rossiyskaya => Russian Federation - {language: "en"}', function(t) {
+    c.geocode('Rossiyskaya', { limit_verify:1, language: 'en' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.end();
+    });
+});
+
+//Is not above 0.5 relev so should fail.
+tape('fake blah blah => [fail]', function(t) {
+    c.geocode('fake blah blah', { limit_verify:1 }, function(err, res) {
+        t.ifError(err);
+        t.notOk(res.features[0]);
+        t.end();
+    });
+});
+
+tape('index.teardown', function(assert) {
+    index.teardown();
+    assert.end();
+});

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -10,6 +10,7 @@ var addFeature = require('../lib/util/addfeature');
 
 var conf = {
     country: new mem({ maxzoom:6 }, function() {}),
+    region: new mem({ maxzoom: 6, geocoder_format_ru: '{country._name}, {region._name}'}, function() {}),
     place: new mem({ maxzoom:6 }, function() {})
 };
 var c = new Carmen(conf);
@@ -132,6 +133,38 @@ tape('St Petersberg => Saint Petersburg - {language: "fr"}', function(t) {
         t.deepEqual(res.features[0].place_name, 'Saint Petersburg, Russian Federation');
         t.deepEqual(res.features[0].id, 'place.1');
         t.deepEqual(res.features[0].context[0].text, 'Russian Federation');
+        t.end();
+    });
+});
+
+tape('index region', function(t) {
+    var region = {
+        type: 'Feature',
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:zxy': ['6/32/32'],
+            'carmen:text_ru': 'Северо-Западный федеральный округ',
+            'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug'
+        },
+        id: 1,
+        geometry: {
+            type: 'MultiPolygon',
+            coordinates: [
+                [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+            ]
+        },
+        bbox: [0,-5.615985819155337,5.625,0]
+    };
+    addFeature(conf.region, region, t.end);
+});
+
+// custom response format template
+tape('Northwestern Federal Distrct => Российская Федерация, Северо-Западный федеральный округ - {language: "ru"}', function(t) {
+    c.geocode('Northwestern', { limit_verify:1, language: 'ru' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Российская Федерация, Северо-Западный федеральный округ');
+        t.deepEqual(res.features[0].id, 'region.1');
+        t.deepEqual(res.features[0].context[0].text, 'Российская Федерация');
         t.end();
     });
 });


### PR DESCRIPTION
Adds the ability to pass a language flag (an iso language code verified by [model-un](http://github.com/mapbox/model-un)) to Carmen.

https://github.com/mapbox/carmen/pull/319 paves the way for queries in local languages, this opens up returning a response in a specified language when available in the index. Defaults to whatever is in `carmen:text`.

Also supports custom templates in indices by language, e.g. `"geocoder_format_zh": "{country._name}{region._name}"`

to do:
* [x] test for context values