### PR TITLE
Dedup addresses w/address vs w/o [WIP]

### DIFF
--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -56,6 +56,31 @@ tape('dedupe', function(assert) {
 
     features = [
         {
+            place_name: 'Dandenong Road, Mount Ommaney',
+            text: 'Dandenong Road',
+            center:[0,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0,0]
+            }
+        },
+        {
+            place_name: '171 Dandenong Road, Mount Ommaney',
+            text: 'Dandenong Road',
+            address: 171,
+            center:[0,0],
+            geometry: {
+                type:'Point',
+                coordinates:[0,0]
+            }
+        }
+    ];
+    assert.deepEqual(dedupe(features), [
+        features[1]
+    ], 'dedup should dedup accross streets w/ address vs without');
+
+    features = [
+        {
             place_name: 'main st springfield',
             text: 'main st',
             center:[0,0],


### PR DESCRIPTION
<img width="447" alt="screenshot 2016-07-13 18 18 51" src="https://cloud.githubusercontent.com/assets/1297009/16821820/6a29d224-4926-11e6-8afe-e265f7683cf5.png">

This really bothers me. WIP method to fix it.

cc/ @mapbox/geocoding-gang 
