### PR TITLE
Remove deprecated text properties from context

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -232,7 +232,7 @@ function loadFeature(source, feat, full, query, language, callback) {
             loaded.properties['carmen:text'] = properties['carmen:text_'+language];
             loaded.properties.language = language;
         } else {
-            loaded.properties['carmen:text'] = properties['carmen:text'] || properties.name || properties.search;
+            loaded.properties['carmen:text'] = properties['carmen:text'];
         }
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }


### PR DESCRIPTION
Will merge when tests pass.

cc @ingalls 