### PR TITLE
[carmen-token-replacement] Update + reenable decollide

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -295,33 +295,30 @@ function decollide(replacer, doc, subq) {
     // remove leading/trailing numtokens.
     subq = subq.replace(/^([0-9]*[#]+)/,'').replace(/([0-9]*[#]+)$/,'');
 
-    var texts = token.replaceToken(replacer, doc.properties['carmen:text']).split(',');
+    var texts = replaceTokenPermutations(replacer, doc.properties['carmen:text']).join('');
     var keys = Object.keys(doc.properties);
     var length = keys.length;
     for (var i = 0; i < length; i ++) {
         var code = keys[i].match(/text_(.+)/);
         if (code && mun.hasLanguage(code[1]) &&
-            doc.properties[keys[i]]) texts = texts.concat(token.replaceToken(replacer, doc.properties[keys[i]]).split(','));
+            doc.properties[keys[i]]) texts += replaceTokenPermutations(replacer, doc.properties[keys[i]]).join('');
     }
 
-    var a = texts.length;
     var fails = 0;
-    while (a--) {
-        var text = unidecode(texts[a].toLowerCase()).toLowerCase().trim();
-        var textHash = {
-            32: true, // ' ' for spaces
-        };
-        var b = text.length;
-        while (b--) textHash[text.charCodeAt(b)] = true;
-        var c = subq.length;
-        while (c--) if (!textHash[subq.charCodeAt(c)]) {
-            fails++;
-            break;
-        }
+    var text = unidecode(texts.toLowerCase()).toLowerCase().trim();
+    var textHash = {
+        32: true, // ' ' for spaces
+    };
+    var b = text.length;
+    while (b--) textHash[text.charCodeAt(b)] = true;
+    var c = subq.length;
+    while (c--) if (!textHash[subq.charCodeAt(c)]) {
+        fails++;
+        break;
     }
     // if subq fails to match every single text, consider it
     // an fnv1a false positive for this feature.
-    return fails !== texts.length;
+    return fails === 0;
 }
 
 function parseSemiNumber(_) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -150,7 +150,7 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
         if (checks) {
             // Compare feature text to matching input subquery as a safeguard
             // against fnv1a collisions.
-            // if (!termops.decollide(source.token_replacer, feat, cover.text)) continue;
+            if (!termops.decollide(source.token_replacer, feat, cover.text)) continue;
             if (options.bbox && !bbox.inside(feat.properties["carmen:center"], options.bbox)) continue;
             feat.properties["carmen:score"] = feat.properties["carmen:score"] || 0;
             feat.properties["carmen:extid"] = source.type + '.' + feat.id;


### PR DESCRIPTION
Quick adjustment to reenable `decollide()` for the `carmen-token-replacement` branch.

I'm seeing that this isn't enough to address our test changes though so I may :mag: :eyes: for a deep dive...

cc @aarthykc @arunasank 
