### PR TITLE
!= vs !===

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -6,7 +6,7 @@ module.exports = indexdocs;
 module.exports.teardown = teardown;
 
 function indexdocs(docs, freq, zoom, geocoder_tokens, callback) {
-    if (typeof zoom != 'number')
+    if (typeof zoom !== 'number')
         return callback(new Error('index has no zoom'));
     if (zoom < 0)
         return callback(new Error('zoom must be greater than 0 --- zoom was '+zoom));


### PR DESCRIPTION
I know, I know, the realistically it's just a best practice and not a bug. Just something that immediately catches my eye when reading Javascript.

In `index-worker.js` around line 162 there is `if (zxy[1] < 0 || zxy[2] < 0) continue;`. In the whole `load_docs` subroutine any data that looks off is either handled by a warning and/or early exit. I'm surprised in that line faulty input is skipped silently. (Of course negative tile number and zoom levels shouldn't ever happen to start with).

In `scripts/carmen.js` there is `('  --proximity="lat,lng"   Favour results by proximity');`. It should say `lng,lat`.

The `termops.getIndexablePhrases` is only called in one place. It returns an array of strings. Right after the caller checks for duplicate entries. Wouldn't it make more sense if the function returned unique phrases (sorted by score)? Actually it looks like it already does.

As an optimization in the past I used to cache term frequency between index builds, assuming that incremental changes rarely introduce new high frequency terms. That assumes of course the normalization logic stayed the same. I'm surprised you don't cut out very high frequency words (in english: the, a. French: le, la etc).

Without a format description (required, optional properties) of `doc` to import I wouldn't be able to import any test data, e.g. a small OSM extract. All OSM/TIGER/openaddresses converters seem to be private repositories. The fixtures are just countries. I'm not saying you should open source conversion scripts, but documenting the data structure would be nice. (I usually import Monaco)

Last year I worked on place popularity based on wikipedia/wikidata interlinking. Sadly couldn't finish it for my FOSSGIS conferences so it remained a proposal during my talk. Would that data set be interesting for your geocoder as well? mtm@opencagedata.com