### PR TITLE
Iratus Bug fix

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -70,7 +70,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 }
             }
             loaded = filtered.loaded;
-            results = filtered.resutls;
+            results = filtered.results;
         }
 
         var verified = verifyFeatures(query, geocoder, results, loaded, options);

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -51,18 +51,26 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         if (err) return callback(err);
 
         if (options.stacks) {
-            var filtered = [];
+            var filtered = {
+                loaded: [],
+                results: []
+            };
             for (var j = 0; j < loaded.length; j++) {
                 // getFeatureByCover does not always return a feature.
                 if (!loaded[j]) continue;
 
                 if (loaded[j].properties['carmen:geocoder_stack']) {
-                    if (options.stacks.indexOf(loaded[j].properties['carmen:geocoder_stack']) > -1) filtered.push(loaded[j]);
+                    if (options.stacks.indexOf(loaded[j].properties['carmen:geocoder_stack']) > -1) {
+                        filtered.loaded.push(loaded[j]);
+                        filtered.results.push(results[j]);
+                    }
                 } else {
-                    filtered.push(loaded[j]);
+                    filtered.loaded.push(loaded[j]);
+                    filtered.results.push(results[j]);
                 }
             }
-            var loaded = filtered;
+            loaded = filtered.loaded;
+            results = filtered.resutls;
         }
 
         var verified = verifyFeatures(query, geocoder, results, loaded, options);

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -289,7 +289,6 @@ var addFeature = require('../lib/util/addfeature');
     tape('check stack/idx agreement', function(t) {
         c.geocode('XXX', { stacks: ['ca'] }, function(err, res) {
             t.ifError(err);
-            console.log(res);
             t.equals(res.features.length, 1);
             t.equals(res.features[0].id, 'place.2');
             t.end();

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -247,6 +247,56 @@ var addFeature = require('../lib/util/addfeature');
     });
 })();
 
+// Test idx assignment
+(function() {
+    var conf = {
+        country: new mem({
+            maxzoom: 6,
+            geocoder_stack: [ 'us', 'ca' ]
+        }, function() {}),
+        place: new mem({
+            maxzoom: 6,
+            geocoder_stack: [ 'us', 'ca' ]
+        }, function() {})
+    };
+    var c = new Carmen(conf);
+
+    tape('index country high score (us)', function(t) {
+        addFeature(conf.country, {
+            id:1,
+            properties: {
+                'carmen:text': 'XXX',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0],
+                'carmen:score': 999,
+                'carmen:geocoder_stack': 'us'
+            }
+        }, t.end);
+    });
+    tape('index place low score (ca)', function(t) {
+        addFeature(conf.place, {
+            id:2,
+            properties: {
+                'carmen:text':'XXX',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0],
+                'carmen:score': 0,
+                'carmen:geocoder_stack': 'ca'
+            }
+        }, t.end);
+    });
+
+    tape('check stack/idx agreement', function(t) {
+        c.geocode('XXX', { stacks: ['ca'] }, function(err, res) {
+            t.ifError(err);
+            console.log(res);
+            t.equals(res.features.length, 1);
+            t.equals(res.features[0].id, 'place.2');
+            t.end();
+        });
+    });
+})();
+
 //Test existing/non-existing index level geocoder_stack
 (function() {
     var conf = {


### PR DESCRIPTION
@sbma44 discovered a bug in the stack filtering code. If a highly scored feature not part of a desired stack was filtered out of the results, the parallel array of metadata would be off by one and match incorrectly.

This is easily fixed by ensuring filtering removes the array element from both the features array as well as the metadata array.