### PR TITLE
Ensure query lengths don't cause stack errors

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -24,6 +24,11 @@ module.exports = function(geocoder, query, options, callback) {
     options.allow_dupes = options.allow_dupes || false;
     options.indexes = options.indexes || false;
 
+    //Limit query length to 256 characters
+    if (query.length > 256) {
+        return callback(errcode('Query too long - ' + query.length + '/256 characters', 'EINVALID'));
+    }
+
     // Types option
     if (options.types) {
         if (!Array.isArray(options.types) || options.types.length < 1)
@@ -63,6 +68,11 @@ module.exports = function(geocoder, query, options, callback) {
 
     // Reverse geocode: lon,lat pair. Provide the context for this location.
     var tokenized = termops.tokenize(query, true);
+
+    if (tokenized.length > 20) {
+        return callback(errcode('Query too long - ' + tokenized.length + '/20 tokens', 'EINVALID'));
+    }
+
     if (tokenized.length === 2 &&
         'number' === typeof tokenized[0] &&
         'number' === typeof tokenized[1]) {


### PR DESCRIPTION
- Enforce max query length of 256 chars
- Enforce max token length of 20 tokens
- Unit tests

cc/ @karenzshea @yhahn @ianshward 