### PR TITLE
make sure timer for getIndexableDocs gets started

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,13 +58,13 @@ function index(geocoder, from, to, options, callback) {
     getDocs(options);
 
     function getDocs(options) {
+        if (TIMER) console.time('getIndexableDocs');
         if (!from) { //Use new stream transform interface
             if (!inStream) return indexDocs(null, [], options);
             docs = [];
             inStream.resume();
 
         } else { //Use old tilelive interface
-            if (TIMER) console.time('getIndexableDocs');
             from.getIndexableDocs(options, indexDocs);
         }
     }


### PR DESCRIPTION
Inside `indexDocs()` there's a `console.timeEnd` which fails if this timer was never started.

Of course you may chose to delete the timer or the if-clause completely since it applies less to the streaming interface that's now in use.