### PR TITLE
Appropriate localization templating

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -194,6 +194,8 @@ function loadFeature(source, feat, full, query, language, callback) {
             feat.properties['carmen:text']||
             feat.properties.name ||
             feat.properties.search;
+        if (language && (feat['carmen:text_'+language] ||
+            (feat.properties && feat.properties['carmen:text_'+language]))) loaded.properties.language = language;
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }
 

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -115,8 +115,9 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
                 }
                 // use the display template appropriate to the language, if available
                 var index = geocoder.byidx[context[0].properties['carmen:dbidx']]._geocoder;
-                var format = (options.language ? index['geocoder_format_' + options.language]: null) || index.geocoder_format;
-                queryData.features.push(ops.toFeature(context, format, options.language));
+                var formats = { default: index.geocoder_format };
+                if (options.language) formats[options.language] = index['geocoder_format_' + options.language];
+                queryData.features.push(ops.toFeature(context, formats, options.language));
                 context.shift();
             }
         } catch (err) {
@@ -213,8 +214,9 @@ function forwardGeocode(geocoder, query, options, callback) {
                 for (var i = 0; i < contexts.length; i++) {
                     // use the display template appropriate to the language, if available
                     var index = geocoder.byidx[contexts[i][0].properties['carmen:dbidx']]._geocoder;
-                    var format = (options.language ? index['geocoder_format_' + options.language] : null) || index.geocoder_format;
-                    var feature = ops.toFeature(contexts[i], format, options.language);
+                    var formats = { default: index.geocoder_format };
+                    if (options.language) formats[options.language] = index['geocoder_format_' + options.language];
+                    var feature = ops.toFeature(contexts[i], formats, options.language);
                     queryData.features.push(feature);
                 }
             } catch (err) {

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -4,6 +4,19 @@ module.exports.toFeature = function(context, format, language) {
     if (!feat.properties['carmen:center']&& !feat.properties['carmen:legacy']) throw new Error('Feature has no carmen:center');
     if (!feat.properties['carmen:extid'])  throw new Error('Feature has no carmen:extid');
 
+    // check for whether or not there are any parts of the response in the queried language.
+    // if not, use the default templating rather than the one appropriate to the queried language.
+    if (language && format[language]) {
+        for (var x = 0; x < context.length; x++) {
+            if (context[x].properties['carmen:text_'+language] ||
+                context[x].properties.language === language) {
+                format = format[language];
+                break;
+            }
+        }
+    }
+    if (typeof format === 'object') format = format['default'];
+
     var gettext = function(f) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
         return (f.properties['carmen:text_'+language]||f.properties['carmen:text']||'').split(',')[0];

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -73,18 +73,18 @@ var addFeature = require('../lib/util/addfeature');
         addFeature(conf.address, address, t.end);
     });
 
-    tape('Search for germany style address', function(t) {
+    tape('Search for germany style address - with language tag but no german vaue', function(t) {
         c.geocode('fake street 9', { limit_verify: 1, language: 'de' }, function(err, res) {
             t.ifError(err);
-            t.equals(res.features[0].place_name, 'fake street 9');
+            t.equals(res.features[0].place_name, '9 fake street');
             t.end();
         });
     });
 
-    tape('Search for us style address, return with german formatting', function(t) {
+    tape('Search for us style address, return with german formatting --  with language tag but no german vaue', function(t) {
         c.geocode('fake street 9', { limit_verify: 1, language: 'de' }, function(err, res) {
             t.ifError(err);
-            t.equals(res.features[0].place_name, 'fake street 9');
+            t.equals(res.features[0].place_name, '9 fake street');
             t.end();
         });
     });

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -9,9 +9,10 @@ var queue = require('queue-async');
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {
-    country: new mem({ maxzoom:6 }, function() {}),
-    region: new mem({ maxzoom: 6, geocoder_format_ru: '{country._name}, {region._name}'}, function() {}),
-    place: new mem({ maxzoom:6 }, function() {})
+    country: new mem({ maxzoom:6, geocoder_name: 'country' }, function() {}),
+    region: new mem({ maxzoom: 6, geocoder_name: 'region', geocoder_format_ru: '{country._name}, {region._name}', geocoder_format_zh: '{country._name}{region._name}'}, function() {}),
+    place: new mem({ maxzoom:6, geocoder_name: 'place' }, function() {}),
+    place2: new mem({ maxzoom:6, geocoder_name: 'place', geocoder_format_zh: '{country._name}{region._name}{place._name}' }, function() {})
 };
 var c = new Carmen(conf);
 
@@ -143,6 +144,7 @@ tape('index region', function(t) {
         properties: {
             'carmen:center': [0,0],
             'carmen:zxy': ['6/32/32'],
+            'carmen:text_zh': '西北部联邦管区',
             'carmen:text_ru': 'Северо-Западный федеральный округ',
             'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug'
         },
@@ -165,6 +167,57 @@ tape('Northwestern Federal Distrct => Российская Федерация, �
         t.deepEqual(res.features[0].place_name, 'Российская Федерация, Северо-Западный федеральный округ');
         t.deepEqual(res.features[0].id, 'region.1');
         t.deepEqual(res.features[0].context[0].text, 'Российская Федерация');
+        t.end();
+    });
+});
+
+tape('index place2', function(t) {
+    var place = {
+        type: 'Feature',
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:zxy': ['6/31/31'],
+            'carmen:text': 'Shenzhen',
+            'carmen:text_zh': '深圳市'
+        },
+        id: 2,
+        geometry: {
+            type: 'MultiPolygon',
+            coordinates: [
+                [[[-5.625,0],[-5.625,5.615985819155337],[0,5.615985819155337],[0,0],[-5.625,0]]]
+            ]
+        },
+        bbox: [-5.625,0,0,5.615985819155337]
+    };
+    addFeature(conf.place2, place, t.end);
+});
+
+tape('西北部联邦管区 => Russian Federation西北部联邦管区', function(t) {
+    c.geocode('西北部联邦管区', { limit_verify:1, language: 'zh' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation西北部联邦管区');
+        t.deepEqual(res.features[0].id, 'region.1');
+        t.deepEqual(res.features[0].context[0].text, 'Russian Federation');
+        t.end();
+    });
+});
+
+tape('Shenzhen => Shenzhen, Northwestern Federal District, Russian Federation', function(t) {
+    c.geocode('Shenzhen', { limit_verify:1, language: 'en' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Shenzhen, Northwestern Federal District, Russian Federation');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.deepEqual(res.features[0].context[0].text, 'Northwestern Federal District');
+        t.end();
+    });
+});
+
+tape('Shenzhen => Russian Federation西北部联邦管区深圳市', function(t) {
+    c.geocode('Shenzhen', { limit_verify:1, language: 'zh' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation西北部联邦管区深圳市');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.deepEqual(res.features[0].context[0].text, '西北部联邦管区');
         t.end();
     });
 });

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -15,7 +15,7 @@ var conf = {
         geocoder_format_zh: '{country._name}{region._name}',
         geocoder_format_es: '{region._name} {region._name} {country._name}'
     }, function() {}),
-    place: new mem({ maxzoom:6, geocoder_name: 'place' }, function() {}),
+    place: new mem({ maxzoom:6, geocoder_name: 'place', geocoder_format_eo: '{country._name} {place._name} {region._name}' }, function() {}),
     place2: new mem({ maxzoom:6, geocoder_name: 'place', geocoder_format_zh: '{country._name}{region._name}{place._name}' }, function() {})
 };
 var c = new Carmen(conf);
@@ -150,7 +150,8 @@ tape('index region', function(t) {
             'carmen:zxy': ['6/32/32'],
             'carmen:text_zh': '西北部联邦管区',
             'carmen:text_ru': 'Северо-Западный федеральный округ',
-            'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug'
+            'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug',
+            'carmen:text_eo': '!!!!'
         },
         id: 1,
         geometry: {
@@ -180,11 +181,22 @@ tape('Northwestern Federal Distrct => Российская Федерация, �
 tape('Northwestern Federal Distrct => Российская Федерация, Северо-Западный федеральный округ - {language: "ru"}', function(t) {
     c.geocode('Northwestern', { limit_verify:1, language: 'es' }, function(err, res) {
         t.ifError(err);
-        console.log(res)
-
         t.deepEqual(res.features[0].place_name, 'Northwestern Federal District, Russian Federation');
         t.deepEqual(res.features[0].id, 'region.1');
         t.deepEqual(res.features[0].context[0].text, 'Russian Federation');
+        t.end();
+    });
+});
+
+// if the first response does not have values in the language queried,
+// but does have a template for that language, and there is a value in that language
+// in the context, use the localized template.
+tape('Northwestern Federal Distrct => Российская Федерация, Северо-Западный федеральный округ - {language: "ru"}', function(t) {
+    c.geocode('Saint Petersburg', { limit_verify:1, language: 'eo' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation Saint Petersburg !!!!');
+        t.deepEqual(res.features[0].id, 'place.1');
+        t.deepEqual(res.features[0].context[0].text, '!!!!');
         t.end();
     });
 });

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -10,7 +10,11 @@ var addFeature = require('../lib/util/addfeature');
 
 var conf = {
     country: new mem({ maxzoom:6, geocoder_name: 'country' }, function() {}),
-    region: new mem({ maxzoom: 6, geocoder_name: 'region', geocoder_format_ru: '{country._name}, {region._name}', geocoder_format_zh: '{country._name}{region._name}'}, function() {}),
+    region: new mem({ maxzoom: 6, geocoder_name: 'region',
+        geocoder_format_ru: '{country._name}, {region._name}',
+        geocoder_format_zh: '{country._name}{region._name}',
+        geocoder_format_es: '{region._name} {region._name} {country._name}'
+    }, function() {}),
     place: new mem({ maxzoom:6, geocoder_name: 'place' }, function() {}),
     place2: new mem({ maxzoom:6, geocoder_name: 'place', geocoder_format_zh: '{country._name}{region._name}{place._name}' }, function() {})
 };
@@ -171,6 +175,20 @@ tape('Northwestern Federal Distrct => Российская Федерация, �
     });
 });
 
+// if the response and the context do not have values in the language queried,
+// but do have a template for that language, use the default template.
+tape('Northwestern Federal Distrct => Российская Федерация, Северо-Западный федеральный округ - {language: "ru"}', function(t) {
+    c.geocode('Northwestern', { limit_verify:1, language: 'es' }, function(err, res) {
+        t.ifError(err);
+        console.log(res)
+
+        t.deepEqual(res.features[0].place_name, 'Northwestern Federal District, Russian Federation');
+        t.deepEqual(res.features[0].id, 'region.1');
+        t.deepEqual(res.features[0].context[0].text, 'Russian Federation');
+        t.end();
+    });
+});
+
 tape('index place2', function(t) {
     var place = {
         type: 'Feature',
@@ -217,6 +235,40 @@ tape('Shenzhen => Russian Federation西北部联邦管区深圳市', function(t)
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Russian Federation西北部联邦管区深圳市');
         t.deepEqual(res.features[0].id, 'place.2');
+        t.deepEqual(res.features[0].context[0].text, '西北部联邦管区');
+        t.end();
+    });
+});
+
+tape('0,0 => Saint Petersburg, Northwestern Federal District, Russian Federation', function(t) {
+    c.geocode('0,0', { limit_verify:1, language: 'en' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Saint Petersburg, Northwestern Federal District, Russian Federation');
+        t.deepEqual(res.features[0].id, 'place.1');
+        t.deepEqual(res.features[0].context[0].text, 'Northwestern Federal District');
+        t.end();
+    });
+});
+
+// if the most granular result (St Petersburg) doesn't have a template for the language,
+// use the default. Templates can go from specific -> general but not the other way around.
+tape('0,0 => Saint Petersburg, 西北部联邦管区, Russian Federation - {language: "zh"}', function(t) {
+    c.geocode('0,0', { limit_verify:1, language: 'zh' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Saint Petersburg, 西北部联邦管区, Russian Federation');
+        t.deepEqual(res.features[0].id, 'place.1');
+        t.deepEqual(res.features[0].context[0].text, '西北部联邦管区');
+        t.end();
+    });
+});
+
+// if the most granular result (St Petersburg) doesn't have a template for the language,
+// use the default. Templates can go from specific -> general but not the other way around.
+tape('Saint Petersburg => Saint Petersburg, 西北部联邦管区, Russian Federation - {language: "zh"}', function(t) {
+    c.geocode('Saint Petersburg', { limit_verify:1, language: 'zh' }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Saint Petersburg, 西北部联邦管区, Russian Federation');
+        t.deepEqual(res.features[0].id, 'place.1');
         t.deepEqual(res.features[0].context[0].text, '西北部联邦管区');
         t.end();
     });


### PR DESCRIPTION
only use the localization template when there are response elements in that language.

This PR acknowledges some odd edge cases that might be encountered now that true localization is supported:

1. Indices with a local template, but no corresponding localized text for the response feature, or any feature in the response context.

    _Will return the default text with the default template as `place_name`._
2. Indices with a local template, but no corresponding localized text for the response feature, but has a context item with localized text.

    _Will return `place_name` formatted with localized template with either default or localized text as available._
3. Indices without a local template for the most specific response feature, but localized text/localized templates for context features.

    _If the localized template is not available to the most specific response feature, default template will be used. Localized text will be prioritized as available. e.g. it could look like `place_name: Beijing, 中国`_

* [x] reverse geocoder tests
* [x] flesh out this pr comment