### PR TITLE
Bump carmen-cache to 0.11.2 and remove test that depends on hasDict

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.11.1",
+    "carmen-cache": "0.11.2",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -234,14 +234,6 @@ test('index', function(t) {
             q.end();
         });
     });
-    t.test('loadall stat ignores Dict', function(q) {
-        q.ok(!conf.to._geocoder.hasDict('stat', 0));
-        carmen.loadall(conf.to, 'stat', 1, function(err) {
-            q.ifError(err);
-            q.ok(!conf.to._geocoder.hasDict('stat', 0));
-            q.end();
-        });
-    });
     t.test('confirm that iterator works', function(q) {
         var monotonic = true;
         var output = [];


### PR DESCRIPTION
This updates carmen-cache, and removes one carmen test that assumes no-longer-present dict functionality in carmen-cache now that dict is gone (and also assumes that "stat" is sharded, which it no longer is).