### PR TITLE
Node mapnik 3.4.10

### DIFF
--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -30,6 +30,7 @@ function _addFeature(source, input, vtile_only, callback) {
     if (input._text) {
         input = feature.transform(input);
     }
+    input.type = 'Feature';
 
     input.geometry = input.geometry || {
         type: 'Point',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "err-code": "0.1.2",
     "eslint": "^1.5.0",
     "locking": "2.0.2",
-    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik": "~3.4.10",
     "minimist": "0.0.5",
     "murmur": "0.0.2",
     "queue-async": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "err-code": "0.1.2",
     "eslint": "^1.5.0",
     "locking": "2.0.2",
-    "mapnik": "~3.4.3",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
     "minimist": "0.0.5",
     "murmur": "0.0.2",
     "queue-async": "1.0.x",

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -154,10 +154,6 @@ test('contextVector empty VT buffer', function(assert) {
     context.getTile.cache.reset();
 
     var vtile = new mapnik.VectorTile(0,0,0);
-    vtile.addGeoJSON(JSON.stringify({
-        "type": "FeatureCollection",
-        "features": []
-    }),"data");
     zlib.gzip(vtile.getData(), function(err, buffer) {
         assert.ifError(err);
         var source = {


### PR DESCRIPTION
node-mapnik@3.4.10 brings in Mapnik v3.0.9-rc2 which has improved GeoJSON parsing behavior in the sense that it is stricter. This caught a few things which likely should be fixed in general. Companion pull request to #372