### PR TITLE
Address cluster CAPS

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -159,6 +159,16 @@ function loadDoc(patch, doc, freq, zoom, token_replacer) {
         }
     }
 
+    //All values in an addresscluster should be lowercase so that the lowercased input query always matches the addresscluster
+    if (doc.properties['carmen:addressnumber']) {
+        for (var addr_it = 0; addr_it < doc.properties['carmen:addressnumber'].length; addr_it++) {
+            doc.properties['carmen:addressnumber'][addr_it] = 
+                typeof doc.properties['carmen:addressnumber'][addr_it] === 'string' ?
+                doc.properties['carmen:addressnumber'][addr_it].toLowerCase() :
+                doc.properties['carmen:addressnumber'][addr_it];
+        }
+    }
+
     if (!doc.bbox && (doc.geometry.type === 'MultiPolygon' || doc.geometry.type === 'Polygon')) {
         doc.bbox = extent(doc.geometry);
     }

--- a/lib/pure/addresscluster.js
+++ b/lib/pure/addresscluster.js
@@ -1,6 +1,6 @@
 module.exports = function(feature, address) {
     // Check both forms of the address (raw, number-parsed)
-    var a1 = address;
+    var a1 = typeof address === 'string' ? address.toLowerCase() : address;
     var a2 = typeof address === 'string' ? address.replace(/\D/, '') : address;
 
     var cluster = feature.properties['carmen:addressnumber'];

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -8,6 +8,37 @@ var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
+//Make sure that capital letters are lowercased on indexing to match input token
+(function() {
+    var conf = {
+        address: new mem({maxzoom: 6, geocoder_address: 1}, function() {})
+    };
+    var c = new Carmen(conf);
+    tape('index alphanum address', function(t) {
+        var address = {
+            id:1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0],
+                'carmen:addressnumber': ['9B', '10C', '7']
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[0,0],[0,0]]
+            }
+        };
+        addFeature(conf.address, address, t.end);
+    });
+    tape('test address index for alphanumerics', function(t) {
+        c.geocode('9B FAKE STREET', { limit_verify: 1 }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
+            t.equals(res.features[0].relevance, 0.99);
+            t.end();
+        });
+    });
+})();
+
 (function() {
     var conf = {
         address: new mem({maxzoom: 6, geocoder_address: 1}, function() {})


### PR DESCRIPTION
Currently address clusters are retained as they are submitted to carmen. So if `24A` is submitted in a cluster it remains `24A`, `24a` remains `24a` etc. The input however is always lowercase. Since the way these are matched up is simply a javascript array, if there is a case different, a match doesn't occur.

`["24a", "24A"]`

This PR ensures that both the query address and the address cluster array are always lowercased.

cc/ @yhahn @sbma44 