### PR TITLE
[yo-dawg] Back to dictsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ geocoder_name           | Optional + advanced. A string to use instead of the pr
 geocoder_type           | Optional + advanced. A string to be used instead the config index id/key. Omission of this falls back to geocoder_name and then to the id.
 geocoder_version        | Required. Should be set to **5** for carmen@v9.x. Index versions <= 1 can be used for reverse geocoding but not forward.
 geocoder_cachesize      | Optional + advanced. Maximum number of shards to allow in the `carmen-cache` message cache. Defaults uptream to 65536 (maximum number of possible shards).
-geocoder_dictsize       | Optional + advanced. Bit size to use for dict cache. Defaults to 24.
+geocoder_dicttype       | Optional + advanced. Dictcache type to use (`bitcache` or `dawg`). Defaults to `bitcache`.
+geocoder_dictsize       | Optional + advanced. Bit size to use for bitarray dict cache. Defaults to 24.
 
 *Note: The sum of maxzoom + geocoder_resolution must be no greater than 14.*
 

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function Geocoder(indexes, options) {
                     callback(null, {
                         id: id,
                         info: loaded[0],
-                        dictcache: new dictcache[geocoder_type](loaded[1], loaded[0].geocoder_dictcache_opts)
+                        dictcache: new dictcache[geocoder_type](loaded[1], loaded[0].geocoder_dictsize)
                     });
                 }
             });

--- a/index.js
+++ b/index.js
@@ -156,11 +156,12 @@ function Geocoder(indexes, options) {
                     });
                 // create dictcache at load time to allow incremental gc
                 } else {
-                    var geocoder_type = loaded[0].geocoder_dictcache_type || process.env.CARMEN_DEFAULT_DICTCACHE || 'bitcache';
+                    var dicttype = loaded[0].geocoder_dicttype || 'bitcache';
+                    var dictsize = dicttype === 'bitcache' ? loaded[0].geocoder_dictsize : undefined;
                     callback(null, {
                         id: id,
                         info: loaded[0],
-                        dictcache: new dictcache[geocoder_type](loaded[1], loaded[0].geocoder_dictsize)
+                        dictcache: new dictcache[dicttype](loaded[1], dictsize)
                     });
                 }
             });

--- a/lib/api-mem.js
+++ b/lib/api-mem.js
@@ -18,6 +18,7 @@ function MemSource(docs, info, callback) {
     this._info = info || { maxzoom: 6 };
     this._info.geocoder_version = this._info.geocoder_version !== undefined ? this._info.geocoder_version : 5;
     this._info.geocoder_dictsize = 24;
+    this._info.geocoder_dicttype = process.env.CARMEN_DEFAULT_DICTCACHE || 'bitcache';
     this.open = true;
     this.docs = docs;
     return callback(null, this);

--- a/lib/api-mem.js
+++ b/lib/api-mem.js
@@ -17,7 +17,7 @@ function MemSource(docs, info, callback) {
     this._grids = {};
     this._info = info || { maxzoom: 6 };
     this._info.geocoder_version = this._info.geocoder_version !== undefined ? this._info.geocoder_version : 5;
-    this._info.geocoder_dictcache_opts = {size: 24};
+    this._info.geocoder_dictsize = 24;
     this.open = true;
     this.docs = docs;
     return callback(null, this);

--- a/lib/util/bitcache.js
+++ b/lib/util/bitcache.js
@@ -29,9 +29,8 @@ module.exports.sizes =  sizes;
 module.exports.bufferSizes =  bufferSizes;
 module.exports.shardLength = shardLength;
 
-function Bitcache(buffer, opts) {
-    opts = opts || {};
-    var bitSize = opts.size || (buffer && bufferSizes[buffer.length]) || 30;
+function Bitcache(buffer, bitSize) {
+    bitSize = bitSize || (buffer && bufferSizes[buffer.length]) || 30;
     if (!sizes[bitSize]) throw new Error('Bitcache bitSize must be one of: ' + Object.keys(sizes).join(', '));
 
     this.size = sizes[bitSize];

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -40,7 +40,7 @@ ReadCache.prototype.hasPhrase = function(subq) {
     return subq.ender ? this.lookupPrefix(subq.text) : this.lookup(subq.text);
 }
 
-var DawgCache = function(buf, opts) {
+var DawgCache = function(buf) {
     if (buf && buf.length) {
         return new ReadCache(buf);
     } else {

--- a/test/bitcache.test.js
+++ b/test/bitcache.test.js
@@ -4,7 +4,7 @@ var encodePhrase = require('../lib/util/termops').encodePhrase;
 var Bitcache = require('../lib/util/dictcache').bitcache;
 
 tape('create (30 bit)', function(assert) {
-    var dict = new Bitcache(null, {size: 30});
+    var dict = new Bitcache(null, 30);
     assert.equal(dict.cache.length, 4, 'created 128MiB cache');
     for (var i = 0; i < Bitcache.shardLength; i++) {
         if (dict.cache[0][i] !== 0) {
@@ -15,7 +15,7 @@ tape('create (30 bit)', function(assert) {
 });
 
 tape('create (31 bit)', function(assert) {
-    var dict = new Bitcache(null, {size: 31});
+    var dict = new Bitcache(null, 31);
     assert.equal(dict.cache.length, 8, 'created 256MiB cache');
     for (var i = 0; i < Bitcache.shardLength; i++) {
         if (dict.cache[0][i] !== 0) {
@@ -41,7 +41,7 @@ tape('create (256 MiB buffer)', function(assert) {
 
 tape('create (err: size)', function(assert) {
     assert.throws(function() {
-        var dict = new Bitcache(null, {size: 34});
+        var dict = new Bitcache(null, 34);
     });
     assert.end();
 });
@@ -145,7 +145,7 @@ tape('auto', function(assert) {
 [10000, 100000, 1000000].forEach(function(ids) {
     var size = Bitcache.auto(ids);
     tape('fuzz auto: ' + ids + ' = ' + size, function(assert) {
-        var dict = new Bitcache(null, {size: size});
+        var dict = new Bitcache(null, size);
         var used = {};
         var count = 0;
         for (var i = 0; i < ids; i++) {
@@ -164,7 +164,7 @@ tape('auto', function(assert) {
 // fuzz test
 [32,31,30].forEach(function(bitSize) {
     tape('fuzz: ' + bitSize, function(assert) {
-        var dict = new Bitcache(null, {size: bitSize});
+        var dict = new Bitcache(null, bitSize);
         var used = {};
         var count = 0;
         for (var i = 0; i < 100000; i++) {


### PR DESCRIPTION
- Rolls back to `geocoder_dictsize` as option key for bitcache,
- Goes with `geocoder_dicttype` as option key for determining type,
- Moves env var from main carmen index loading to `api-mem` source so it can only really affect tests.

cc @apendleton 