### PR TITLE
Allow adding multiple features

### DIFF
--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -53,18 +53,39 @@ function _addFeature(source, input, vtile_only, callback) {
 
     var q = queue();
     for (var i = 0; i < zxys.length; i++) q.defer(function(zxy, done) {
-        var vtile = new mapnik.VectorTile(zxy[0],zxy[1],zxy[2]);
-        vtile.addGeoJSON(JSON.stringify({
-            type: 'FeatureCollection',
-            features: [input]
-        }, null, 2), 'data');
-        zlib.gzip(vtile.getData(), function(err, buffer) {
-            if (err) return done(err);
-            source.putTile(zxy[0],zxy[1],zxy[2], buffer, function(err) {
-                if (err) return done(err);
-                done();
-            });
+        source.getTile(zxy[0],zxy[1],zxy[2], function(err, res) {
+            if (err) {
+                addData();
+            } else {
+                zlib.gunzip(res, function(err, vtileData) {
+                    var tmpTile = new mapnik.VectorTile(zxy[0],zxy[1],zxy[2]);
+                    tmpTile.addData(vtileData, 'data');
+                    addData(tmpTile);
+                });
+            }
         });
+
+        function addData(currentTile) {
+            if (currentTile) {
+                var feats = JSON.parse(currentTile.toGeoJSONSync('data')).features;
+                feats.push(input);
+            } else {
+                feats = [input]
+            }
+
+            var vtile = new mapnik.VectorTile(zxy[0],zxy[1],zxy[2]);
+            vtile.addGeoJSON(JSON.stringify({
+                type: 'FeatureCollection',
+                features: feats
+            }, null, 2), 'data');
+            zlib.gzip(vtile.getData(), function(err, buffer) {
+                if (err) return done(err);
+                source.putTile(zxy[0],zxy[1],zxy[2], buffer, function(err) {
+                    if (err) return done(err);
+                    done();
+                });
+            });
+        }
     }, zxys[i]);
 
     q.awaitAll(function(err) {


### PR DESCRIPTION
At the moment the `addFeature` function used by our unit tests overwrites the vector tiles each time it is called. This is fine for forward only indexes as these are appended to. However for reverse queries it causes problems as only the last feature will be present.

This PR changes this behavior to retain all features in a given VT.