### PR TITLE
make sure timer for getIndexableDocs gets started

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,7 @@ function index(geocoder, from, to, options, callback) {
     getDocs(options);
 
     function getDocs(options) {
+        if (TIMER) console.time('getIndexableDocs');
         if (!inStream) return indexDocs(null, [], options);
         docs = [];
         inStream.resume();


### PR DESCRIPTION
Inside `indexDocs()` there's a `console.timeEnd` which fails if this timer was never started.