### PR TITLE
[WIP] Additional Score Filter

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -33,8 +33,9 @@ module.exports = function(geocoder, query, options, callback) {
     }
 
     //scoreAbove option
-    if (options.scoreAbove && Number.isNaN(options.scoreAbove)) {
-        return callback(errcode('--scoreAbove can only be a number'));
+    if (options.scoreAbove) {
+        if (!Number.isNaN(options.scoreAbove) || (options.scoreAbove < 1 || options.scoreAbove > 100))
+            return callback(errcode('--scoreAbove must be a number between 0 and 100'));
     }
 
     // Types option

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -32,6 +32,11 @@ module.exports = function(geocoder, query, options, callback) {
         return callback(errcode('Query too long - ' + query.length + '/' + constants.MAX_QUERY_CHARS + ' characters', 'EINVALID'));
     }
 
+    //scoreAbove option
+    if (options.scoreAbove && Number.isNaN(options.scoreAbove)) {
+        return callback(errcode('--scoreAbove can only be a number'));
+    }
+
     // Types option
     if (options.types) {
         if (!Array.isArray(options.types) || options.types.length < 1)

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -89,6 +89,7 @@ function spatialmatch(query, phrasematches, options, callback) {
                 while (m--) {
                     feature[m].mask = byIdx[feature[m].idx].mask;
                     feature[m].text = byIdx[feature[m].idx].text;
+                    feature[m].scorefactor = byIdx[feature[m].idx].scorefactor;
                     feature[m].score = feature[m].score * byIdx[feature[m].idx].scorefactor;
                     feature[m].scoredist = feature[m].scoredist * byIdx[feature[m].idx].scorefactor;
                 }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -105,16 +105,26 @@ function dropFeature(geocoder, options, results, callback) {
         }
 
         function scoreMatch() {
-            return (options.scoreAbove && (cover.score > options.scoreAbove));
+            return (options.scoreAbove && (cover.score >= options.scoreAbove));
         }
 
-        if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
-            (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
-            (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||
-            (options.stacks && options.types && typeMatch() && stackMatch()) ||
-            (options.stacks && options.scoreAbove && scoreMatch() && stackMatch()) ||
-            (options.types && options.scoreAbove && typeMatch() && scoreMatch()) ||
-            (options.stacks && options.types && options.scoreAbove && typeMatch() && stackMatch() && scoreMatch())) {
+        function qualifyResult(result, options) {
+            var yes = options.types || options.stacks || options.scoreAbove;
+            if (options.types) {
+                yes = yes && typeMatch();
+            }
+            if (options.stacks) {
+                yes = yes && stackMatch();
+            }
+            if (options.scoreAbove) {
+                yes = yes && scoreMatch();
+            }
+            if (yes) {
+                return result;
+            }
+        }
+
+        if (qualifyResult(results[i], options)) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -104,6 +104,10 @@ function dropFeature(geocoder, options, results, callback) {
             }
         }
 
+        function scoreMatch() {
+            return (options.scoreAbove && (cover.score > options.scoreAbove));
+        }
+
         if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
             (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
             (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -27,7 +27,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     options.limit_verify = options.limit_verify || 10;
 
     // Limit features to those matching specified types.
-    if (options.types || options.stacks) {
+    if (options.types || options.stacks || options.scoreAbove) {
         results = dropFeature(geocoder, options, results);
     }
 
@@ -104,10 +104,13 @@ function dropFeature(geocoder, options, results, callback) {
             }
         }
 
-        if ((options.types && !options.stacks && typeMatch()) ||
-            (options.stacks && !options.types && stackMatch()) ||
-            (options.stacks && options.types && typeMatch() && stackMatch())) {
-
+        if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
+            (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
+            (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||
+            (options.stacks && options.types && typeMatch() && stackMatch()) ||
+            (options.stacks && options.scoreAbove && scoreMatch() && stackMatch()) ||
+            (options.types && options.scoreAbove && typeMatch() && scoreMatch()) ||
+            (options.stacks && options.types && options.scoreAbove && typeMatch() && stackMatch() && scoreMatch())) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -105,7 +105,7 @@ function dropFeature(geocoder, options, results, callback) {
         }
 
         function scoreMatch() {
-            return (options.scoreAbove && (cover.score >= options.scoreAbove));
+            return (options.scoreAbove && (cover.score >= options.scoreAbove * 0.01 * cover.scoreFactor));
         }
 
         function qualifyResult(result, options) {

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -78,15 +78,39 @@ tape('verifymatch.dropFeature', function(t) {
             ]
         };
         var options = {
-            scoreAbove: 1
+            scoreAbove: 100
         };
         var results = [
-            [{ idx: 0, id: 0, score: 200 }],
+            [{ idx: 0, id: 0, score: 200, scoreFactor:2 }],
             [{ idx: 1, id: 1, score: 0 }]
         ];
         var res = verifymatch.dropFeature(geocoder, options, results);
         t.equals(res.length, 1);
         t.equals(res[0][0].id, 0);
+        q.end()
+    });
+
+    t.test('dropFeature scoreAbove', function(q) {
+        var geocoder = {
+            byidx: [
+                {
+                    stack: ['ca']
+                },
+                {
+                    stack: ['us']
+                }
+            ]
+        };
+        var options = {
+            scoreAbove: 100
+        };
+        var results = [
+            [{ idx: 0, id: 0, score: 2, scoreFactor: 5 }],
+            [{ idx: 1, id: 1, score: 5, scoreFactor: 3 }]
+        ];
+        var res = verifymatch.dropFeature(geocoder, options, results);
+        t.equals(res.length, 1);
+        t.equals(res[0][0].id, 1);
         q.end()
     });
 

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -66,6 +66,30 @@ tape('verifymatch.dropFeature', function(t) {
         q.end()
     });
 
+    t.test('dropFeature scoreAbove', function(q) {
+        var geocoder = {
+            byidx: [
+                {
+                    stack: ['ca']
+                },
+                {
+                    stack: ['us']
+                }
+            ]
+        };
+        var options = {
+            scoreAbove: 1
+        };
+        var results = [
+            [{ idx: 0, id: 0, score: 200 }],
+            [{ idx: 1, id: 1, score: 0 }]
+        ];
+        var res = verifymatch.dropFeature(geocoder, options, results);
+        t.equals(res.length, 1);
+        t.equals(res[0][0].id, 0);
+        q.end()
+    });
+
     t.test('dropFeature types & stacks', function(q) {
         var geocoder = {
             byidx: [


### PR DESCRIPTION
Filter features by a score X that's a CLI parameter. This will also mean that we _may_ expose the scores of features in the result json.

**CLI parameter**
- `--scoreAbove` (can range between 1 -100)

**How this works**
- The value of `scoreAbove` is normalised for each index that carmen decides to search in:
  `Normalised value of scoreAbove in an index = scoreAbove * scorefactor`

if **Normalised value of scoreAbove in an index > feature score**, filter feature;
else, drop;

cc/ @mapbox/geocoding-gang 
