### PR TITLE
[yo-dawg] Unobject encodePhrase

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,8 @@ machine:
   node:
     version: 0.10.30
   pre:
-  - if [[ $(uname -s) == 'Linux' ]]; then wget https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test/+files/libstdc%2B%2B6_4.8.1-2ubuntu1~12.04_amd64.deb && dpkg -x libstdc++6_4.8.1-2ubuntu1~12.04_amd64.deb ./ && export LD_PRELOAD=$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6; fi
+  - wget https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test/+files/libstdc%2B%2B6_4.8.1-2ubuntu1~12.04_amd64.deb && dpkg -x libstdc++6_4.8.1-2ubuntu1~12.04_amd64.deb ./ && export LD_PRELOAD=$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test; sudo apt-get update; sudo apt-get install gcc-4.8 g++-4.8; export CXX=g++-4.8
 
 test:
   override:

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ function update(source, docs, zoom, callback) {
         }
         if (TIMER) console.timeEnd('update:loadall');
         if (TIMER) console.time('update:indexdocs');
-        indexdocs(docs, freq, zoom, source.geocoder_tokens, source._dictcache.properties, updateCache);
+        indexdocs(docs, freq, zoom, source.geocoder_tokens, updateCache);
     });
 
     function updateCache(err, patch) {
@@ -122,33 +122,45 @@ function update(source, docs, zoom, callback) {
                 return source._commit ? source._commit(callback) : callback();
             });
         }, features);
-        for (var type in patch) if (type !== 'docs') setParts(patch[type], type);
+        setParts(patch.grid, 'grid');
+        setText(patch.text);
         q.awaitAll(callback);
 
-        function setParts(patchData, type) {
-            q.defer(function(patchData, type, callback) {
-                if (type != 'grid') return callback();
-
-                var ids = Object.keys(patchData.data);
+        function setParts(data, type) {
+            q.defer(function(data, type, callback) {
+                var ids = Object.keys(data);
                 var cache = source._geocoder;
                 var dictcache = source._dictcache;
                 if (TIMER) console.time('update:setParts:'+type);
                 cache.loadall(getter, type, ids, function(err) {
                     if (err) return callback(err);
-                    for (var i = 0; i < ids.length; i++) {
-                        var id = ids[i];
-                        // This merges new entries on top of old ones.
-                        cache.set('grid', id, patchData.data[id], true);
-                        if (dictcache.properties.needsText) {
-                            if (patchData.text[id]) dictcache.setText(patchData.text[id]);
-                        } else {
+                    if (dictcache.properties.needsText) {
+                        for (var i = 0; i < ids.length; i++) {
+                            var id = ids[i];
+                            // This merges new entries on top of old ones.
+                            cache.set('grid', id, data[id], true);
+                        }
+                    } else {
+                        for (var i = 0; i < ids.length; i++) {
+                            var id = ids[i];
+                            // This merges new entries on top of old ones.
+                            cache.set('grid', id, data[id], true);
                             dictcache.setId(id);
                         }
                     }
                     if (TIMER) console.timeEnd('update:setParts:'+type);
                     callback();
                 });
-            }, patchData, type);
+            }, data, type);
+        }
+
+        function setText(text) {
+            var dictcache = source._dictcache;
+            if (dictcache.properties.needsText) {
+                for (var i = 0; i < text.length; i++) {
+                    dictcache.setText(text[i]);
+                }
+            }
         }
     }
 }

--- a/lib/indexer/indexdocs-worker.js
+++ b/lib/indexer/indexdocs-worker.js
@@ -21,15 +21,14 @@ module.exports.loadDoc = loadDoc;
 module.exports.verifyCenter = verifyCenter;
 
 process.on('message', function(data) {
-    if (data.freq && data.zoom && data.geocoder_tokens && data.cache_properties) {
+    if (data.freq && data.zoom && data.geocoder_tokens) {
         freq = data.freq;
         zoom = data.zoom;
         token_replacer = token.createReplacer(data.geocoder_tokens);
-        cache_properties = data.cache_properties;
     } else {
-        var patch = { grid: {data: {}, text: {}}, docs: [] };
+        var patch = { grid: {}, docs: [], text: [] };
         for (var i = 0; i < data.length; i++) {
-            var err = loadDoc(patch, data[i], freq, zoom, token_replacer, cache_properties);
+            var err = loadDoc(patch, data[i], freq, zoom, token_replacer);
             if (err) return process.send(err);
         }
         process.send(patch);
@@ -81,7 +80,7 @@ function runChecks(doc, zoom) {
     return '';
 }
 
-function loadDoc(patch, doc, freq, zoom, token_replacer, cache_properties) {
+function loadDoc(patch, doc, freq, zoom, token_replacer) {
     var err = runChecks(doc, zoom);
     if (err) return err;
 
@@ -147,17 +146,15 @@ function loadDoc(patch, doc, freq, zoom, token_replacer, cache_properties) {
             // Make sure the phrase is only counted once per doc.
             // Synonyms and other multiple text situations can
             // create dupe phrases.
-            if (phraseUniq[phrase.id]) continue;
-            phraseUniq[phrase.id] = true;
+            if (phraseUniq[phrase]) continue;
+            phraseUniq[phrase] = true;
 
             if (DEBUG && !phrases[y].degen) {
                 console.warn('[%d] phrase: %s @ %d', doc.id, phrases[y].text, phrases[y].relev);
             }
 
-            patch.grid.data[phrase.id] = patch.grid.data[phrase.id] || [];
-            if (cache_properties.needsText && (!phrases[y].degen || cache_properties.needsDegens)) {
-                patch.grid.text[phrase.id] = phrase.text;
-            }
+            patch.grid[phrase] = patch.grid[phrase] || [];
+            if (!phrases[y].degen) patch.text.push(phrases[y].text);
 
             l = xy.length
             while (l--) {
@@ -173,8 +170,7 @@ function loadDoc(patch, doc, freq, zoom, token_replacer, cache_properties) {
                 } catch (err) {
                     console.warn(err.toString() + ', doc id: ' + doc.id);
                 }
-
-                if (encoded) patch.grid.data[phrase.id].push(encoded);
+                if (encoded) patch.grid[phrase].push(encoded);
             }
         }
     }

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -5,7 +5,7 @@ var workers = [];
 module.exports = indexdocs;
 module.exports.teardown = teardown;
 
-function indexdocs(docs, freq, zoom, geocoder_tokens, cache_properties, callback) {
+function indexdocs(docs, freq, zoom, geocoder_tokens, callback) {
     if (typeof zoom != 'number')
         return callback(new Error('index has no zoom'));
     if (zoom < 0)
@@ -14,7 +14,7 @@ function indexdocs(docs, freq, zoom, geocoder_tokens, cache_properties, callback
         return callback(new Error('zoom must be less than 15 --- zoom was '+zoom));
 
     var remaining = docs.length;
-    var full = { grid: {data: {}, text: {}}, docs:[] };
+    var full = { grid: {}, text:[], docs:[] };
     var types = Object.keys(full);
     var patches = [];
 
@@ -31,8 +31,7 @@ function indexdocs(docs, freq, zoom, geocoder_tokens, cache_properties, callback
         workers[i].send({
             freq:freq,
             zoom:zoom,
-            geocoder_tokens:geocoder_tokens,
-            cache_properties: cache_properties,
+            geocoder_tokens:geocoder_tokens
         });
         workers[i].removeAllListeners('exit');
         workers[i].on('exit', exit);
@@ -71,19 +70,12 @@ function exit(code) {
 
 function processPatch(patch, types, full) {
     full.docs.push.apply(full.docs, patch.docs);
+    full.text.push.apply(full.text, patch.text);
 
     for (var i = 0; i < types.length; i++) {
         var type = types[i];
 
-        if (type === "grid") {
-            for (var k in patch[type].data) {
-                full[type].data[k] = full[type].data[k] || [];
-                full[type].data[k].push.apply(full[type].data[k], patch[type].data[k]);
-            }
-            for (var k in patch[type].text) {
-                full[type].text[k] = patch[type].text[k];
-            }
-        } else if (type !== 'docs') {
+        if (type === 'grid') {
             for (var k in patch[type]) {
                 full[type][k] = full[type][k] || [];
                 full[type][k].push.apply(full[type][k], patch[type][k]);

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -27,7 +27,8 @@ module.exports = function phrasematch(source, query, callback) {
 
     for (var l = 0; l < subqueries.length; l++) {
         var phrase = termops.encodePhrase(subqueries[l], subqueries[l].ender);
-        subqueries[l].phraseObj = phrase;
+        subqueries[l].text = termops.encodableText(subqueries[l]);
+        subqueries[l].phrase = phrase;
     }
 
     loadall(getter, 'freq', [1], function(err) {
@@ -42,10 +43,9 @@ module.exports = function phrasematch(source, query, callback) {
 
         var l = subqueries.length;
         while (l--) {
-            if (!source._dictcache.hasPhrase(subqueries[l].phraseObj)) continue;
+            if (!source._dictcache.hasPhrase(subqueries[l])) continue;
             // Augment permutations with matched grids,
             // index position and weight relative to input query.
-            subqueries[l].phrase = subqueries[l].phraseObj.id;
             subqueries[l].scorefactor = scorefactor;
             subqueries[l].getter = getter;
             subqueries[l].loadall = loadall;

--- a/lib/util/bitcache.js
+++ b/lib/util/bitcache.js
@@ -94,8 +94,8 @@ Bitcache.prototype.hasId = function(id) {
     return Boolean(this.cache[shard][byte] & (1 << (id & 7)));
 };
 
-Bitcache.prototype.hasPhrase = function(phraseObj) {
-    return this.hasId(phraseObj.id);
+Bitcache.prototype.hasPhrase = function(subq) {
+    return this.hasId(subq.phrase);
 }
 
 Bitcache.prototype.properties = {

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -36,8 +36,8 @@ var ReadCache = function(buf) {
 
 ReadCache.prototype = Object.create(_dawgCache.CompactDawg.prototype);
 
-ReadCache.prototype.hasPhrase = function(phraseObj) {
-    return phraseObj.degen ? this.lookupPrefix(phraseObj.text) : this.lookup(phraseObj.text);
+ReadCache.prototype.hasPhrase = function(subq) {
+    return subq.ender ? this.lookupPrefix(subq.text) : this.lookup(subq.text);
 }
 
 var DawgCache = function(buf, opts) {

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -58,9 +58,14 @@ function getTermWeight(freq, term) {
     return terms;
 }
 
+module.exports.encodableText = encodableText;
+function encodableText(tokens) {
+    return unidecode(typeof tokens === 'string' ?  tokens : tokens.join(' ')).toLowerCase().trim();
+}
+
 module.exports.encodePhrase = encodePhrase;
 function encodePhrase(tokens, degen) {
-    var text = unidecode(typeof tokens === 'string' ?  tokens : tokens.join(' ')).toLowerCase().trim().replace(/[\s]+/g,' ');
+    var text = encodableText(tokens);
     var encoded = parseInt(murmur.hash128(text).hex().substr(-13), 16);
     return encoded - (encoded % 2) + (degen ? 0 : 1);
 };
@@ -391,22 +396,25 @@ function getIndexablePhrases(tokens, freq) {
         // Indexing optimization.
         if (perms[i].relev < 0.8) break;
 
+        var text = perms[i].join(' ');
+
         // Encode canonical phrase.
         var toEncode = [];
         toEncode.push({
             degen: false,
             relev: perms[i].relev,
-            text: perms[i].join(' '),
+            text: encodableText(perms[i].join(' ')),
             phrase: encodePhrase(perms[i].join(' '), false)
         });
 
         // Encode degens of phrase.
-        var degens = getPhraseDegens(toEncode[0].text);
+        // Pre-unidecoded text is used to handle CJK degens properly.
+        var degens = getPhraseDegens(text);
         l = degens.length;
         while (l--) toEncode.push({
             degen: true,
             relev: perms[i].relev,
-            text: degens[l],
+            text: encodableText(degens[l]),
             phrase: encodePhrase(degens[l], true)
         });
 

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -60,13 +60,9 @@ function getTermWeight(freq, term) {
 
 module.exports.encodePhrase = encodePhrase;
 function encodePhrase(tokens, degen) {
-    var text = unidecode(typeof tokens === 'string' ?  tokens : tokens.join(' ')).toLowerCase().trim();
+    var text = unidecode(typeof tokens === 'string' ?  tokens : tokens.join(' ')).toLowerCase().trim().replace(/[\s]+/g,' ');
     var encoded = parseInt(murmur.hash128(text).hex().substr(-13), 16);
-    return {
-        text: text,
-        id: encoded - (encoded % 2) + (degen ? 0 : 1),
-        degen: degen
-    }
+    return encoded - (encoded % 2) + (degen ? 0 : 1);
 };
 
 // Generate a hash id from a feature ID. Fits within a 20-bit integer space
@@ -419,8 +415,8 @@ function getIndexablePhrases(tokens, freq) {
             var obj = toEncode[l];
 
             // Uses the highest scored phrase via sort.
-            if (uniq[obj.phrase.id]) continue;
-            uniq[obj.phrase.id] = true;
+            if (uniq[obj.phrase]) continue;
+            uniq[obj.phrase] = true;
             phrases.push(obj);
         }
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "err-code": "0.1.2",
     "eslint": "^1.5.0",
     "locking": "2.0.2",
-    "dawg-cache": "https://github.com/mapbox/dawg-cache/tarball/68b46f82448a40710a90fea62162ab0c8ab91df0",
+    "dawg-cache": "https://github.com/mapbox/dawg-cache/tarball/1741a7cf5ee5466e7e77a5584f7692c7a3ee8274",
     "mapnik": "~3.4.10",
     "minimist": "0.0.5",
     "mmap": "2.0.2",

--- a/test/dawgcache.test.js
+++ b/test/dawgcache.test.js
@@ -23,12 +23,12 @@ tape('dump/load', function(assert) {
             assert.ifError(err);
             var loaded = new DawgCache(data);
             for (var i = 1; i <= 4; i++) {
-                assert.equal(loaded.hasPhrase({text: "a" + i, degen: false}), true, 'has a' + i);
+                assert.equal(loaded.hasPhrase({text: "a" + i, ender: false}), true, 'has a' + i);
             }
-            assert.equal(loaded.hasPhrase({text: "a5", degen: false}), false, 'not a5');
+            assert.equal(loaded.hasPhrase({text: "a5", ender: false}), false, 'not a5');
 
-            assert.equal(loaded.hasPhrase({text: "a", degen: false}), false, 'not a');
-            assert.equal(loaded.hasPhrase({text: "a", degen: true}), true, 'has a as degen');
+            assert.equal(loaded.hasPhrase({text: "a", ender: false}), false, 'not a');
+            assert.equal(loaded.hasPhrase({text: "a", ender: true}), true, 'has a as degen');
             assert.end();
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -253,8 +253,8 @@ test('index phrase collection', function(assert) {
     index.update(conf.test, docs, 6, afterUpdate);
     function afterUpdate(err) {
         assert.ifError(err);
-        var id1 = termops.encodePhrase('a', true).id;
-        var id2 = termops.encodePhrase('a', false).id;
+        var id1 = termops.encodePhrase('a', true);
+        var id2 = termops.encodePhrase('a', false);
         assert.deepEqual(conf.test._geocoder.list('grid',Math.floor(id1/68719476736)), [ id1.toString(), id2.toString() ], '2 phrases');
         assert.deepEqual(conf.test._geocoder.get('grid',id1), [ 6755949230424065, 6755949230424066 ], 'grid has 2 zxy+feature ids');
         assert.deepEqual(conf.test._geocoder.get('grid',id2), [ 6755949230424065, 6755949230424066 ], 'grid has 2 zxy+feature ids');

--- a/test/indexdocs-worker.test.js
+++ b/test/indexdocs-worker.test.js
@@ -14,7 +14,7 @@ tape('worker.loadDoc', function(assert) {
     var doc;
     var err;
 
-    patch = { grid:{data:{}, text:{}}, docs:[] };
+    patch = { grid:{}, docs:[], text:[] };
     freq = {};
     tokens = ['main', 'st'];
     zoom = 6;
@@ -38,11 +38,11 @@ tape('worker.loadDoc', function(assert) {
     freq[termops.encodeTerm(tokens[1])] = [100];
 
     // Indexes single doc.
-    err = worker.loadDoc(patch, doc, freq, zoom, token_replacer, Bitcache.prototype.properties);
+    err = worker.loadDoc(patch, doc, freq, zoom, token_replacer);
     assert.ifError(err);
-    assert.deepEqual(Object.keys(patch.grid.data).length, 8);
-    assert.deepEqual(patch.grid.data[Object.keys(patch.grid.data)[0]].length, 1);
-    assert.deepEqual(grid.decode(patch.grid.data[Object.keys(patch.grid.data)[0]][0]), {
+    assert.deepEqual(Object.keys(patch.grid).length, 8);
+    assert.deepEqual(patch.grid[Object.keys(patch.grid)[0]].length, 1);
+    assert.deepEqual(grid.decode(patch.grid[Object.keys(patch.grid)[0]][0]), {
         id: 1,
         relev: 1,
         score: 4, // scales score based on max score value (100)
@@ -51,6 +51,7 @@ tape('worker.loadDoc', function(assert) {
     });
     assert.deepEqual(patch.docs.length, 1);
     assert.deepEqual(patch.docs[0], doc);
+    assert.deepEqual(patch.text, ['main st', 'main']);
 
     assert.end();
 });

--- a/test/termops.encodePhrase.test.js
+++ b/test/termops.encodePhrase.test.js
@@ -5,45 +5,45 @@ var test = require('tape');
 test('termops.encodePhrase', function(assert) {
     var a;
 
-    a = termops.encodePhrase('main').id;
+    a = termops.encodePhrase('main');
     assert.deepEqual(a, 609659059851265, 'main');
     assert.deepEqual(a % 2, 1, 'main = non-degen');
 
-    a = termops.encodePhrase('main', true).id;
+    a = termops.encodePhrase('main', true);
     assert.deepEqual(a, 609659059851264, 'main (degen)');
     assert.deepEqual(a % 2, 0, 'main = degen');
 
-    a = termops.encodePhrase('main st').id;
+    a = termops.encodePhrase('main st');
     assert.deepEqual(a, 2135214313017581, 'main st');
     assert.deepEqual(a % 2, 1, 'main st = non-degen');
 
     // prev as token array
-    a = termops.encodePhrase(['main','st']).id;
+    a = termops.encodePhrase(['main','st']);
     assert.deepEqual(a, 2135214313017581, 'main st');
     assert.deepEqual(a % 2, 1, 'main st = non-degen');
 
-    a = termops.encodePhrase('lazy dog').id;
+    a = termops.encodePhrase('lazy dog');
     assert.deepEqual(a, 1523002542039449, 'lazy dog')
     assert.deepEqual(a % 2, 1, 'lazy dog = non-degen');
 
-    a = termops.encodePhrase('lazy dog', 1).id;
+    a = termops.encodePhrase('lazy dog', 1);
     assert.deepEqual(a, 1523002542039448, 'lazy dog (degen)')
     assert.deepEqual(a % 2, 0, 'lazy dog = degen');
 
-    a = termops.encodePhrase('The quick brown fox jumps over the lazy dog').id;
+    a = termops.encodePhrase('The quick brown fox jumps over the lazy dog');
     assert.deepEqual(a, 2067419977200835, 'long phrase');
     assert.deepEqual(a % 2, 1, 'long phrase = non-degen');
 
-    a = termops.encodePhrase('The quick brown fox jumps over the lazy dog', true).id;
+    a = termops.encodePhrase('The quick brown fox jumps over the lazy dog', true);
     assert.deepEqual(a, 2067419977200834, 'long phrase (degen)');
     assert.deepEqual(a % 2, 0, 'long phrase = degen');
 
     // unicode vs unidecoded
-    a = termops.encodePhrase('京都市').id;
+    a = termops.encodePhrase('京都市');
     assert.deepEqual(a, 657403748910369, '京都市');
     assert.deepEqual(a % 2, 1, '京都市 = non-degen');
 
-    a = termops.encodePhrase('jing du shi').id;
+    a = termops.encodePhrase('jing du shi');
     assert.deepEqual(a, 657403748910369, 'jing du shi = 京都市');
     assert.deepEqual(a % 2, 1, 'jing du shi = non-degen');
 
@@ -52,8 +52,8 @@ test('termops.encodePhrase', function(assert) {
 
     // no longer a collision in 52-bit fnv1a
     // assert.deepEqual(
-    //     termops.encodePhrase('av francisco de aguirre # la serena').id,
-    //     termops.encodePhrase('# r ademar da silva neiva').id,
+    //     termops.encodePhrase('av francisco de aguirre # la serena'),
+    //     termops.encodePhrase('# r ademar da silva neiva'),
     //     'known collisions: #1'
     // );
 
@@ -67,7 +67,7 @@ test('termops.encodePhrase collisions', function(assert) {
     var collisions = [];
     while (texts < sample) {
         var text = Math.random().toString(36);
-        var id = termops.encodePhrase(text).id;
+        var id = termops.encodePhrase(text);
         if (ids[id] === text) {
             continue;
         } else if (ids[id]) {

--- a/test/termops.getIndexablePhrases.test.js
+++ b/test/termops.getIndexablePhrases.test.js
@@ -125,10 +125,10 @@ test('termops.getIndexablePhrases (京都市)', function(assert) {
     freq[termops.encodeTerm(tokens[0])] = [1];
 
     assert.deepEqual(termops.getIndexablePhrases(tokens, freq), [
-        { degen: true, phrase: termops.encodePhrase('京', true), relev: 1, text: '京' },
-        { degen: true, phrase: termops.encodePhrase('京都', true), relev: 1, text: '京都' },
-        { degen: true, phrase: termops.encodePhrase('京都市', true), relev: 1, text: '京都市' },
-        { degen: false, phrase: termops.encodePhrase('京都市', false), relev: 1, text: '京都市' }
+        { degen: true, phrase: termops.encodePhrase('京', true), relev: 1, text: 'jing' },
+        { degen: true, phrase: termops.encodePhrase('京都', true), relev: 1, text: 'jing du' },
+        { degen: true, phrase: termops.encodePhrase('京都市', true), relev: 1, text: 'jing du shi' },
+        { degen: false, phrase: termops.encodePhrase('京都市', false), relev: 1, text: 'jing du shi' }
     ]);
 
     assert.end();
@@ -144,13 +144,13 @@ test('termops.getIndexablePhrases (москва)', function(assert) {
     freq[termops.encodeTerm(tokens[0])] = [1];
 
     assert.deepEqual(termops.getIndexablePhrases(tokens, freq), [
-        { degen: true, phrase: termops.encodePhrase('м', true), relev: 1, text: 'м' },
-        { degen: true, phrase: termops.encodePhrase('мо', true), relev: 1, text: 'мо' },
-        { degen: true, phrase: termops.encodePhrase('мос', true), relev: 1, text: 'мос' },
-        { degen: true, phrase: termops.encodePhrase('моск', true), relev: 1, text: 'моск' },
-        { degen: true, phrase: termops.encodePhrase('москв', true), relev: 1, text: 'москв' },
-        { degen: true, phrase: termops.encodePhrase('москва', true), relev: 1, text: 'москва' },
-        { degen: false, phrase: termops.encodePhrase('москва', false), relev: 1, text: 'москва' }
+        { degen: true, phrase: termops.encodePhrase('м', true), relev: 1, text: 'm' },
+        { degen: true, phrase: termops.encodePhrase('мо', true), relev: 1, text: 'mo' },
+        { degen: true, phrase: termops.encodePhrase('мос', true), relev: 1, text: 'mos' },
+        { degen: true, phrase: termops.encodePhrase('моск', true), relev: 1, text: 'mosk' },
+        { degen: true, phrase: termops.encodePhrase('москв', true), relev: 1, text: 'moskv' },
+        { degen: true, phrase: termops.encodePhrase('москва', true), relev: 1, text: 'moskva' },
+        { degen: false, phrase: termops.encodePhrase('москва', false), relev: 1, text: 'moskva' }
     ]);
 
     assert.end();
@@ -169,8 +169,8 @@ test('termops.getIndexablePhrases (josé)', function(assert) {
         { degen: true, phrase: termops.encodePhrase('j',true), relev: 1, text: 'j' },
         { degen: true, phrase: termops.encodePhrase('jo',true), relev: 1, text: 'jo' },
         { degen: true, phrase: termops.encodePhrase('jos',true), relev: 1, text: 'jos' },
-        { degen: true, phrase: termops.encodePhrase('josé',true), relev: 1, text: 'josé' },
-        { degen: false, phrase: termops.encodePhrase('josé',false), relev: 1, text: 'josé' }
+        { degen: true, phrase: termops.encodePhrase('josé',true), relev: 1, text: 'jose' },
+        { degen: false, phrase: termops.encodePhrase('josé',false), relev: 1, text: 'jose' }
     ]);
 
     assert.end();


### PR DESCRIPTION
This rolls back the phrase-as-object concept bringing `yo-dawg` a bit closer to `master`. (https://github.com/mapbox/carmen/compare/yo-dawg-patchtext)

I'm realizing the reason I knee-jerked in this direction is because at runtime we already have the `subquery` object that serves a very similar concept to the phrase object currently in the `yo-dawg` branch.

Should pass tests locally -- not passing on circle for build-ey reasons.

cc @apendleton for your review