### PR TITLE
Autodetect dictcache bitsize from buffer length

### DIFF
--- a/lib/util/dictcache.js
+++ b/lib/util/dictcache.js
@@ -3,10 +3,15 @@ var sizes = {
     28: Math.pow(2,28)
 };
 
+// For backwards lookup from bufferSize to bitSize
+var bufferSizes = {};
+bufferSizes[sizes[24]/8] = 24;
+bufferSizes[sizes[28]/8] = 28;
+
 module.exports = Dictcache;
 
 function Dictcache(buffer, bitSize) {
-    bitSize = bitSize || 24;
+    bitSize = bitSize || (buffer && bufferSizes[buffer.length]) || 24;
     if (!sizes[bitSize]) throw new Error('Dictcache bitSize must be one of: ' + Object.keys(sizes).join(', '));
 
     this.size = sizes[bitSize];

--- a/test/dictcache.test.js
+++ b/test/dictcache.test.js
@@ -29,11 +29,6 @@ tape('create (2 MiB buffer)', function(assert) {
     var dict = new Dictcache(new Buffer(2097152));
     assert.equal(dict.cache.length, 2097152, 'created 2MiB cache');
     assert.equal(dict.size, Math.pow(2,24), 'created 24 bitsize cache');
-    for (var i = 0; i < 2097152; i++) {
-        if (dict.cache[i] !== 0) {
-            assert.fail('buffer filled with 0s');
-        }
-    }
     assert.end();
 });
 
@@ -41,11 +36,6 @@ tape('create (32 MiB buffer)', function(assert) {
     var dict = new Dictcache(new Buffer(33554432));
     assert.equal(dict.cache.length, 33554432, 'created 32MiB cache');
     assert.equal(dict.size, Math.pow(2,28), 'created 28 bitsize cache');
-    for (var i = 0; i < 33554432; i++) {
-        if (dict.cache[i] !== 0) {
-            assert.fail('buffer filled with 0s');
-        }
-    }
     assert.end();
 });
 
@@ -133,9 +123,9 @@ tape('set/has/del', function(assert) {
     var count = 0;
     for (var i = 0; i < 10000; i++) {
         var id = encodePhrase([Math.random().toString()]);
-        if (used[id%Dictcache.size]) continue;
+        if (used[id%dict.size]) continue;
         count++;
-        used[id%Dictcache.size] = true;
+        used[id%dict.size] = true;
         if (dict.has(id) !== false) assert.fail('fuzz test pre has(): ' + id)
         if (dict.set(id) !== undefined) assert.fail('fuzz test set(): ' + id)
         if (dict.has(id) !== true) assert.fail('fuzz test post has(): ' + id)

--- a/test/dictcache.test.js
+++ b/test/dictcache.test.js
@@ -25,6 +25,30 @@ tape('create (28 bit)', function(assert) {
     assert.end();
 });
 
+tape('create (2 MiB buffer)', function(assert) {
+    var dict = new Dictcache(new Buffer(2097152));
+    assert.equal(dict.cache.length, 2097152, 'created 2MiB cache');
+    assert.equal(dict.size, Math.pow(2,24), 'created 24 bitsize cache');
+    for (var i = 0; i < 2097152; i++) {
+        if (dict.cache[i] !== 0) {
+            assert.fail('buffer filled with 0s');
+        }
+    }
+    assert.end();
+});
+
+tape('create (32 MiB buffer)', function(assert) {
+    var dict = new Dictcache(new Buffer(33554432));
+    assert.equal(dict.cache.length, 33554432, 'created 32MiB cache');
+    assert.equal(dict.size, Math.pow(2,28), 'created 28 bitsize cache');
+    for (var i = 0; i < 33554432; i++) {
+        if (dict.cache[i] !== 0) {
+            assert.fail('buffer filled with 0s');
+        }
+    }
+    assert.end();
+});
+
 tape('create (err: size)', function(assert) {
     assert.throws(function() {
         var dict = new Dictcache(null, 20);


### PR DESCRIPTION
When not specified, autodetect it. Smooths out some operations!