### PR TITLE
during index update, make dictcache writable first

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var termops = require('./util/termops'),
     uniq = require('./util/uniq'),
     ops = require('./util/ops'),
     queue = require('queue-async'),
+    dawgcache = require('./util/dawg'),
     indexdocs = require('./indexer/indexdocs'),
     split = require('split'),
     TIMER = process.env.TIMER
@@ -171,6 +172,10 @@ function update(source, docs, options, callback) {
                 return source._commit ? source._commit(callback) : callback();
             });
         }, features);
+
+        //create a new empty writeable cache
+        source._dictcache = new dawgcache;
+
         setParts(patch.grid, 'grid');
         setText(patch.text);
         q.awaitAll(callback);


### PR DESCRIPTION
`update()` receives a CarmenSource instance.

That `source` might already contain geocoder data and thus during index opening/loading `source._dictcache` is set to `ReadCache` instance. See https://github.com/mapbox/carmen/blob/master/lib/util/dawg.js#L43

To be able to update the `._dictcache` we'd need a `WriteCache` though.

I opted to clear the `._dictcache` since the update operation seems to be a full overwrite without rollback on error. I couldn't find a good place to add test to an existing test file.