### PR TITLE
Dumber faster

### DIFF
--- a/bench/dictcache.js
+++ b/bench/dictcache.js
@@ -1,0 +1,37 @@
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+var Dictcache = require('../lib/util/dictcache');
+var encodePhrase = require('../lib/util/termops').encodePhrase;
+
+var hashes = [];
+var dict = new Dictcache();
+// fuzz test
+for (var i = 0; i < 10000; i++) {
+    hashes.push(encodePhrase([Math.random().toString()]));
+}
+
+module.exports = benchmark;
+
+function benchmark(cb) {
+    if (!cb) cb = function(){};
+    console.log('# dictcache.Dictcache');
+
+    suite.add('Dictcache', function() {
+        for (var i = 0; i < hashes.length; i++) {
+            var id = hashes[i];
+            dict.has(id);
+            dict.set(id);
+            dict.del(id);
+        }
+    })
+    .on('cycle', function(event) {
+        console.log(String(event.target));
+    })
+    .on('complete', function() {
+      console.log('Fastest is ' + this.filter('fastest').pluck('name'), '\n');
+      cb(null, suite);
+    })
+    .run();
+}
+
+if (!process.env.runSuite) benchmark();

--- a/lib/util/dictcache.js
+++ b/lib/util/dictcache.js
@@ -1,8 +1,5 @@
 module.exports = Dictcache;
 
-var masks = {};
-for (var i = 0; i < 8; i++) masks[i] = Math.pow(2,i);
-
 function Dictcache(buffer) {
     if (buffer) {
         if (buffer.length !== Dictcache.size/8) throw new Error('Dictcache buffer must have length ' + (Dictcache.size/8))
@@ -15,26 +12,30 @@ function Dictcache(buffer) {
 }
 
 Dictcache.size = Math.pow(2,24);
+Dictcache.sizeMinus1 = Dictcache.size - 1;
 
 Dictcache.prototype.dump = function() {
     return this.cache;
 };
 
+// Note: (1 << (id & 7)) == Math.pow(2, id % 8)
+// and id & Dictcache.sizeMinus1 == id % Dictcache.size
+
 Dictcache.prototype.set = function(id, val) {
-    id = id % Dictcache.size;
-    var byte = Math.floor(id/8);
-    this.cache[byte] = this.cache[byte] | masks[id%8];
+    id = id & Dictcache.sizeMinus1;
+    var byte = id >> 3;
+    this.cache[byte] = this.cache[byte] | (1 << (id & 7));
 };
 
 Dictcache.prototype.del = function(id) {
-    id = id % Dictcache.size;
-    var byte = Math.floor(id/8);
-    this.cache[byte] = this.cache[byte] ^ masks[id%8];
+    id = id & Dictcache.sizeMinus1;
+    var byte = id >> 3;
+    this.cache[byte] = this.cache[byte] ^ (1 << (id & 7));
 };
 
 Dictcache.prototype.has = function(id) {
-    id = id % Dictcache.size;
-    var byte = Math.floor(id/8);
-    return Boolean(this.cache[byte] & masks[id%8]);
+    id = id & Dictcache.sizeMinus1;
+    var byte = id >> 3;
+    return Boolean(this.cache[byte] & (1 << (id & 7)));
 };
 


### PR DESCRIPTION
Bench comparison:

# on dumber
dictcache.Dictcache
Dictcache x 777 ops/sec ±3.89% (82 runs sampled)

# on dumber-faster
dictcache.Dictcache
Dictcache x 1,629 ops/sec ±4.39% (82 runs sampled)