### PR TITLE
expose non-carmen properties in context array

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -234,6 +234,15 @@ function loadFeature(source, feat, full, query, language, callback) {
         } else {
             loaded.properties['carmen:text'] = properties['carmen:text'];
         }
+
+        // copy non-carmen:* properties
+        var propertyKeys = Object.keys(properties);
+        for (var propi = 0; propi < propertyKeys.length; propi++) {
+            if (!/^carmen:/.test(propertyKeys[propi])) {
+                loaded.properties[propertyKeys[propi]] = properties[propertyKeys[propi]];
+            }
+        }
+
         return callback(null, loaded.properties['carmen:text'] ? loaded : false);
     }
     feature.getFeatureById(source, feat.id, function(err, loaded) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -238,7 +238,7 @@ function loadFeature(source, feat, full, query, language, callback) {
         // copy non-carmen:* properties
         var propertyKeys = Object.keys(properties);
         for (var propi = 0; propi < propertyKeys.length; propi++) {
-            if (!/^carmen:/.test(propertyKeys[propi])) {
+            if (!/^(carmen:|id)/.test(propertyKeys[propi])) {
                 loaded.properties[propertyKeys[propi]] = properties[propertyKeys[propi]];
             }
         }

--- a/lib/context.js
+++ b/lib/context.js
@@ -238,7 +238,7 @@ function loadFeature(source, feat, full, query, language, callback) {
         // copy non-carmen:* properties
         var propertyKeys = Object.keys(properties);
         for (var propi = 0; propi < propertyKeys.length; propi++) {
-            if (!/^(carmen:|id)/.test(propertyKeys[propi])) {
+            if (!/^(carmen:|id$)/.test(propertyKeys[propi])) {
                 loaded.properties[propertyKeys[propi]] = properties[propertyKeys[propi]];
             }
         }

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -107,13 +107,17 @@ module.exports.toFeature = function(context, format, language) {
         feature.context = [];
         for (var i = 1; i < context.length; i++) {
             if (!context[i].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
-            var feat = {
+            var contextFeat = {
                 id: context[i].properties['carmen:extid'],
                 text: gettext(context[i])
             };
-            if ((feat.id.split('.')[0] === 'country') && (context[i].properties.iso3166))
-                feat.iso3166 = context[i].properties.iso3166;
-            feature.context.push(feat);
+
+            // copy over all non-'carmen:*' properties
+            var propertyKeys = Object.keys(context[i].properties).filter(function(prop) { return !/carmen:/.test(prop); });
+            for(var j = 0; j < propertyKeys.length; j++)
+                contextFeat[propertyKeys] = context[i].properties[propertyKeys];
+
+            feature.context.push(contextFeat);
         }
     }
 

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -107,10 +107,13 @@ module.exports.toFeature = function(context, format, language) {
         feature.context = [];
         for (var i = 1; i < context.length; i++) {
             if (!context[i].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
-            feature.context.push({
+            var feat = {
                 id: context[i].properties['carmen:extid'],
                 text: gettext(context[i])
-            });
+            };
+            if ((feat.id.split('.')[0] === 'country') && (context[i].properties.iso3166))
+                feat.iso3166 = context[i].properties.iso3166;
+            feature.context.push(feat);
         }
     }
 

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -114,7 +114,7 @@ module.exports.toFeature = function(context, format, language) {
 
             // copy over all non-'carmen:*' properties
             var propertyKeys = Object.keys(context[i].properties).filter(function(prop) { return !/carmen:/.test(prop); });
-            for(var j = 0; j < propertyKeys.length; j++)
+            for (var j = 0; j < propertyKeys.length; j++)
                 contextFeat[propertyKeys] = context[i].properties[propertyKeys];
 
             feature.context.push(contextFeat);

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -113,7 +113,7 @@ module.exports.toFeature = function(context, format, language) {
             };
 
             // copy over all non-'carmen:*' properties
-            var propertyKeys = Object.keys(context[i].properties).filter(function(prop) { return !/carmen:/.test(prop); });
+            var propertyKeys = Object.keys(context[i].properties).filter(function(prop) { return !/^carmen:/.test(prop); });
             for (var j = 0; j < propertyKeys.length; j++)
                 contextFeat[propertyKeys] = context[i].properties[propertyKeys];
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "8.6.0-contextprops-2",
+  "version": "8.6.0-contextprops-3",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "8.5.4",
+  "version": "8.5.4-iso3166",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "8.6.0-contextprops",
+  "version": "8.6.0-contextprops-2",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "8.5.4-iso3166",
+  "version": "8.5.4-contextprops",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -72,7 +72,10 @@ test('contextVector deflate', function(t) {
                 'carmen:vtquerydist': 0,
                 'carmen:geomtype': 'Polygon',
                 'carmen:tmpid': Math.pow(2,25) + 5,
-                'carmen:text': 'United States of America, United States, America, USA, US'
+                'carmen:text': 'United States of America, United States, America, USA, US',
+                'iso2': 'US',
+                'population': 307212123,
+                'title': 'United States of America'
             }
         });
         t.end();
@@ -109,7 +112,10 @@ test('contextVector gzip', function(t) {
                 'carmen:tmpid': Math.pow(2,25) + 5,
                 'carmen:vtquerydist': 0,
                 'carmen:geomtype': 'Polygon',
-                'carmen:text': 'United States of America, United States, America, USA, US'
+                'carmen:text': 'United States of America, United States, America, USA, US',
+                'iso2': 'US',
+                'population': 307212123,
+                'title': 'United States of America'
             }
         });
         t.end();

--- a/test/fixtures/context-vt-light.json
+++ b/test/fixtures/context-vt-light.json
@@ -10,7 +10,9 @@
                 -0.751446,
                 39.311412
             ],
-            "carmen:text": "Comunidad Valenciana,VC"
+            "carmen:text": "Comunidad Valenciana,VC",
+            "title": "Comunidad Valenciana",
+            "area": 23043674283
         }
     },
     {
@@ -24,7 +26,10 @@
                 -3.47836,
                 39.909167
             ],
-            "carmen:text": "Spain"
+            "carmen:text": "Spain",
+            "title": "Spain",
+            "population": 40525002,
+            "iso2": "ES"
         }
     }
 ]

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -7,7 +7,8 @@ test('ops#toFeature', function(t) {
             "carmen:center": [-99.392855, 63.004759],
             "carmen:text": "Canada, CA",
             "carmen:extid": "country.1833980151",
-            "carmen:relevance": 1
+            "carmen:relevance": 1,
+            "iso3166": "ca"
         }
     }]), {
         id: 'country.1833980151',
@@ -16,8 +17,8 @@ test('ops#toFeature', function(t) {
         place_name: 'Canada',
         relevance: undefined,
         center: [ -99.392855, 63.004759 ],
+        properties: { iso3166: "ca" },
         geometry: { type: 'Point', coordinates: [ -99.392855, 63.004759 ] },
-        properties: {}
     });
 
     //Test Address formatting
@@ -40,7 +41,7 @@ test('ops#toFeature', function(t) {
             "carmen:relevance": 1
         }
     }], "{address._number} {address._name}").place_name, '9 Fake Street', 'Address number & name exist');
-    
+
     t.deepEqual(ops.toFeature([{
         properties: {
             "carmen:center": [-99.392855,63.004759],
@@ -91,8 +92,8 @@ test('ops#toFeature', function(t) {
             "carmen:extid": "place.1"
         }
     }], "{address._number} {address._name}, {place.name}").place_name, '9 Fake Street', 'Address & no Place');
-    
-    
+
+
     t.deepEqual(ops.toFeature([{
         properties: {
             "carmen:center": [-99.392855,63.004759],
@@ -108,8 +109,8 @@ test('ops#toFeature', function(t) {
             "carmen:extid": "place.1"
         }
     }], "{address._number} {address.name}, {place._name}").place_name, '9, Andor', 'No Address street & Place');
-    
-    
+
+
     t.deepEqual(ops.toFeature([{
         properties: {
             "carmen:center": [-99.392855,63.004759],
@@ -151,11 +152,18 @@ test('ops#toFeature', function(t) {
             "carmen:text": "1234",
             "carmen:extid": "postcode.1"
         }
-    }]
+    },{
+        properties: {
+            "carmen:center": [ -99.392855, 63.004759 ],
+            "carmen:text": "Canada",
+            "carmen:extid": "country.1",
+            "iso3166": "ca"
+        }
+    }];
 
     t.deepEqual(ops.toFeature(fullStack, "{address._number} {address._name}, {place._name}, {region._name} {postcode._name}").place_name, 'Fake Street, Caemlyn, Andor 1234', 'Full stack');
     t.deepEqual(ops.toFeature(fullStack, "{address._number} {address._name}, {place.name}, {region._name} {postcode._name}").place_name, 'Fake Street, Andor 1234', 'Full stack');
-
+    t.equals(ops.toFeature(fullStack).context.pop().iso3166, 'ca', 'iso3166 property made it into context array');
 
     t.end();
 });

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -8,7 +8,7 @@ test('ops#toFeature', function(t) {
             "carmen:text": "Canada, CA",
             "carmen:extid": "country.1833980151",
             "carmen:relevance": 1,
-            "iso3166": "ca"
+            "short_code": "ca"
         }
     }]), {
         id: 'country.1833980151',
@@ -17,7 +17,7 @@ test('ops#toFeature', function(t) {
         place_name: 'Canada',
         relevance: undefined,
         center: [ -99.392855, 63.004759 ],
-        properties: { iso3166: "ca" },
+        properties: { short_code: "ca" },
         geometry: { type: 'Point', coordinates: [ -99.392855, 63.004759 ] },
     });
 
@@ -157,13 +157,13 @@ test('ops#toFeature', function(t) {
             "carmen:center": [ -99.392855, 63.004759 ],
             "carmen:text": "Canada",
             "carmen:extid": "country.1",
-            "iso3166": "ca"
+            "short_code": "ca"
         }
     }];
 
     t.deepEqual(ops.toFeature(fullStack, "{address._number} {address._name}, {place._name}, {region._name} {postcode._name}").place_name, 'Fake Street, Caemlyn, Andor 1234', 'Full stack');
     t.deepEqual(ops.toFeature(fullStack, "{address._number} {address._name}, {place.name}, {region._name} {postcode._name}").place_name, 'Fake Street, Andor 1234', 'Full stack');
-    t.equals(ops.toFeature(fullStack).context.pop().iso3166, 'ca', 'iso3166 property made it into context array');
+    t.equals(ops.toFeature(fullStack).context.pop().short_code, 'ca', 'short_code property made it into context array');
 
     t.end();
 });


### PR DESCRIPTION
Country codes are a common feature request for geocoding. These are easy enough to expose in an country document's custom properties. However, it will often be desirable to understand the country that a non-country-level result resides in. Doing so will require more information to be exposed in a result's `context` array.

This PR exposes the `iso3166` custom property of `country` objects in a result's `context` array (when it exists).

This is a straightforward implementation and follows the precedent of hardcoding which properties get exposed in `context`. But I'm not sure it's the best or most flexible approach. 

An alternative would be to define a new Carmen GeoJSON property that indicates which properties should be exposed in `context`. For example:

```
properties: {
    "carmen:center": [0,0],
    "carmen:text": "Canada",
    "carmen:extid": "country.1"
    "carmen:contextProperties": ["iso3661"],
    "iso3661": "ca"
}
```

This bulks up the documents, but for this layer it's unlikely to be a big issue.

Happy to go either way on this (or a third I'm not seeing yet). I can see arguments for both approaches.