### PR TITLE
Dedupe spatialmatch cache loading I/O

### DIFF
--- a/lib/api-mem.js
+++ b/lib/api-mem.js
@@ -15,23 +15,39 @@ function MemSource(docs, info, callback) {
 
     this._shards = {};
     this._grids = {};
-    this._info = info || { maxzoom: 6 };
+    this._info = info || { maxzoom: 6, timeout: 0 };
     this._info.geocoder_version = this._info.geocoder_version !== undefined ? this._info.geocoder_version : 6;
     this.open = true;
     this.docs = docs;
+    this.logs = {
+        getGeocoderData: [],
+        putGeocoderData: [],
+        getTile: [],
+        putTile: []
+    };
     return callback(null, this);
 }
 
 // Implements carmen#getGeocoderData method.
 MemSource.prototype.getGeocoderData = function(type, shard, callback) {
-    return callback(null, this._shards[type] && this._shards[type][shard]);
+    this.logs.getGeocoderData.push(type + ',' + shard);
+    if (this._info.timeout) {
+        setTimeout(function() { callback(null, this._shards[type] && this._shards[type][shard]); }.bind(this), this._info.timeout);
+    } else {
+        callback(null, this._shards[type] && this._shards[type][shard]);
+    }
 };
 
 // Implements carmen#putGeocoderData method.
 MemSource.prototype.putGeocoderData = function(type, shard, data, callback) {
+    this.logs.putGeocoderData.push(type + ',' + shard + ',' + data.length);
     if (this._shards[type] === undefined) this._shards[type] = {};
     this._shards[type][shard] = data;
-    return callback(null);
+    if (this._info.timeout) {
+        setTimeout(function() { callback(null); }, 10);
+    } else {
+        callback(null);
+    }
 };
 
 // Implements carmen#getIndexableDocs method.
@@ -80,12 +96,14 @@ MemSource.prototype.getInfo = function(callback) {
 };
 
 MemSource.prototype.getTile = function(z,x,y,callback) {
+    this.logs.getTile.push(z + ',' + x + ',' + y);
     var key = z + '/' + x + '/' + y;
     if (this._grids[key]) return callback(null, this._grids[key]);
     return callback(new Error('Tile does not exist'));
 };
 
 MemSource.prototype.putTile= function(z,x,y,grid,callback) {
+    this.logs.putTile.push(z + ',' + x + ',' + y);
     var key = z + '/' + x + '/' + y;
     this._grids[key] = grid;
     return callback && callback();

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -2,6 +2,7 @@ var decode = require('./util/grid.js').decode;
 var proximity = require('./util/proximity.js');
 var queue = require('queue-async');
 var coalesce = require('carmen-cache').Cache.coalesce;
+var uniq = require('./util/uniq');
 
 module.exports = spatialmatch;
 module.exports.stackable = stackable;
@@ -15,18 +16,48 @@ function spatialmatch(query, phrasematches, options, callback) {
     var sets = {};
     var waste = [];
 
-    var q = queue();
+    coalesceLoad();
 
-    for (var i = 0; i < stacks.length; i++) {
-        var stack = stacks[i];
-        var l = 0;
-        var m = 0;
+    // Load grid indexes necessary for coalesce.
+    function coalesceLoad(stack, callback) {
+        // First make a pass where phrase IDs to load are grouped by idx.
+        var loadables = {};
+        for (var i = 0; i < stacks.length; i++) {
+            var stack = stacks[i];
+            for (var j = 0; j < stack.length; j++) {
+                var idx = stack[j].idx;
+                loadables[idx] = loadables[idx] || {
+                    loadall: stack[j].loadall,
+                    getter: stack[j].getter,
+                    ids: []
+                };
+                loadables[idx].ids.push(stack[j].phrase);
+            }
+        }
 
+        // Then queue loading in a single pass deduping ids.
+        var q = queue();
+        for (var idx in loadables) {
+            q.defer(loadables[idx].loadall, loadables[idx].getter, 'grid', uniq(loadables[idx].ids));
+        }
+        q.awaitAll(coalesceStacks);
+    }
+
+    // Shards are loaded, now coalesce all stacks.
+    function coalesceStacks(err) {
+        if (err) return callback(err);
+        var q = queue();
+        for (var i = 0; i < stacks.length; i++) q.defer(coalesceStack, stacks[i]);
+        q.awaitAll(coalesceFinalize);
+    }
+
+    // Coalesce a single stack, add debugging info.
+    function coalesceStack(stack, callback) {
         // Proximity option is set.
         // Convert proximity to xy @ highest zoom level for this stack
         var coalesceOpts = {};
         if (options && options.proximity) {
-            l = stack.length;
+            var l = stack.length;
             var maxZoom = 0;
             while (l--) maxZoom = Math.max(maxZoom, stack[l].zoom);
             coalesceOpts.centerzxy = proximity.center2zxy(
@@ -36,25 +67,6 @@ function spatialmatch(query, phrasematches, options, callback) {
             );
         }
 
-        q.defer(coalesceLoad, stack, coalesceOpts);
-    }
-
-    q.awaitAll(coalesceFinalize);
-
-    // Load grid indexes necessary for coalesce.
-    function coalesceLoad(stack, coalesceOpts, callback) {
-        var q = queue();
-        for (var i = 0; i < stack.length; i++) {
-            q.defer(stack[i].loadall, stack[i].getter, 'grid', [stack[i].phrase]);
-        }
-        q.awaitAll(function(err) {
-            if (err) return callback(err);
-            coalesceStack(stack, coalesceOpts, callback);
-        });
-    }
-
-    // Coalesce stack, add debugging info.
-    function coalesceStack(stack, coalesceOpts, callback) {
         coalesce(stack, coalesceOpts, function(err, features) {
             // Include text for debugging with each matched feature.
             var byIdx = stackByIdx(stack);

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -1,0 +1,76 @@
+// Unit tests for IO-deduping when loading grid shards during spatialmatch.
+// Setups up multiple indexes representing logical equivalents.
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var queue = require('queue-async');
+var addFeature = require('../lib/util/addfeature');
+
+// Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
+var conf = {
+    place1: new mem({ maxzoom:6, geocoder_name: 'place', timeout:10 }, function() {}),
+    place2: new mem({ maxzoom:6, geocoder_name: 'place', timeout:10 }, function() {}),
+    place3: new mem({ maxzoom:6, geocoder_name: 'place', timeout:10 }, function() {}),
+    street1: new mem({ maxzoom:6, geocoder_name: 'street', timeout:10, geocoder_address:1 }, function() {}),
+    street2: new mem({ maxzoom:6, geocoder_name: 'street', timeout:10, geocoder_address:1 }, function() {}),
+    street3: new mem({ maxzoom:6, geocoder_name: 'street', timeout:10, geocoder_address:1 }, function() {})
+};
+var c = new Carmen(conf);
+[1,2,3].forEach(function(i) {
+    tape('index place ' + i, function(t) {
+        addFeature(conf['place'+i], {
+            _id:1,
+            _text:'springfield',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        }, t.end);
+    });
+    tape('index street ' + i, function(t) {
+        addFeature(conf['street'+i], {
+            _id:1,
+            _text:'winding river rd',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        }, t.end);
+    });
+    tape('index street ' + i, function(t) {
+        addFeature(conf['street'+i], {
+            _id:2,
+            _text:'river rd',
+            _zxy:['6/32/32'],
+            _center:[0,0]
+        }, t.end);
+    });
+    tape('clear memory, i/o log', function(t) {
+        conf['place'+i]._geocoder.unloadall('grid');
+        conf['place'+i]._original.logs.getGeocoderData = [];
+        conf['place'+i]._original.logs.getTile = [];
+        conf['street'+i]._geocoder.unloadall('grid');
+        conf['street'+i]._original.logs.getGeocoderData = [];
+        conf['street'+i]._original.logs.getTile = [];
+        t.end();
+    });
+});
+
+tape('winding river rd springfield', function(t) {
+    c.geocode('winding river rd  springfield', {}, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'winding river rd, springfield');
+        t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, ['grid,62799'], 'place1: loads 1 grid');
+        t.deepEqual(c.indexes.place1._original.logs.getTile, ['6,32,32'], 'place1: loads 1 tile');
+
+        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData, ['grid,52975','grid,8765','feature,1','feature,2'], 'street1: loads 1 grid, 1 feature per result');
+        t.deepEqual(c.indexes.street1._original.logs.getTile, [], 'street1: loads no tiles (most specific index)');
+        t.end();
+    });
+});
+
+tape('index.teardown', function(assert) {
+    index.teardown();
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -62,7 +62,7 @@ tape('winding river rd springfield', function(t) {
         t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, ['grid,62799'], 'place1: loads 1 grid');
         t.deepEqual(c.indexes.place1._original.logs.getTile, ['6,32,32'], 'place1: loads 1 tile');
 
-        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData, ['grid,52975','grid,8765','feature,1','feature,2'], 'street1: loads 1 grid, 1 feature per result');
+        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData.sort(), ['feature,1','feature,2','grid,52975','grid,8765'], 'street1: loads 1 grid, 1 feature per result');
         t.deepEqual(c.indexes.street1._original.logs.getTile, [], 'street1: loads no tiles (most specific index)');
         t.end();
     });


### PR DESCRIPTION
- Adds io logging to the memsource for logging + testing io for different query scenarios,
- Adds tests to demonstrate that in master it's possible to load the same grid cache shard multiple times during the same query (https://circleci.com/gh/mapbox/carmen/343),
- Adds logic to spatialmatch to dedupe I/O for loading grid cache shards

### Next actions

- [x] Tests pass
- [x] Test IRL
- [ ] Release