### PR TITLE
Unscaled scoring

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -32,6 +32,11 @@ module.exports = function(geocoder, query, options, callback) {
         return callback(errcode('Query too long - ' + query.length + '/' + constants.MAX_QUERY_CHARS + ' characters', 'EINVALID'));
     }
 
+    //scoreAbove option
+    if (options.scoreAbove && Number.isNaN(options.scoreAbove)) {
+        return callback(errcode('--scoreAbove can only be a number'));
+    }
+
     // Types option
     if (options.types) {
         if (!Array.isArray(options.types) || options.types.length < 1)

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -106,11 +106,7 @@ function dropFeature(geocoder, options, results, callback) {
             }
         }
 
-        function scoreMatch() {
-            return (options.scoreAbove && (cover.score >= options.scoreAbove));
-        }
-
-        function qualifyResult(result, options) {
+        function qualifyResult(options) {
             var yes = options.types || options.stacks || options.scoreAbove;
             if (options.types) {
                 yes = yes && typeMatch();
@@ -118,15 +114,12 @@ function dropFeature(geocoder, options, results, callback) {
             if (options.stacks) {
                 yes = yes && stackMatch();
             }
-            if (options.scoreAbove) {
-                yes = yes && scoreMatch();
-            }
             if (yes) {
                 return result;
             }
         }
 
-        if (qualifyResult(results[i], options)) {
+        if (qualifyResult(options)) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -105,16 +105,26 @@ function dropFeature(geocoder, options, results, callback) {
         }
 
         function scoreMatch() {
-            return (options.scoreAbove && (cover.score > options.scoreAbove));
+            return (options.scoreAbove && (cover.score >= options.scoreAbove));
         }
 
-        if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
-            (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
-            (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||
-            (options.stacks && options.types && typeMatch() && stackMatch()) ||
-            (options.stacks && options.scoreAbove && scoreMatch() && stackMatch()) ||
-            (options.types && options.scoreAbove && typeMatch() && scoreMatch()) ||
-            (options.stacks && options.types && options.scoreAbove && typeMatch() && stackMatch() && scoreMatch())) {
+        function qualifyResult(result, options) {
+            var yes = options.types || options.stacks || options.scoreAbove;
+            if (options.types) {
+                yes = yes && typeMatch();
+            }
+            if (options.stacks) {
+                yes = yes && stackMatch();
+            }
+            if (options.scoreAbove) {
+                yes = yes && scoreMatch();
+            }
+            if (yes) {
+                return result;
+            }
+        }
+
+        if (qualifyResult(results[i], options)) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -104,6 +104,10 @@ function dropFeature(geocoder, options, results, callback) {
             }
         }
 
+        function scoreMatch() {
+            return (options.scoreAbove && (cover.score > options.scoreAbove));
+        }
+
         if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
             (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
             (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -126,6 +126,23 @@ function dropFeature(geocoder, options, results, callback) {
     return filtered;
 }
 
+function qualifyResult(options, functions) {
+    var yes = false;
+    options.forEach(function(option) {
+        yes = yes || option;
+    });
+
+    if (!yes) return;
+
+    functions.forEach(function(fn, index) {
+        if (options[index] && fn) {
+            yes = yes && fn.func.apply(null,fn.arguments);
+        }
+    });
+
+    return yes;
+}
+
 function verifyFeatures(query, geocoder, spatial, loaded, options) {
     var meanScore = 1;
     var result = [];

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -27,7 +27,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     options.limit_verify = options.limit_verify || 10;
 
     // Limit features to those matching specified types.
-    if (options.types || options.stacks) {
+    if (options.types || options.stacks || options.scoreAbove) {
         results = dropFeature(geocoder, options, results);
     }
 
@@ -104,10 +104,13 @@ function dropFeature(geocoder, options, results, callback) {
             }
         }
 
-        if ((options.types && !options.stacks && typeMatch()) ||
-            (options.stacks && !options.types && stackMatch()) ||
-            (options.stacks && options.types && typeMatch() && stackMatch())) {
-
+        if ((options.types && !options.stacks && !options.scoreAbove && typeMatch()) ||
+            (options.stacks && !options.types && !options.scoreAbove && stackMatch()) ||
+            (options.scoreAbove && !options.stack && !options.types && scoreMatch()) ||
+            (options.stacks && options.types && typeMatch() && stackMatch()) ||
+            (options.stacks && options.scoreAbove && scoreMatch() && stackMatch()) ||
+            (options.types && options.scoreAbove && typeMatch() && scoreMatch()) ||
+            (options.stacks && options.types && options.scoreAbove && typeMatch() && stackMatch() && scoreMatch())) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -92,34 +92,21 @@ function dropFeature(geocoder, options, results, callback) {
         // For now, catch and return error to try to learn more.
         if (!source) return callback(new Error('Misuse: source undefined for idx ' + cover.idx));
 
-        function typeMatch() {
-            return (options.types.indexOf(source.type) !== -1);
+        function typeMatch(optionsTypes, sourceType) {
+            return (optionsTypes.indexOf(sourceType) !== -1);
         }
 
-        function stackMatch() {
-            if (options.stacks && source.stack) {
-                for (var j = 0; j < source.stack.length; j++) {
-                    if (options.stacks.indexOf(source.stack[j]) !== -1) return true;
+        function stackMatch(optionsStacks, sourceStack) {
+            if (optionsStacks && sourceStack) {
+                for (var j = 0; j < sourceStack.length; j++) {
+                    if (optionsStacks.indexOf(sourceStack[j]) !== -1) return true;
                 }
-            } else if (options.stacks && !source.stack) {
+            } else if (optionsStacks && !sourceStack) {
                 return true;
             }
         }
 
-        function qualifyResult(options) {
-            var yes = options.types || options.stacks || options.scoreAbove;
-            if (options.types) {
-                yes = yes && typeMatch();
-            }
-            if (options.stacks) {
-                yes = yes && stackMatch();
-            }
-            if (yes) {
-                return result;
-            }
-        }
-
-        if (qualifyResult(options)) {
+        if (qualifyResult([options.types, options.stacks], [{func: typeMatch, arguments: [options.types, source.type]}, {func: stackMatch, arguments: [options.stacks, source.stack]}])) {
             filtered.push(results[i]);
         }
     }

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -116,10 +116,13 @@ function dropFeature(geocoder, options, results, callback) {
 
 function qualifyResult(options, functions) {
     var yes = false;
+    var noOptionsSet = true;
     options.forEach(function(option) {
+        noOptionsSet = noOptionsSet && !option;
         yes = yes || option;
     });
 
+    if (noOptionsSet) return true;
     if (!yes) return;
 
     functions.forEach(function(fn, index) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -49,6 +49,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     }
 
     function afterFeatures(err, loaded) {
+        console.log('afterFeatures ', loaded);
         if (err) return callback(err);
 
         if (options.stacks) {
@@ -74,6 +75,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             results = filtered.results;
         }
 
+        console.log('PROCESSED: ', 'loaded ', loaded, ' filtered ', results);
         var verified = verifyFeatures(query, geocoder, results, loaded, options);
         verified = verified.slice(0, options.limit_verify);
         loadContexts(geocoder, verified, sets, options, callback);

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -69,7 +69,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         }
 
         function stackMatch(loadedFeatureStack, optionStacks) {
-            return ((loadedFeatureStack && (optionStacks.indexOf(loadedFeatureStack > -1))) || !loadedFeatureStack);
+            return ((loadedFeatureStack && (optionStacks.indexOf(loadedFeatureStack) > -1)) || !loadedFeatureStack);
         }
 
         function scoreMatch(resultScore, optionScores) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -59,14 +59,13 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             for (var j = 0; j < loaded.length; j++) {
                 // getFeatureByCover does not always return a feature.
                 if (!loaded[j]) continue;
-
-                if (qualifyResult([options.stacks, options.scoreAbove], [{func: stackMatch, arguments: [loaded[j].properties['carmen:geocoder_stack'], options.stacks]}, {func: scoreMatch, arguments: [results[j][0].score, options.scoreAbove]}])) {
+                if (qualifyResult([options.stacks, options.scoreAbove], [{func: stackMatch, arguments: [loaded[j].properties['carmen:geocoder_stack'], options.stacks]}, {func: scoreMatch, arguments: [loaded[j].properties['carmen:score'], options.scoreAbove]}])) {
                     filtered.loaded.push(loaded[j]);
                     filtered.results.push(results[j]);
                 }
-                loaded = filtered.loaded;
-                results = filtered.results;
             }
+            loaded = filtered.loaded;
+            results = filtered.results;
         }
 
         function stackMatch(loadedFeatureStack, optionStacks) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -49,10 +49,9 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     }
 
     function afterFeatures(err, loaded) {
-        console.log('afterFeatures ', loaded);
         if (err) return callback(err);
 
-        if (options.stacks) {
+        if (options.scoreAbove || options.stacks) {
             var filtered = {
                 loaded: [],
                 results: []
@@ -61,21 +60,23 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 // getFeatureByCover does not always return a feature.
                 if (!loaded[j]) continue;
 
-                if (loaded[j].properties['carmen:geocoder_stack']) {
-                    if (options.stacks.indexOf(loaded[j].properties['carmen:geocoder_stack']) > -1) {
-                        filtered.loaded.push(loaded[j]);
-                        filtered.results.push(results[j]);
-                    }
-                } else {
+                if (qualifyResult([options.stacks, options.scoreAbove], [{func: stackMatch, arguments: [loaded[j].properties['carmen:geocoder_stack'], options.stacks]}, {func: scoreMatch, arguments: [results[j][0].score, options.scoreAbove]}])) {
                     filtered.loaded.push(loaded[j]);
                     filtered.results.push(results[j]);
                 }
+                loaded = filtered.loaded;
+                results = filtered.results;
             }
-            loaded = filtered.loaded;
-            results = filtered.results;
         }
 
-        console.log('PROCESSED: ', 'loaded ', loaded, ' filtered ', results);
+        function stackMatch(loadedFeatureStack, optionStacks) {
+            return ((loadedFeatureStack && (optionStacks.indexOf(loadedFeatureStack > -1))) || !loadedFeatureStack);
+        }
+
+        function scoreMatch(resultScore, optionScores) {
+            return (optionScores >= resultScore);
+        }
+
         var verified = verifyFeatures(query, geocoder, results, loaded, options);
         verified = verified.slice(0, options.limit_verify);
         loadContexts(geocoder, verified, sets, options, callback);

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -74,7 +74,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         }
 
         function scoreMatch(resultScore, optionScores) {
-            return (optionScores >= resultScore);
+            return (resultScore >= optionScores);
         }
 
         var verified = verifyFeatures(query, geocoder, results, loaded, options);

--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -91,7 +91,8 @@ carmen.geocode(argv.query, {
     'debug': argv.debug,
     'stats': true,
     'language': argv.language,
-    'indexes': true
+    'indexes': true,
+    'scoreAbove': argv.scoreAbove
 }, function(err, data) {
     if (err) throw err;
     if (data.features.length && !argv.geojson) {

--- a/test/geocode-unit.scoreAbove.test.js
+++ b/test/geocode-unit.scoreAbove.test.js
@@ -1,0 +1,57 @@
+// Tests Eiffel Tower (landmark) vs Eiffel Tower (dry cleaners)
+// Eiffel Tower should win via scoreAbove bonus.
+
+var tape = require('tape');
+var Carmen = require('..');
+var index = require('../lib/index');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature');
+
+(function() {
+    var conf = {
+        poi: new mem(null, function() {})
+    };
+    var c = new Carmen(conf);
+    var tajMahalVarious = ['Taj Mahal Dry Cleaners', 'Taj Mahal Photos', 'Taj Mahal restaurant', 'Taj Mahal cafe']
+    
+    tape('index insignificant Taj Mahal pois (noise)', function(t) {
+        var q = queue(1);
+        for (var i = 1; i < 5; i++) q.defer(function(i, done) {
+            addFeature(conf.poi, {
+                id:i,
+                properties: {
+                    'carmen:score':i,
+                    'carmen:text': tajMahalVarious[i-1],
+                    'carmen:zxy':['6/32/32'],
+                    'carmen:center':[i,0]
+                }
+            }, done);
+        }, i);
+        q.awaitAll(t.end);
+    });
+    
+    tape('index Taj Mahal (landmark)', function(t) {
+        addFeature(conf.poi, {
+            id:5,
+            properties: {
+                'carmen:score': 1e9,
+                'carmen:text': 'Taj Mahal',
+                'carmen:zxy': ['6/33/32'],
+                'carmen:center': [0,0]
+            }
+        }, t.end);
+    });
+    tape('query', function(t) {
+        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+            t.end();
+        });
+    });
+})();
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/geocode-unit.scoreAbove.test.js
+++ b/test/geocode-unit.scoreAbove.test.js
@@ -36,15 +36,34 @@ var addFeature = require('../lib/util/addfeature');
         addFeature(conf.poi, {
             id:5,
             properties: {
-                'carmen:score': 1e9,
+                'carmen:score': 300,
                 'carmen:text': 'Taj Mahal',
                 'carmen:zxy': ['6/33/32'],
                 'carmen:center': [0,0]
             }
         }, t.end);
     });
-    tape('query', function(t) {
+    tape('scoreAbove = 1', function(t) {
         c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+            t.equal(res.features.length, 5);
+            t.end();
+        });
+    });
+    tape('scoreAbove = 2', function(t) {
+        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+            t.equal(res.features.length, 4);
+            t.end();
+        });
+    });
+    tape('scoreAbove = 3', function(t) {
+        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+            t.equal(res.features.length, 3);
+            t.end();
+        });
+    });
+    tape('scoreAbove = 4', function(t) {
+        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+            t.equal(res.features.length, 2);
             t.end();
         });
     });

--- a/test/geocode-unit.scoreAbove.test.js
+++ b/test/geocode-unit.scoreAbove.test.js
@@ -39,31 +39,59 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:score': 300,
                 'carmen:text': 'Taj Mahal',
                 'carmen:zxy': ['6/33/32'],
-                'carmen:center': [0,0]
+                'carmen:center': [8.44, -2.81]
             }
         }, t.end);
     });
     tape('scoreAbove = 1', function(t) {
         c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
             t.equal(res.features.length, 5);
+            var ids = []
+            res.features.forEach(function(feature) {
+                ids.push(feature.id)
+            });
+            t.deepEqual(ids.sort(), ['poi.1', 'poi.2', 'poi.3', 'poi.4','poi.5']);
             t.end();
         });
     });
     tape('scoreAbove = 2', function(t) {
-        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+        c.geocode('Taj Mahal', { scoreAbove:2 }, function(err, res) {
             t.equal(res.features.length, 4);
+            var ids = []
+            res.features.forEach(function(feature) {
+                ids.push(feature.id)
+            });
+            t.deepEqual(ids.sort(), ['poi.2', 'poi.3', 'poi.4','poi.5']);
             t.end();
         });
     });
     tape('scoreAbove = 3', function(t) {
-        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+        c.geocode('Taj Mahal', { scoreAbove:3 }, function(err, res) {
             t.equal(res.features.length, 3);
+            var ids = []
+            res.features.forEach(function(feature) {
+                ids.push(feature.id)
+            });
+            t.deepEqual(ids.sort(), ['poi.3', 'poi.4','poi.5']);
             t.end();
         });
     });
     tape('scoreAbove = 4', function(t) {
-        c.geocode('Taj Mahal', { scoreAbove:1 }, function(err, res) {
+        c.geocode('Taj Mahal', { scoreAbove:4 }, function(err, res) {
             t.equal(res.features.length, 2);
+            var ids = []
+            res.features.forEach(function(feature) {
+                ids.push(feature.id)
+            });
+            t.deepEqual(ids.sort(), ['poi.4','poi.5']);
+            t.end();
+        });
+    });
+    tape('scoreAbove = 200', function(t) {
+        c.geocode('Taj Mahal', { scoreAbove:200 }, function(err, res) {
+            t.equal(res.features.length, 1);
+            t.equal(res.features[0].id, 'poi.5');
+            t.equal(res.features[0].text, 'Taj Mahal');
             t.end();
         });
     });

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -66,30 +66,6 @@ tape('verifymatch.dropFeature', function(t) {
         q.end()
     });
 
-    t.test('dropFeature scoreAbove', function(q) {
-        var geocoder = {
-            byidx: [
-                {
-                    stack: ['ca']
-                },
-                {
-                    stack: ['us']
-                }
-            ]
-        };
-        var options = {
-            scoreAbove: 1
-        };
-        var results = [
-            [{ idx: 0, id: 0, score: 200 }],
-            [{ idx: 1, id: 1, score: 0 }]
-        ];
-        var res = verifymatch.dropFeature(geocoder, options, results);
-        t.equals(res.length, 1);
-        t.equals(res[0][0].id, 0);
-        q.end()
-    });
-
     t.test('dropFeature types & stacks', function(q) {
         var geocoder = {
             byidx: [

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -66,6 +66,30 @@ tape('verifymatch.dropFeature', function(t) {
         q.end()
     });
 
+    t.test('dropFeature scoreAbove', function(q) {
+        var geocoder = {
+            byidx: [
+                {
+                    stack: ['ca']
+                },
+                {
+                    stack: ['us']
+                }
+            ]
+        };
+        var options = {
+            scoreAbove: 1
+        };
+        var results = [
+            [{ idx: 0, id: 0, score: 200 }],
+            [{ idx: 1, id: 1, score: 0 }]
+        ];
+        var res = verifymatch.dropFeature(geocoder, options, results);
+        t.equals(res.length, 1);
+        t.equals(res[0][0].id, 0);
+        q.end()
+    });
+
     t.test('dropFeature types & stacks', function(q) {
         var geocoder = {
             byidx: [


### PR DESCRIPTION
Filter features by a score X that's a CLI parameter.

`--scoreAbove` - takes in an arbitrary number. Returns features that have a `carmen:score` higher than the the CLI parameter.

Different from https://github.com/mapbox/carmen/pull/492 (which is incomplete) in the sense that this is a _direct_ comparison between the CLI score and the `carmen:score` with the `scorefactor` not influencing feature selection in any way.
- Use `carmen:score` from the indexes to qualify a feature, instead of `score`.
- Wrote a new function to conditionally qualify features depending on options passed.
