### PR TITLE
use xregexp for named token group replacement

### DIFF
--- a/bench/replaceTokenGroups.js
+++ b/bench/replaceTokenGroups.js
@@ -1,0 +1,40 @@
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+var token = require('../lib/util/token');
+var tokens = require('./fixtures/tokens.json');
+
+module.exports = benchmark;
+
+function benchmark(cb) {
+    if (!cb) cb = function(){};
+    console.log('# token.replaceTokenGroups');
+
+    suite.add('token replace - no group replacement', function() {
+        var replacers = token.createReplacer({
+            "\\d+": "###"
+        });
+        var res = token.replaceToken(replacers, 'abc ' + Math.round(Math.random() * 1000) + ' def');
+    })
+    suite.add('token replace - numbered groups', function() {
+        var replacers = token.createReplacer({
+            "(\\d+)": "#$1#"
+        });
+        var res = token.replaceToken(replacers, 'abc ' + Math.round(Math.random() * 1000) + ' def');
+    })
+    .add('token replace - named groups', function() {
+        var replacers = token.createReplacer({
+            "(?<num>\\d+)": "#${num}#"
+        });
+        var res = token.replaceToken(replacers, 'abc ' + Math.round(Math.random() * 1000) + ' def');
+    })
+    .on('cycle', function(event) {
+        console.log(String(event.target));
+    })
+    .on('complete', function() {
+      console.log('Fastest is ' + this.filter('fastest').pluck('name'), '\n');
+      cb(null, suite);
+    })
+    .run();
+}
+
+if (!process.env.runSuite) benchmark();

--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -1,4 +1,5 @@
 var unidecode = require('unidecode-cxx');
+var XRegExp = require('xregexp');
 
 module.exports.createReplacer = function(tokens) {
     var replacers = [];
@@ -18,12 +19,25 @@ module.exports.createReplacer = function(tokens) {
             }
 
             var entry = {};
-            entry.from = new RegExp('(\\W|^)' + from + '(\\W|$)', 'gi');
+            var parsedFrom = new XRegExp(from);
+            entry.named = (parsedFrom.xregexp.captureNames !== null);
 
-            // increment replacements indexes in `to`
-            var groupReplacements = 0;
-            to = to.replace(/\$(\d+)/g, function(str, index) { groupReplacements++; return '$' + (parseInt(index)+1).toString();});
-            entry.to = '$1' + to + '$' + (groupReplacements + 2).toString(); // normalize abbrev
+            // ensure that named groups are all or nothing; otherwise we have order problems
+            if (entry.named && parsedFrom.xregexp.captureNames.some(function(captureName) { return captureName === null; }))
+                throw new Error('Cannot process \'%s\'; must use either named or numbered capture groups, not both', from);
+
+            if (entry.named) {
+                entry.from = new XRegExp('(?<tokenBeginning>\\W|^)' + from + '(?<tokenEnding>\\W|$)', 'gi');
+                entry.to = '${tokenBeginning}' + to + '${tokenEnding}';
+            }
+            else {
+                entry.from = new RegExp('(\\W|^)' + from + '(\\W|$)', 'gi');
+
+                // increment replacements indexes in `to`
+                var groupReplacements = 0;
+                to = to.replace(/\$(\d+)/g, function(str, index) { groupReplacements++; return '$' + (parseInt(index)+1).toString();});
+                entry.to = '$1' + to + '$' + (groupReplacements + 2).toString(); // normalize abbrev
+            }
 
             replacers.push(entry);
         }
@@ -34,7 +48,10 @@ module.exports.createReplacer = function(tokens) {
 module.exports.replaceToken = function(tokens, query) {
     var abbr = query;
     for (var i=0; i<tokens.length; i++) {
-        var abbr = abbr.replace(tokens[i].from, tokens[i].to);
+        if (tokens[i].named)
+            abbr = XRegExp.replace(abbr, tokens[i].from, tokens[i].to);
+        else
+            abbr = abbr.replace(tokens[i].from, tokens[i].to);
     }
 
     return abbr;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "11.0.0",
+  "version": "11.0.0-xregexp",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
     "carmen-cache": "0.10.0",
+    "dawg-cache": "0.2.0",
     "err-code": "0.1.2",
     "eslint": "^1.5.0",
     "locking": "2.0.2",
-    "dawg-cache": "0.2.0",
     "mapnik": "~3.4.10",
     "minimist": "0.0.5",
     "mmap": "2.0.2",
@@ -31,7 +31,8 @@
     "turf-linestring": "1.0.x",
     "turf-point": "2.0.x",
     "turf-point-on-surface": "1.0.x",
-    "unidecode-cxx": "0.0.2"
+    "unidecode-cxx": "0.0.2",
+    "xregexp": "3.0.0"
   },
   "devDependencies": {
     "retire": "0.4.x",


### PR DESCRIPTION
Enables named group replacement in token substitutions, employing xregexp to support it.  For performance reasons, uses existing regexp functionality when named group replacements aren't needed. 

note: when a named replacement group is used in a replacement pattern, the regex pattern must not contain any numbered/un-named groups (an error will be thrown if it does). This is necessary in order to avoid some very confusing substitution-group-renumbering scenarios.

also note that xregexp is pinned because an internal structure is used to simplify the process of detecting whether a pattern contains named groups.