### PR TITLE
remove check for carmen:center at load time

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -100,8 +100,6 @@ function runChecks(doc, zoom) {
         return 'doc has no properties on id:' + doc.id;
     } else if (!doc.properties["carmen:text"]) {
         return 'doc has no carmen:text on id:' + doc.id;
-    } else if (!doc.properties["carmen:center"]) {
-        return 'doc has no carmen:center on id:' + doc.id;
     } else if (doc.properties["carmen:geocoder_stack"] &&
         typeof doc.properties["carmen:geocoder_stack"] !== 'string') {
         return 'geocoder_stack must be a string value';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -154,8 +154,9 @@ test('index.update freq', function(t) {
         });
     });
     t.test('indexes doc with geometry and no carmen:center', function(q) {
-        index.update(conf.to, [{ id:1, type: 'Feature', properties: { 'carmen:text': 'main st' }, geometry:{ type:'Point', coordinates: [-75.598211,38.367333]}}], { zoom: 6 }, function(err) {
-            q.equal('Error: doc has no carmen:center on id:1', err.toString());
+        var doc = { id:1, type: 'Feature', properties: { 'carmen:text': 'main st' }, geometry:{ type:'Point', coordinates: [-75.598211,38.367333]}};
+        index.update(conf.to, [doc], { zoom: 6 }, function(err, res, too) {
+            q.ok(doc.properties['carmen:center'], 'carmen:center has been set');
             q.end();
         });
     });

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -58,7 +58,7 @@ tape('indexdocs.loadDoc', function(assert) {
 });
 
 tape('indexdocs.loadDoc - No Center', function(assert) {
-var token_replacer = token.createReplacer({});
+    var token_replacer = token.createReplacer({});
     var patch;
     var tokens;
     var freq;

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -40,6 +40,64 @@ tape('indexdocs.loadDoc', function(assert) {
     // Indexes single doc.
     err = indexdocs.loadDoc(patch, doc, freq, zoom, token_replacer);
     assert.ifError(err);
+
+    assert.deepEqual(Object.keys(patch.grid).length, 8);
+    assert.deepEqual(patch.grid[Object.keys(patch.grid)[0]].length, 1);
+    assert.deepEqual(grid.decode(patch.grid[Object.keys(patch.grid)[0]][0]), {
+        id: 1,
+        relev: 1,
+        score: 4, // scales score based on max score value (100)
+        x: 32,
+        y: 32
+    });
+    assert.deepEqual(patch.docs.length, 1);
+    assert.deepEqual(patch.docs[0], doc);
+    assert.deepEqual(patch.text, ['xmain st', 'xmain']);
+
+    assert.end();
+});
+
+tape('indexdocs.loadDoc - No Center', function(assert) {
+var token_replacer = token.createReplacer({});
+    var patch;
+    var tokens;
+    var freq;
+    var zoom;
+    var doc;
+    var err;
+
+    patch = { grid:{}, docs:[], text:[] };
+    freq = {};
+    tokens = ['main', 'st'];
+    zoom = 6;
+    doc = {
+        id: 1,
+        type: "Feature",
+        properties: {
+            'carmen:text': 'main st',
+            'carmen:zxy': ['6/32/32', '14/16384/32'],
+            'carmen:score': 100
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        }
+    };
+
+    freq[0] = [101];
+    freq[1] = [200];
+    freq[termops.encodeTerm(tokens[0])] = [1];
+    freq[termops.encodeTerm(tokens[1])] = [100];
+
+    assert.deepEqual(doc.properties['carmen:center'], undefined);
+    assert.deepEqual(doc.properties['carmen:zxy'], ['6/32/32', '14/16384/32']);
+
+    // Load doc without center, check that center gets set
+    err = indexdocs.loadDoc(patch, doc, freq, zoom, token_replacer);
+    assert.ifError(err);
+    assert.deepEqual(doc.properties['carmen:center'],[0,0]);
+    assert.deepEqual(doc.properties['carmen:zxy'], ['6/32/32', '14/16384/32']);
+
     assert.deepEqual(Object.keys(patch.grid).length, 8);
     assert.deepEqual(patch.grid[Object.keys(patch.grid)[0]].length, 1);
     assert.deepEqual(grid.decode(patch.grid[Object.keys(patch.grid)[0]][0]), {
@@ -135,4 +193,3 @@ tape('indexdocs.runChecks', function(assert) {
     }, 12), '');
     assert.end();
 });
-


### PR DESCRIPTION
Carmen will fail if you attempt to index features that do not have a center set.

From chat with @ingalls:

>ingalls [4:13 PM] 
@sbma44: @mattficke Carmen won’t actually generate centres
it will only correct them if there are invalid centres
so the centre column has to be populated with a valid lon/lat coord
or else it will hard fail
We should consider changing this as carmen’s centres are perfectly fine

This check seems to be redundant and causes unnecessary failures since we also check for and fix the center with this code:
```js
if (!doc.properties["carmen:center"] || !verifyCenter(doc.properties["carmen:center"], tiles)) {
        console.warn('carmen:center did not fall within the provided geometry for %s (%s). Calculating new point on surface.',
            doc.id, doc.properties["carmen:text"]);
        doc.properties["carmen:center"] = centroid(doc.geometry).geometry.coordinates;
        if (!verifyCenter(doc.properties["carmen:center"], tiles)) {
            return 'Invalid carmen:center provided, and unable to calculate corrected centroid. Verify validity of doc.geometry for doc id:' + doc.id;
        } else {
            console.warn('new: carmen:center: ', doc.properties["carmen:center"]);
            console.warn('new: zxy:    ', doc.properties['carmen:zxy']);
        }
    }
```
This removes the first check for `carmen:center` that runs before carmen attempts to fix the issue.