### PR TITLE
avoid massive callback stacks

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -159,7 +159,7 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
     if (!phrasematches[idx]) return stacks;
 
     // Recurse, skipping this level
-    stacks.push.apply(stacks, stackable(phrasematches, idx+1, mask, nmask, stack, relev));
+    stacks = stacks.concat(stackable(phrasematches, idx+1, mask, nmask, stack, relev));
 
     // Recurse, including this level
     for (var i = 0; i < phrasematches[idx].length; i++) {
@@ -193,7 +193,7 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
             stacks.push(targetStack);
         }
 
-        stacks.push.apply(stacks, stackable(phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev));
+        stacks = stacks.concat(stackable(phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev));
     }
 
     if (idx === 0) stacks.sort(sortByRelevLengthIdx);


### PR DESCRIPTION
We've seen several errors around `push.apply` generating massive callback stacks. This has been resolved twice before in carmen by migrating to the faster and non-callback based approach of `concat`

cc/ @yhahn @karenzshea 
