### PR TITLE
Simplify/robustify how context handles center, text properties

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -213,26 +213,25 @@ function loadFeature(source, feat, full, query, language, callback) {
     var dbidx = source._geocoder.idx;
     var dbtype = source._geocoder.type;
     if (!full) {
+        var properties = feat.properties || feat;
         var loaded = { properties: {} };
         loaded.properties['carmen:extid'] = dbtype + '.' + feat.id;
         loaded.properties['carmen:tmpid'] = (dbidx*mp25) + termops.feature(feat.id);
         loaded.properties['carmen:dbidx'] = dbidx;
         loaded.properties['carmen:vtquerydist'] = feat['carmen:vtquerydist'];
         loaded.properties['carmen:geomtype'] = feat['carmen:geomtype'];
-        if (feat['carmen:center']) {
-            loaded.properties['carmen:center'] = JSON.parse(feat['carmen:center']);
-        } else if (feat.properties && feat.properties['carmen:center']) {
-            var coords = feat.properties['carmen:center'].split(',');
+        if (properties['carmen:center']) {
+            var coords = properties['carmen:center'][0] === '[' ?
+                JSON.parse(properties['carmen:center']) :
+                properties['carmen:center'].split(',');
             loaded.properties['carmen:center'] = [parseFloat(coords[0]), parseFloat(coords[1])];
         }
-        loaded.properties['carmen:text'] = (language ? feat['carmen:text_'+language] ||
-                (feat.properties ? feat.properties['carmen:text_'+language]: null) : null)||
-            feat['carmen:text'] ||
-            feat.properties['carmen:text']||
-            feat.properties.name ||
-            feat.properties.search;
-        if (language && (feat['carmen:text_'+language] ||
-            (feat.properties && feat.properties['carmen:text_'+language]))) loaded.properties.language = language;
+        if (language && properties['carmen:text_'+language]) {
+            loaded.properties['carmen:text'] = properties['carmen:text_'+language];
+            loaded.properties.language = language;
+        } else {
+            loaded.properties['carmen:text'] = properties['carmen:text'] || properties.name || properties.search;
+        }
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }
     feature.getFeatureById(source, feat.id, function(err, loaded) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -221,6 +221,8 @@ function loadFeature(source, feat, full, query, language, callback) {
         loaded.properties['carmen:vtquerydist'] = feat['carmen:vtquerydist'];
         loaded.properties['carmen:geomtype'] = feat['carmen:geomtype'];
         if (properties['carmen:center']) {
+            // Attempt to detect "lon,lat" or "[lon,lat]" -- some VT encoders
+            // treat array properties differently when encoding.
             var coords = properties['carmen:center'][0] === '[' ?
                 JSON.parse(properties['carmen:center']) :
                 properties['carmen:center'].split(',');


### PR DESCRIPTION
And add a little logic to handle center attributes from VT encoders that JSON-encode arrays.

- [x] tests pass
- [x] IRL testing