### PR TITLE
Cylon

### DIFF
--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -27,7 +27,7 @@ function addVT(source, doc, callback) {
 }
 
 function zxyArray(input) {
-     return input.properties['carmen:zxy'].map(function(zxy) {
+    return input.properties['carmen:zxy'].map(function(zxy) {
         zxy = zxy.split('/');
         zxy[0] = parseInt(zxy[0],10);
         zxy[1] = parseInt(zxy[1],10);

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -28,13 +28,13 @@ function addVT(source, doc, callback) {
 }
 
 function zxyArray(input) {
-	 return input.properties['carmen:zxy'].map(function(zxy) {
-		zxy = zxy.split('/');
-		zxy[0] = parseInt(zxy[0],10);
-		zxy[1] = parseInt(zxy[1],10);
-		zxy[2] = parseInt(zxy[2],10);
-		return zxy
-	});
+     return input.properties['carmen:zxy'].map(function(zxy) {
+        zxy = zxy.split('/');
+        zxy[0] = parseInt(zxy[0],10);
+        zxy[1] = parseInt(zxy[1],10);
+        zxy[2] = parseInt(zxy[2],10);
+        return zxy
+    });
 }
 
 function _addFeature(source, input, vtile_only, callback) {
@@ -48,12 +48,12 @@ function _addFeature(source, input, vtile_only, callback) {
             return zxy[2] + '/' + zxy[0] + '/' + zxy[1]
         });
 
-		var zxys = zxyArray(input);
+        var zxys = zxyArray(input);
     } else if (!input.geometry) {
-		var zxys = zxyArray(input);
+        var zxys = zxyArray(input);
 
         var i = zxys.length;
-		var zxyCoords = [];
+        var zxyCoords = [];
         while (i--) {
             zxyCoords[i] = tilebelt.tileToGeoJSON([zxys[i][1], zxys[i][2], zxys[i][0]]).coordinates;
         }
@@ -62,15 +62,15 @@ function _addFeature(source, input, vtile_only, callback) {
             type: "MultiPolygon",
             coordinates: zxyCoords
         }
-	} else {
-		var zxys = zxyArray(input);
-	}
+    } else {
+        var zxys = zxyArray(input);
+    }
 
 
-	input.geometry = input.geometry || {
-		type: 'Point',
-		coordinates: input.properties['carmen:center']
-	};
+    input.geometry = input.geometry || {
+        type: 'Point',
+        coordinates: input.properties['carmen:center']
+    };
 
     var q = queue();
     for (var i = 0; i < zxys.length; i++) q.defer(function(zxy, done) {

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -5,6 +5,7 @@ var path = require('path');
 var zlib = require('zlib');
 var feature = require('./feature');
 var cover = require('tile-cover');
+var tilebelt = require('tilebelt');
 
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'ogr.input'));
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
@@ -26,30 +27,50 @@ function addVT(source, doc, callback) {
     return _addFeature(source, doc, true, callback);
 }
 
+function zxyArray(input) {
+	 return input.properties['carmen:zxy'].map(function(zxy) {
+		zxy = zxy.split('/');
+		zxy[0] = parseInt(zxy[0],10);
+		zxy[1] = parseInt(zxy[1],10);
+		zxy[2] = parseInt(zxy[2],10);
+		return zxy
+	});
+}
+
 function _addFeature(source, input, vtile_only, callback) {
     if (input._text) {
         input = feature.transform(input);
     }
     input.type = 'Feature';
 
-    input.geometry = input.geometry || {
-        type: 'Point',
-        coordinates: input.properties['carmen:center']
-    };
-
     if (!input.properties['carmen:zxy']) {
         input.properties['carmen:zxy'] = cover.tiles(input.geometry, {min_zoom: source.maxzoom, max_zoom: source.maxzoom}).map(function(zxy) {
             return zxy[2] + '/' + zxy[0] + '/' + zxy[1]
         });
-    }
 
-    var zxys = input.properties['carmen:zxy'].map(function(zxy) {
-        zxy = zxy.split('/');
-        zxy[0] = parseInt(zxy[0],10);
-        zxy[1] = parseInt(zxy[1],10);
-        zxy[2] = parseInt(zxy[2],10);
-        return zxy
-    });
+		var zxys = zxyArray(input);
+    } else if (!input.geometry) {
+		var zxys = zxyArray(input);
+
+        var i = zxys.length;
+		var zxyCoords = [];
+        while (i--) {
+            zxyCoords[i] = tilebelt.tileToGeoJSON([zxys[i][1], zxys[i][2], zxys[i][0]]).coordinates;
+        }
+
+        input.geometry = {
+            type: "MultiPolygon",
+            coordinates: zxyCoords
+        }
+	} else {
+		var zxys = zxyArray(input);
+	}
+
+
+	input.geometry = input.geometry || {
+		type: 'Point',
+		coordinates: input.properties['carmen:center']
+	};
 
     var q = queue();
     for (var i = 0; i < zxys.length; i++) q.defer(function(zxy, done) {

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -3,7 +3,6 @@ var index = require('../../lib/index');
 var mapnik = require('mapnik');
 var path = require('path');
 var zlib = require('zlib');
-var feature = require('./feature');
 var cover = require('tile-cover');
 var tilebelt = require('tilebelt');
 
@@ -38,9 +37,6 @@ function zxyArray(input) {
 }
 
 function _addFeature(source, input, vtile_only, callback) {
-    if (input._text) {
-        input = feature.transform(input);
-    }
     input.type = 'Feature';
 
     if (!input.properties['carmen:zxy']) {

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -40,19 +40,23 @@ tape('index', function(assert) {
     function write1(err) {
         assert.ifError(err);
         addFeature(conf.index, {
-            _id:38,
-            _text:'Canada',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:38,
+            properties: {
+                'carmen:text':'Canada',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, write2);
     }
     function write2(err) {
         assert.ifError(err);
         addFeature(conf.index, {
-            _id:39,
-            _text:'Brazil',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:39,
+            properties: {
+                'carmen:text':'Brazil',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, store);
     }
     function store(err) {

--- a/test/geocode-unit.dict-collision.test.js
+++ b/test/geocode-unit.dict-collision.test.js
@@ -14,10 +14,12 @@ var c = new Carmen(conf);
 
 tape('index unicode place', function(t) {
     var place = {
-        _id: 1,
-        _text: '京都市',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id: 1,
+        properties: {
+            'carmen:text': '京都市',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.place, place, t.end);
 });

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -24,46 +24,56 @@ var conf = {
 var c = new Carmen(conf);
 tape('index province', function(t) {
     var province = {
-        _id:1,
-        _text:'new york, ny',
-        _zxy:['6/32/32','6/34/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'new york, ny',
+            'carmen:zxy':['6/32/32','6/34/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.province, province, t.end);
 });
 tape('index city 1', function(t) {
     var city = {
-        _id:1,
-        _text:'new york, ny',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'new york, ny',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.city, city, t.end);
 });
 tape('index city 2', function(t) {
     var city = {
-        _id:2,
-        _text:'tonawanda',
-        _zxy:['6/34/32'],
-        _center:[14.0625, -2.8079929095776683]
+        id:2,
+        properties: {
+            'carmen:text':'tonawanda',
+            'carmen:zxy':['6/34/32'],
+            'carmen:center':[14.0625, -2.8079929095776683]
+        }
     };
     addFeature(conf.city, city, t.end);
 });
 tape('index street 1', function(t) {
     var street = {
-        _id:1,
-        _text:'west st',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'west st',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.street, street, t.end);
 });
 tape('index street 2', function(t) {
     var street = {
-        _id:2,
-        _text:'west st',
-        _zxy:['6/34/32'],
-        _center:[14.0625, -2.8079929095776683]
+        id:2,
+        properties: {
+            'carmen:text':'west st',
+            'carmen:zxy':['6/34/32'],
+            'carmen:center':[14.0625, -2.8079929095776683]
+        }
     };
     addFeature(conf.street, street, t.end);
 });

--- a/test/geocode-unit.io-reverse.test.js
+++ b/test/geocode-unit.io-reverse.test.js
@@ -24,34 +24,42 @@ tape('ready', function(assert) {
 
 tape('index country', function(t) {
     addFeature(conf.country, {
-        _id:1,
-        _text:'us',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'us',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     }, t.end);
 });
 tape('index region', function(t) {
     addFeature(conf.region, {
-        _id:1,
-        _text:'ohio',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'ohio',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     }, t.end);
 });
 tape('index place', function(t) {
     addFeature(conf.place, {
-        _id:1,
-        _text:'springfield',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'springfield',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     }, t.end);
 });
 tape('index street', function(t) {
     addFeature(conf.street, {
-        _id:1,
-        _text:'river rd',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'river rd',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center': [0,0]
+        }
     }, t.end);
 });
 

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -27,34 +27,42 @@ tape('ready', function(assert) {
 [1,2,3].forEach(function(i) {
     tape('index place ' + i, function(t) {
         addFeature(conf['place'+i], {
-            _id:1,
-            _text:'springfield',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:1,
+            properties: {
+                'carmen:text':'springfield',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, t.end);
     });
     tape('index street ' + i, function(t) {
         addFeature(conf['street'+i], {
-            _id:1,
-            _text:'winding river rd',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:1,
+            properties: {
+                'carmen:text':'winding river rd',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, t.end);
     });
     tape('index street ' + i, function(t) {
         addFeature(conf['street'+i], {
-            _id:2,
-            _text:'river rd',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:2,
+            properties: {
+                'carmen:text':'river rd',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, t.end);
     });
     tape('index street ' + i, function(t) {
         addFeature(conf['street'+i], {
-            _id:3,
-            _text:'springfield st',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:3,
+            properties: {
+                'carmen:text':'springfield st',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, t.end);
     });
 });

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -15,19 +15,23 @@ var c = new Carmen(conf);
 
 tape('index country', function(t) {
     var country = {
-        _id:1,
-        _text:'country',
-        _zxy:['1/0/0'],
-        _center:[-100,60]
+        id:1,
+        properties: {
+            'carmen:text':'country',
+            'carmen:zxy':['1/0/0'],
+            'carmen:center':[-100,60]
+        }
     };
     addFeature(conf.country, country, t.end);
 });
 tape('index country', function(t) {
     var country = {
-        _id:2,
-        _text:'country',
-        _zxy:['1/0/1'],
-        _center:[-60,-20]
+        id:2,
+        properties: {
+            'carmen:text':'country',
+            'carmen:zxy':['1/0/1'],
+            'carmen:center':[-60,-20]
+        }
     };
     addFeature(conf.country, country, t.end);
 });
@@ -35,37 +39,45 @@ tape('index country', function(t) {
 //Across layers
 tape('index province', function(t) {
     var province = {
-        _id:1,
-        _text:'province',
-        _zxy:['6/17/24'],
-        _center:[-80,40]
+        id:1,
+        properties: {
+            'carmen:text':'province',
+            'carmen:zxy':['6/17/24'],
+            'carmen:center':[-80,40]
+        }
     };
     addFeature(conf.province, province, t.end);
 });
 tape('index province', function(t) {
     var country = {
-        _id:3,
-        _text:'province',
-        _zxy:['1/1/0'],
-        _center:[145,70]
+        id:3,
+        properties: {
+            'carmen:text':'province',
+            'carmen:zxy':['1/1/0'],
+            'carmen:center':[145,70]
+        }
     };
     addFeature(conf.country, country, t.end);
 });
 tape('index province', function(t) {
     var province = {
-        _id:2,
-        _text:'fakeprov',
-        _zxy:['6/14/18'],
-        _center:[-100,60]
+        id:2,
+        properties: {
+            'carmen:text':'fakeprov',
+            'carmen:zxy':['6/14/18'],
+            'carmen:center':[-100,60]
+        }
     };
     addFeature(conf.province, province, t.end);
 });
 tape('index province', function(t) {
     var province = {
-        _id:3,
-        _text:'fakeprov',
-        _zxy:['6/21/35'],
-        _center:[-60,-20]
+        id:3,
+        properties: {
+            'carmen:text':'fakeprov',
+            'carmen:zxy':['6/21/35'],
+            'carmen:center':[-60,-20]
+        }
     };
     addFeature(conf.province, province, t.end);
 });

--- a/test/geocode-unit.scorefactor.test.js
+++ b/test/geocode-unit.scorefactor.test.js
@@ -19,22 +19,26 @@ var addFeature = require('../lib/util/addfeature');
         var q = queue(1);
         for (var i = 1; i < 41; i++) q.defer(function(i, done) {
             addFeature(conf.place, {
-                _id:i,
-                _score:10,
-                _text:'testplace',
-                _zxy:['6/32/32'],
-                _center:[0,0]
+                id:i,
+                properties: {
+                    'carmen:score':10,
+                    'carmen:text':'testplace',
+                    'carmen:zxy':['6/32/32'],
+                    'carmen:center':[0,0]
+                }
             }, done);
         }, i);
         q.awaitAll(t.end);
     });
     tape('index big score (noise)', function(t) {
         addFeature(conf.country, {
-            _id:1,
-            _score: 1e9,
-            _text:'ignoreme',
-            _zxy:['6/32/32'],
-            _center:[0,0]
+            id:1,
+            properties: {
+                'carmen:score': 1e9,
+                'carmen:text':'ignoreme',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
         }, t.end);
     });
     tape('index big score (signal)', function(t) {

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -18,28 +18,34 @@ var conf = {
 var c = new Carmen(conf);
 tape('index province', function(t) {
     var province = {
-        _id:1,
-        _text:'connecticut, ct',
-        _zxy:['6/32/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'connecticut, ct',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.province, province, t.end);
 });
 tape('index city', function(t) {
     var city = {
-        _id:1,
-        _text:'windsor',
-        _zxy:['6/32/32','6/33/32'],
-        _center:[0,0]
+        id:1,
+        properties: {
+            'carmen:text':'windsor',
+            'carmen:zxy':['6/32/32','6/33/32'],
+            'carmen:center':[0,0]
+        }
     };
     addFeature(conf.city, city, t.end);
 });
 tape('index street', function(t) {
     var street = {
-        _id:1,
-        _text:'windsor ct',
-        _zxy:['6/33/32'],
-        _center:[360/64,0]
+        id:1,
+        properties: {
+            'carmen:text':'windsor ct',
+            'carmen:zxy':['6/33/32'],
+            'carmen:center':[360/64,0]
+        }
     };
     addFeature(conf.street, street, t.end);
 });


### PR DESCRIPTION
Update more of our older `_zxy` based unit tests to the newer GeoJSON compliant format.

Discovered addFeature code was not generating Polygons out of non-geometry input (`carmen:zxy` only / no geometry)  and instead using the `carmen:center` field to generate a point geometry. This has been rectified to generate a tilecover using the zxys. 