### PR TITLE
stricter eslint rules (fixed)

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,6 +1,5 @@
 var uniq = require('./util/uniq');
 var decode = require('./util/grid').decode;
-var termops = require('./util/termops');
 
 module.exports = function analyze(source, callback) {
     var s = source;
@@ -12,7 +11,7 @@ module.exports = function analyze(source, callback) {
         byRelev: {}
     };
     for (var i = 0; i < 7; i++) stats.byScore[i] = 0;
-    for (var i = 0.4; i <= 1; i = i + 0.2) stats.byRelev[i.toFixed(1)] = 0;
+    for (var j = 0.4; j <= 1; j = j + 0.2) stats.byRelev[j.toFixed(1)] = 0;
 
     getStats(Math.pow(16,4), callback);
 
@@ -28,7 +27,7 @@ module.exports = function analyze(source, callback) {
             while (ids.length) {
                 var id = ids.shift();
                 var grids = s._geocoder.get('grid', id);
-                rels = grids.length;
+                var rels = grids.length;
 
                 // Verify that relations are unique.
                 if (rels !== uniq(grids).length) {

--- a/lib/api-mem.js
+++ b/lib/api-mem.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter,
-    fs = require('fs'),
     inherits = require('util').inherits;
 
 module.exports = MemSource;
@@ -85,7 +84,7 @@ MemSource.prototype.startWriting = function(callback) {
 
 // Shards are stored as binary buffers, so we need to convert them to base64
 // strings in order for them to be safe for JSON.stringify
-MemSource.prototype.serialize = function(name, callback) {
+MemSource.prototype.serialize = function() {
     function shardify(shards) {
         var o = {};
         for (var i in shards) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,10 +1,7 @@
 var mp25 = Math.pow(2,25);
-var zlib = require('zlib'),
-    SphericalMercator = require('sphericalmercator'),
-    mapnik = require('mapnik'),
+var mapnik = require('mapnik'),
     termops = require('./util/termops'),
     feature = require('./util/feature'),
-    ops = require('./util/ops'),
     queue = require('d3-queue').queue,
     Locking = require('locking'),
     addressCluster = require('./pure/addresscluster'),
@@ -42,7 +39,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
 
     var q = queue();
 
-    for (index_ids_it = 0; index_ids_it < index_ids.length; index_ids_it++) {
+    for (var index_ids_it = 0; index_ids_it < index_ids.length; index_ids_it++) {
         var source = indexes[index_ids[index_ids_it]];
         var bounds = source.bounds;
 
@@ -71,7 +68,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
             combined = combined.concat(res[res_it]);
         }
 
-        var combined = combined.sort(function(a, b) {
+        combined = combined.sort(function(a, b) {
             if (a['carmen:vtquerydist'] > b['carmen:vtquerydist']) return 1;
             if (a['carmen:vtquerydist'] < b['carmen:vtquerydist']) return -1;
         }).filter(function(a) {
@@ -132,7 +129,6 @@ module.exports = function(geocoder, lon, lat, options, callback) {
                         // For now, catch and return error to try to learn more.
                         if (!replaceSource) return callback(new Error('Misuse: source undefined for idx ' + replaceIdx));
 
-                        var replaceType = replaceSource.type;
                         var replaceName = replaceSource.name;
                         if (replaceName !== name) memo[name] = res[i];
 
@@ -145,8 +141,8 @@ module.exports = function(geocoder, lon, lat, options, callback) {
             }
         }
         var types = Object.keys(memo);
-        for (var i = 0; i < types.length; i++) {
-            stack.push(memo[types[i]]);
+        for (var k = 0; k < types.length; k++) {
+            stack.push(memo[types[k]]);
         }
         callback(null, stack);
     }
@@ -317,7 +313,6 @@ function contextVector(source, lon, lat, full, matched, language, callback) {
 // Load the full feature from geocoding data if needed, otherwise create
 // a light reference with id + text.
 function loadFeature(source, feat, full, query, language, callback) {
-    var dbname = source.name;
     var dbidx = source.idx;
     var dbtype = source.type;
 
@@ -365,7 +360,7 @@ function loadFeature(source, feat, full, query, language, callback) {
 
         var hasAddr = false;
         if (source.geocoder_address && loaded.properties['carmen:addressnumber']) {
-            addr = addressCluster.reverse(loaded, query);
+            var addr = addressCluster.reverse(loaded, query);
             if (addr) {
                 hasAddr = true;
                 loaded = addr;

--- a/lib/context.js
+++ b/lib/context.js
@@ -68,11 +68,9 @@ module.exports = function(geocoder, lon, lat, options, callback) {
             combined = combined.concat(res[res_it]);
         }
 
-        combined = combined.sort(function(a, b) {
+        combined.sort(function(a, b) {
             if (a['carmen:vtquerydist'] > b['carmen:vtquerydist']) return 1;
             if (a['carmen:vtquerydist'] < b['carmen:vtquerydist']) return -1;
-        }).filter(function(a) {
-            if (a) return a;
         });
 
         combined = combined.slice(0, options.limit);
@@ -178,6 +176,7 @@ getTile.setVtCacheSize = function(size) {
 }
 
 module.exports.getTile = getTile;
+module.exports.proximityVector = proximityVector;
 module.exports.contextVector = contextVector;
 
 function tileCover(source, lon, lat, cb) {
@@ -207,7 +206,7 @@ function proximityVector(source, lon, lat, callback) {
 
     function query(err, vt) {
         if (err) return callback(err);
-        if (!vt) return callback(null, false);
+        if (!vt) return callback(null, []);
 
         // Uses a 1000m (web mercator units tol)
         vt.query(lon, lat, {
@@ -215,7 +214,7 @@ function proximityVector(source, lon, lat, callback) {
             layer: source.geocoder_layer
         }, function(err, results) {
             if (err) return callback(err);
-            if (!results || !results.length) return callback(null, false);
+            if (!results || !results.length) return callback(null, []);
 
             var loaded = [];
             for (var results_it = 0; results_it < results.length; results_it++) {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -1,5 +1,4 @@
-var sm = new (require('sphericalmercator'))(),
-    ops = require('./util/ops'),
+var ops = require('./util/ops'),
     phrasematch = require('./phrasematch'),
     context = require('./context'),
     termops = require('./util/termops'),
@@ -7,10 +6,8 @@ var sm = new (require('sphericalmercator'))(),
     verifymatch = require('./verifymatch'),
     queue = require('d3-queue').queue,
     feature = require('./util/feature'),
-    proximity = require('./util/proximity'),
     token = require('./util/token'),
     mu = require('model-un'),
-    bbox = require('./util/bbox'),
     constants = require('./constants');
 var dedupe = require('./util/dedupe');
 var errcode = require('err-code');
@@ -45,9 +42,9 @@ module.exports = function(geocoder, query, options, callback) {
     if (options.stacks) {
         if (!Array.isArray(options.stacks) || options.stacks.length < 1)
             return callback(errcode('options.stacks must be an array with at least 1 stack', 'EINVALID'));
-        var l = options.stacks.length;
-        while (l--) if (!geocoder.bystack[options.stacks[l]])
-            return callback(errcode('Stack "' + options.stacks[l] + '" is not a known stack. Must be one of: ' + Object.keys(geocoder.bystack).join(', '), 'EINVALID'));
+        var k = options.stacks.length;
+        while (k--) if (!geocoder.bystack[options.stacks[k]])
+            return callback(errcode('Stack "' + options.stacks[k] + '" is not a known stack. Must be one of: ' + Object.keys(geocoder.bystack).join(', '), 'EINVALID'));
     }
 
     //Proximity is currently not enabled
@@ -262,9 +259,6 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
     }
 }
 
-var uniq = require('./util/uniq');
-var idmod = Math.pow(2,25);
-
 function forwardGeocode(geocoder, query, options, callback) {
     options.limit = options.limit ? (options.limit > 10 ? 10 : options.limit) : 5;
     query = token.replaceToken(geocoder.replacer, query);
@@ -272,13 +266,11 @@ function forwardGeocode(geocoder, query, options, callback) {
         type: 'FeatureCollection',
         query: termops.tokenize(query)
     };
-    var zooms = [];
-    var grids = [];
-    var stats = {};
     var q = queue(5);
 
+    var stats;
     if (options.stats) {
-        var stats = {};
+        stats = {};
         stats.time = +new Date();
         stats.phrasematch = {};
         stats.spatialmatch = {};
@@ -295,9 +287,6 @@ function forwardGeocode(geocoder, query, options, callback) {
             options.allowed_idx[geocoder.bytype[type][i].idx] = true;
         }
     }
-
-    var mp25 = Math.pow(2,25);
-    var mp33 = Math.pow(2,33);
 
     // search runs `geocoder.search` over each backend with `data.query`,
     // condenses all of the results, and sorts them by potential usefulness.
@@ -382,9 +371,9 @@ function forwardGeocode(geocoder, query, options, callback) {
             // record index names for each feature context
             if (options.indexes) {
                 var contextIndexes = {};
-                for (var i = 0; i < queryData.features.length; i++) {
-                    for (var context_i = 0; context_i < contexts[i].length; context_i++)
-                        contextIndexes[geocoder.byidx[contexts[i][context_i].properties['carmen:dbidx']].id] = true;
+                for (var k = 0; k < queryData.features.length; k++) {
+                    for (var context_k = 0; context_k < contexts[k].length; context_k++)
+                        contextIndexes[geocoder.byidx[contexts[k][context_k].properties['carmen:dbidx']].id] = true;
                 }
                 queryData.indexes = Object.keys(contextIndexes);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,4 @@
-var mp32 = Math.pow(2,32);
-var termops = require('./util/termops'),
-    token = require('./util/token'),
-    feature = require('./util/feature'),
-    uniq = require('./util/uniq'),
-    ops = require('./util/ops'),
+var feature = require('./util/feature'),
     queue = require('d3-queue').queue,
     indexdocs = require('./indexer/indexdocs'),
     split = require('split'),
@@ -104,7 +99,7 @@ function update(source, docs, options, callback) {
     //Add Global Tokens to source token list
     if (options.tokens) {
         var tokens = Object.keys(options.tokens);
-        for (tokens_it = 0; tokens_it < tokens.length; tokens_it++) {
+        for (var tokens_it = 0; tokens_it < tokens.length; tokens_it++) {
             source.geocoder_tokens[tokens[tokens_it]] = options.tokens[tokens[tokens_it]];
         }
     }
@@ -154,15 +149,16 @@ function update(source, docs, options, callback) {
                 if (TIMER) console.time('update:setParts:'+type);
                 cache.loadall(getter, type, ids, function(err) {
                     if (err) return callback(err);
+                    var id;
                     if (dictcache.properties.needsText) {
                         for (var i = 0; i < ids.length; i++) {
-                            var id = ids[i];
+                            id = ids[i];
                             // This merges new entries on top of old ones.
                             cache.set('grid', id, data[id], true);
                         }
                     } else {
-                        for (var i = 0; i < ids.length; i++) {
-                            var id = ids[i];
+                        for (var k = 0; k < ids.length; k++) {
+                            id = ids[k];
                             // This merges new entries on top of old ones.
                             cache.set('grid', id, data[id], true);
                             dictcache.setId(id);
@@ -203,7 +199,7 @@ function store(source, callback) {
             var ids = cache.list(type, shard);
             for (var i = 0; i < ids.length; i++) {
                 var id = ids[i];
-                var data = source._geocoder.get(type, id);
+                source._geocoder.get(type, id);
             }
             return [type, shard];
         }

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -1,18 +1,14 @@
-var mp32 = Math.pow(2,32);
 var cover = require('tile-cover');
-var ops = require('../util/ops');
 var grid = require('../util/grid');
 var token = require('../util/token');
 var termops = require('../util/termops');
 var tilebelt = require('tilebelt');
 var centroid = require('turf-point-on-surface');
 var DEBUG = process.env.DEBUG;
-var uniq = require('../util/uniq');
 var extent = require('turf-extent');
 var point = require('turf-point');
 var linestring = require('turf-linestring');
 var geojsonHint = require('geojsonhint');
-var token = require('../util/token');
 var feature = require('../util/feature');
 var TIMER = process.env.TIMER;
 
@@ -49,8 +45,9 @@ function indexdocs(docs, source, zoom, geocoder_tokens, callback) {
     }
 
     if (TIMER) console.time('update:freq');
+    var freq;
     try {
-        var freq = generateFrequency(docs, source.token_replacer);
+        freq = generateFrequency(docs, source.token_replacer);
     } catch (err) {
         return callback(err);
     }
@@ -77,7 +74,7 @@ function indexdocs(docs, source, zoom, geocoder_tokens, callback) {
         if (TIMER) console.timeEnd('update:loadall');
         if (TIMER) console.time('update:indexdocs');
 
-        for (f_it = 0; f_it < docs.length; f_it++) {
+        for (var f_it = 0; f_it < docs.length; f_it++) {
             loadDoc(freq, full, docs[f_it], source, zoom, source.token_replacer)
         }
 
@@ -86,7 +83,6 @@ function indexdocs(docs, source, zoom, geocoder_tokens, callback) {
 }
 
 function parseDocs(docs, settings, full) {
-    var source = settings.source;
     var zoom = settings.zoom;
     var token_replacer = token.createReplacer(settings.geocoder_tokens);
 
@@ -96,14 +92,15 @@ function parseDocs(docs, settings, full) {
             return res;
         } else docs[i] = res;
 
+        var c_it, addr_it, feat;
         //Create vectorizable version of doc
         if (docs[i].properties['carmen:addressnumber']) {
             docs[i].properties.id = docs[i].id;
-            for (var c_it = 0; c_it < docs[i].properties['carmen:addressnumber'].length; c_it++) {
+            for (c_it = 0; c_it < docs[i].properties['carmen:addressnumber'].length; c_it++) {
                 if (!docs[i].properties['carmen:addressnumber'][c_it]) continue;
 
-                for (var addr_it = 0; addr_it < docs[i].properties['carmen:addressnumber'][c_it].length; addr_it++) {
-                    var feat = JSON.parse(JSON.stringify(docs[i]));
+                for (addr_it = 0; addr_it < docs[i].properties['carmen:addressnumber'][c_it].length; addr_it++) {
+                    feat = JSON.parse(JSON.stringify(docs[i]));
                     feat.properties['carmen:addressnumber'] = feat.properties['carmen:addressnumber'][c_it][addr_it];
                     feat.properties['carmen:center'] = feat.geometry.geometries[c_it].coordinates[addr_it];
                     feat = point(feat.geometry.geometries[c_it].coordinates[addr_it], feat.properties);
@@ -113,11 +110,11 @@ function parseDocs(docs, settings, full) {
             }
         }
         if (docs[i].properties['carmen:rangetype']) {
-            for (var c_it = 0; c_it < docs[i].geometry.geometries.length; c_it++) {
+            for (c_it = 0; c_it < docs[i].geometry.geometries.length; c_it++) {
                 if (docs[i].geometry.geometries[c_it].type !== 'MultiLineString') continue;
 
-                for (var addr_it = 0; addr_it < docs[i].geometry.geometries[c_it].coordinates.length; addr_it++) {
-                    var feat = JSON.parse(JSON.stringify(docs[i]));
+                for (addr_it = 0; addr_it < docs[i].geometry.geometries[c_it].coordinates.length; addr_it++) {
+                    feat = JSON.parse(JSON.stringify(docs[i]));
                     if (feat.properties['carmen:parityl'][c_it]) feat.properties['carmen:parityl'] = [feat.properties['carmen:parityl'][c_it][addr_it]]
                     if (feat.properties['carmen:parityr'][c_it]) feat.properties['carmen:parityr'] = [feat.properties['carmen:parityr'][c_it][addr_it]]
                     if (feat.properties['carmen:lfromhn'][c_it]) feat.properties['carmen:lfromhn'] = [feat.properties['carmen:lfromhn'][c_it][addr_it]]
@@ -140,7 +137,7 @@ function parseDocs(docs, settings, full) {
     }
 };
 
-function runChecks(doc, zoom) {
+function runChecks(doc) {
     var geojsonErr = geojsonHint.hint(doc);
 
     if (!doc.id) {
@@ -161,17 +158,18 @@ function runChecks(doc, zoom) {
     if (doc.geometry.type === 'Polygon' || doc.geometry.type === 'MultiPolygon') {
         // check for Polygons or Multipolygons with too many vertices
         var vertices = 0;
+        var ringCount;
         if (doc.geometry.type === 'Polygon') {
-            var ringCount = doc.geometry.coordinates.length;
+            ringCount = doc.geometry.coordinates.length;
             for (var i = 0; i < ringCount; i++) {
                 vertices+= doc.geometry.coordinates[i].length;
             }
         } else {
             var polygonCount = doc.geometry.coordinates.length;
             for (var k = 0; k < polygonCount; k++) {
-                var ringCount = doc.geometry.coordinates[k].length;
-                for (var i = 0; i < ringCount; i++) {
-                    vertices += doc.geometry.coordinates[k][i].length;
+                ringCount = doc.geometry.coordinates[k].length;
+                for (var j = 0; j < ringCount; j++) {
+                    vertices += doc.geometry.coordinates[k][j].length;
                 }
             }
         }
@@ -182,7 +180,7 @@ function runChecks(doc, zoom) {
     return '';
 }
 
-function standardize(doc, zoom, token_replacer) {
+function standardize(doc, zoom) {
     var err = runChecks(doc, zoom);
     if (err) return err;
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,20 +1,9 @@
-var mp32 = Math.pow(2,32);
-var cache = require('./util/cxxcache');
-var cpus = require('os').cpus().length;
 var stream = require('stream');
-var termops = require('./util/termops'),
-    token = require('./util/token'),
-    feature = require('./util/feature'),
-    uniq = require('./util/uniq'),
-    ops = require('./util/ops'),
-    queue = require('d3-queue').queue,
-    indexdocs = require('./indexer/indexdocs'),
-    split = require('split'),
+var queue = require('d3-queue').queue,
     extend = require('util')._extend,
     dawgCache = require('dawg-cache'),
     fork = require('child_process').fork,
-    fs = require('fs'),
-    TIMER = process.env.TIMER;
+    fs = require('fs');
 
 module.exports = merge;
 module.exports.multimerge = multimerge;
@@ -45,17 +34,18 @@ var pairwiseGeocoderIterator = function(from1, from2, type) {
 
                 // reset the fetch queue so we can call await on it again
                 fetchq = queue();
+                var out;
                 if (nexts[0].done && nexts[1].done) {
                     // both sides are done
                     readStream.push(null);
                 } else if (!nexts[0].done && (nexts[1].done || nexts[0].value.shard < nexts[1].value.shard)) {
                     // return and advance next[0]
-                    var out = nexts[0];
+                    out = nexts[0];
                     advance(0);
                     readStream.push({ shard: out.value.shard, data1: out.value.data, data2: undefined });
                 } else if (!nexts[1].done && (nexts[0].done || nexts[1].value.shard < nexts[0].value.shard)) {
                     // return and advance next[1]
-                    var out = nexts[1];
+                    out = nexts[1];
                     advance(1);
                     readStream.push({ shard: out.value.shard, data2: out.value.data, data1: undefined });
                 } else if (nexts[0].value.shard == nexts[1].value.shard) {

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -1,6 +1,5 @@
 var termops = require('./util/termops');
 var token = require('./util/token');
-var queue = require('d3-queue').queue;
 var bb = require('./util/bbox');
 
 // # phrasematch

--- a/lib/pure/addressitp.js
+++ b/lib/pure/addressitp.js
@@ -25,20 +25,20 @@ var turf = {
 var O = { O: true, B: true, '': true };
 var E = { E: true, B: true, '': true };
 
-function standardize(feat, i) {
+function standardize(feat, k) {
     var ranges = [];
 
     // features without address data at all, on either side of the street
-    if (i === null || i === undefined || feat.properties['carmen:rangetype'] !== 'tiger' || !feat.geometry || !feat.geometry.geometries || feat.geometry.geometries[i].type !== 'MultiLineString') return ranges;
+    if (k === null || k === undefined || feat.properties['carmen:rangetype'] !== 'tiger' || !feat.geometry || !feat.geometry.geometries || feat.geometry.geometries[k].type !== 'MultiLineString') return ranges;
 
     var stdFeat = {
-        lines: feat.geometry.geometries[i].coordinates,
-        lf: feat.properties['carmen:lfromhn'] ? feat.properties['carmen:lfromhn'][i] : [],
-        lt: feat.properties['carmen:ltohn'] ? feat.properties['carmen:ltohn'][i] : [],
-        rf: feat.properties['carmen:rfromhn'] ? feat.properties['carmen:rfromhn'][i] : [],
-        rt: feat.properties['carmen:rtohn'] ? feat.properties['carmen:rtohn'][i] : [],
-        lp: feat.properties['carmen:parityl'] ? feat.properties['carmen:parityl'][i] : [],
-        rp: feat.properties['carmen:parityr'] ? feat.properties['carmen:parityr'][i] : []
+        lines: feat.geometry.geometries[k].coordinates,
+        lf: feat.properties['carmen:lfromhn'] ? feat.properties['carmen:lfromhn'][k] : [],
+        lt: feat.properties['carmen:ltohn'] ? feat.properties['carmen:ltohn'][k] : [],
+        rf: feat.properties['carmen:rfromhn'] ? feat.properties['carmen:rfromhn'][k] : [],
+        rt: feat.properties['carmen:rtohn'] ? feat.properties['carmen:rtohn'][k] : [],
+        lp: feat.properties['carmen:parityl'] ? feat.properties['carmen:parityl'][k] : [],
+        rp: feat.properties['carmen:parityr'] ? feat.properties['carmen:parityr'][k] : []
     };
     // convert feature into array of ranges so it can be sorted
     // into a stable-orderd array.
@@ -367,7 +367,8 @@ function setPoint(address, start, end, coords, omitted) {
     var distance = calculateDistance(coords);
     var unnorm = part * distance;
 
-    for (var stop = 1; stop < coords.length - 1; stop++) {
+    var stop;
+    for (stop = 1; stop < coords.length - 1; stop++) {
         if (coords[stop][2] > unnorm) break;
     }
 

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -1,4 +1,3 @@
-var decode = require('./util/grid.js').decode;
 var proximity = require('./util/proximity.js');
 var queue = require('d3-queue').queue;
 var coalesce = require('carmen-cache').Cache.coalesce;
@@ -18,21 +17,19 @@ function spatialmatch(query, phrasematches, options, callback) {
         stacks[i] = rebalance(query, stacks[i]);
     }
 
-    var relevMax = 0;
-    var features = [];
-    var sets = {};
     var waste = [];
 
     coalesceLoad();
 
     // Load grid indexes necessary for coalesce.
-    function coalesceLoad(stack, callback) {
+    function coalesceLoad() {
         // First make a pass where phrase IDs to load are grouped by idx.
         var loadables = {};
+        var idx;
         for (var i = 0; i < stacks.length; i++) {
             var stack = stacks[i];
             for (var j = 0; j < stack.length; j++) {
-                var idx = stack[j].idx;
+                idx = stack[j].idx;
                 loadables[idx] = loadables[idx] || {
                     loadall: stack[j].loadall,
                     getter: stack[j].getter,
@@ -44,7 +41,7 @@ function spatialmatch(query, phrasematches, options, callback) {
 
         // Then queue loading in a single pass deduping ids.
         var q = queue();
-        for (var idx in loadables) {
+        for (idx in loadables) {
             q.defer(loadables[idx].loadall, loadables[idx].getter, 'grid', uniq(loadables[idx].ids));
         }
         q.awaitAll(coalesceStacks);
@@ -74,7 +71,6 @@ function spatialmatch(query, phrasematches, options, callback) {
         }
 
         if (options && options.bbox) {
-            var l = stack.length;
             coalesceOpts.bboxzxy = bbox.insideTile(options.bbox, stack[0].zoom);
         }
 
@@ -274,9 +270,9 @@ function rebalance(query, stack) {
     //recompute total relevance from scratch
     stackClone.relev = 0;
 
-    for (var i = 0; i < stackClone.length; i++) {
-        stackClone[i].weight = weight;
-        stackClone.relev += stackClone[i].weight;
+    for (var k = 0; k < stackClone.length; k++) {
+        stackClone[k].weight = weight;
+        stackClone.relev += stackClone[k].weight;
     }
 
     return stackClone;

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -39,14 +39,15 @@ function zxyArray(input) {
 function _addFeature(source, input, vtile_only, callback) {
     input.type = 'Feature';
 
+    var zxys;
     if (!input.properties['carmen:zxy']) {
         input.properties['carmen:zxy'] = cover.tiles(input.geometry, {min_zoom: source.maxzoom, max_zoom: source.maxzoom}).map(function(zxy) {
             return zxy[2] + '/' + zxy[0] + '/' + zxy[1]
         });
 
-        var zxys = zxyArray(input);
+        zxys = zxyArray(input);
     } else if (!input.geometry) {
-        var zxys = zxyArray(input);
+        zxys = zxyArray(input);
 
         var i = zxys.length;
         var zxyCoords = [];
@@ -59,7 +60,7 @@ function _addFeature(source, input, vtile_only, callback) {
             coordinates: zxyCoords
         }
     } else {
-        var zxys = zxyArray(input);
+        zxys = zxyArray(input);
     }
 
     input.geometry = input.geometry || {
@@ -69,7 +70,7 @@ function _addFeature(source, input, vtile_only, callback) {
 
     if (options.tokens) {
         var tokens = Object.keys(options.tokens);
-        for (tokens_it = 0; tokens_it < tokens.length; tokens_it++) {
+        for (var tokens_it = 0; tokens_it < tokens.length; tokens_it++) {
             source.geocoder_tokens[tokens[tokens_it]] = options.tokens[tokens[tokens_it]];
         }
     }
@@ -130,8 +131,9 @@ function vectorize(feat, source, done) {
         });
 
         function addData(currentTile) {
+            var feats;
             if (currentTile && !currentTile.empty()) {
-                var feats = JSON.parse(currentTile.toGeoJSONSync('data')).features;
+                feats = JSON.parse(currentTile.toGeoJSONSync('data')).features;
                 feats.push(feat);
             } else {
                 feats = [feat]

--- a/lib/util/cxxcache.js
+++ b/lib/util/cxxcache.js
@@ -1,6 +1,5 @@
 var Cache = require('carmen-cache').Cache;
 var queue = require('d3-queue').queue;
-var immediate = global.setImmediate || process.nextTick;
 var uniq = require('./uniq');
 var types = {
     freq: 2,
@@ -164,8 +163,8 @@ Cache.prototype.loadall = function(getter, type, ids, callback) {
     }
 
     var q = queue(10);
-    for (var i = 0; i < shards.length; i++) {
-        q.defer(getter, type, +shards[i]);
+    for (var k = 0; k < shards.length; k++) {
+        q.defer(getter, type, +shards[k]);
     }
 
     q.awaitAll(function(err, buffers) {

--- a/lib/util/dedupe.js
+++ b/lib/util/dedupe.js
@@ -7,9 +7,11 @@ function dedupe(features) {
     // dedupe one: strictly by place name
     var a = [];
     var by_place_name = {};
+    var feature;
+    var previous;
     for (var i = 0; i < features.length; i++) {
-        var feature = features[i];
-        var previous = by_place_name[feature.place_name];
+        feature = features[i];
+        previous = by_place_name[feature.place_name];
         if (previous) {
             if (a[previous.index].geometry.omitted && !feature.geometry.omitted) {
                 a[previous.index] = feature;
@@ -30,8 +32,8 @@ function dedupe(features) {
     // dedupe two: by address + distance threshold
     var b = [];
     var by_address = {};
-    for (var i = 0; i < a.length; i++) {
-        var feature = a[i];
+    for (var k = 0; k < a.length; k++) {
+        feature = a[k];
 
         // No address. Keep.
         if (!feature.address) {
@@ -41,7 +43,7 @@ function dedupe(features) {
 
         // Has address, check for a previous dupe within distance threshold.
         var address = feature.address + ' ' + feature.text.toLowerCase();
-        var previous = by_address[address];
+        previous = by_address[address];
         if (previous && distance(previous.point, point(feature.center), 'kilometers') < 5) {
             if (b[previous.index].geometry.omitted && !feature.geometry.omitted) {
                 b[previous.index] = feature;

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -14,6 +14,7 @@ module.exports.getFeatureById = getFeatureById;
 module.exports.putFeatures = putFeatures;
 
 function addrTransform(doc) {
+    var c_it;
     //All values in an addresscluster should be lowercase so that the lowercased input query always matches the addresscluster
     //All addressnumber type features are also converted into GeometryCollections
     if (doc.properties['carmen:addressnumber'] && doc.geometry) {
@@ -33,7 +34,7 @@ function addrTransform(doc) {
             return 'carmen:addressnumber array must be equal to geometry.geometries array';
         }
 
-        for (var c_it = 0; c_it < doc.properties['carmen:addressnumber'].length; c_it++) {
+        for (c_it = 0; c_it < doc.properties['carmen:addressnumber'].length; c_it++) {
             if (!doc.properties['carmen:addressnumber'][c_it] || !doc.properties['carmen:addressnumber'][c_it].length) continue;
 
             if (doc.properties['carmen:addressnumber'][c_it].length !== doc.geometry.geometries[c_it].coordinates.length) {
@@ -71,7 +72,7 @@ function addrTransform(doc) {
             return 'ITP results must be a LineString, MultiLineString, or GeometryCollection';
         }
 
-        for (var c_it = 0; c_it < doc.geometry.geometries.length; c_it++) {
+        for (c_it = 0; c_it < doc.geometry.geometries.length; c_it++) {
             if (doc.geometry.geometries[c_it].type === 'LineString') return 'ITP geometries in a GeometryCollection must be MultiLineStrings';
 
             ['parityl', 'parityr', 'lfromhn', 'rfromhn', 'ltohn', 'rtohn'].forEach(function(type) {
@@ -85,8 +86,8 @@ function addrTransform(doc) {
 
 //Old syle documents use a flat heiarchy - transform them into geojson
 function transform(feat) {
-    keys = Object.keys(feat);
-    l = keys.length
+    var keys = Object.keys(feat);
+    var l = keys.length
     var doc = {
         type: 'Feature',
         properties: {}
@@ -140,17 +141,17 @@ function transform(feat) {
 
     if (!doc.geometry && feat._zxy) {
         var zxys = []
-        for (var i = 0; i < feat._zxy.length; i++) {
-            zxy = feat._zxy[i].split('/');
+        for (var j = 0; j < feat._zxy.length; j++) {
+            var zxy = feat._zxy[j].split('/');
             zxy[0] = parseInt(zxy[0],10);
             zxy[1] = parseInt(zxy[1],10);
             zxy[2] = parseInt(zxy[2],10);
             zxys.push(zxy)
         }
 
-        var i = zxys.length;
-        while (i--) {
-            zxys[i] = tilebelt.tileToGeoJSON([zxys[i][1], zxys[i][2], zxys[i][0]]).coordinates;
+        var k = zxys.length;
+        while (k--) {
+            zxys[k] = tilebelt.tileToGeoJSON([zxys[k][1], zxys[k][2], zxys[k][0]]).coordinates;
         }
 
         doc.geometry = {
@@ -294,22 +295,23 @@ function putFeatures(source, docs, callback) {
         }
 
         if (!doc.properties['carmen:zxy']) {
-            tiles = cover.tiles(doc.geometry, {min_zoom: source.maxzoom, max_zoom: source.maxzoom});
+            var tiles = cover.tiles(doc.geometry, {min_zoom: source.maxzoom, max_zoom: source.maxzoom});
             doc.properties['carmen:zxy'] = [];
             tiles.forEach(function(tile) {
                 doc.properties['carmen:zxy'].push(tile[2]+'/'+tile[0]+'/'+tile[1]);
             });
         }
-        var s = termops.feature(doc.id);
-        byshard[s] = byshard[s] || [];
-        byshard[s].push(doc);
+        var sh = termops.feature(doc.id);
+        byshard[sh] = byshard[sh] || [];
+        byshard[sh].push(doc);
     }
     var q = queue(100);
     for (var s in byshard) q.defer(function(s, docs, callback) {
         source.getGeocoderData('feature', s, function(err, buffer) {
             if (err) return callback(err);
+            var current;
             try {
-                var current = buffer && buffer.length ? JSON.parse(buffer) : {};
+                current = buffer && buffer.length ? JSON.parse(buffer) : {};
             } catch (err) {
                 return callback(err);
             }

--- a/lib/util/grid.js
+++ b/lib/util/grid.js
@@ -1,14 +1,9 @@
 // Caching shows a 6% perf bump
 var mp51 = Math.pow(2,51);
 var mp48 = Math.pow(2,48);
-var mp39 = Math.pow(2,39);
 var mp34 = Math.pow(2,34);
-var mp25 = Math.pow(2,25);
-var mp23 = Math.pow(2,23);
 var mp20 = Math.pow(2,20);
 var mp14 = Math.pow(2,14);
-var mp3 = Math.pow(2,3);
-var mp2 = Math.pow(2,2);
 
 module.exports.encode = encode;
 module.exports.decode = decode;

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -16,9 +16,9 @@ function toFeature(context, format, language) {
     // check for whether or not there are any parts of the response in the queried language.
     // if not, use the default templating rather than the one appropriate to the queried language.
     if (language && format[language]) {
-        for (var x = 0; x < context.length; x++) {
-            if (context[x].properties['carmen:text_'+language] ||
-                context[x].properties.language === language) {
+        for (var k = 0; k < context.length; k++) {
+            if (context[k].properties['carmen:text_'+language] ||
+                context[k].properties.language === language) {
                 format = format[language];
                 break;
             }
@@ -30,6 +30,7 @@ function toFeature(context, format, language) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
         return (f.properties['carmen:text_'+language]||f.properties['carmen:text']||'').split(',')[0];
     };
+    var place_name;
     //Use geocoder_format to format output if applicable
     if (!format || format === true || format === 1) {
         place_name = ((feat.properties['carmen:address'] ? feat.properties['carmen:address'] + ' ' : '') + context.map(gettext).join(', ')).trim();
@@ -115,20 +116,20 @@ function toFeature(context, format, language) {
     }
     if (context.length > 1) {
         feature.context = [];
-        for (var i = 1; i < context.length; i++) {
-            if (!context[i].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
+        for (var c = 1; c < context.length; c++) {
+            if (!context[c].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
             var contextFeat = {
-                id: context[i].properties['carmen:extid'],
-                text: gettext(context[i])
+                id: context[c].properties['carmen:extid'],
+                text: gettext(context[c])
             };
 
             // copy over all non-'carmen:*' properties
-            var propertyKeys = Object.keys(context[i].properties).filter(function(prop) {
+            var propertyKeys = Object.keys(context[c].properties).filter(function(prop) {
                 return !/^carmen:/.test(prop) && !/^id$/.test(prop);
             });
 
             for (var j = 0; j < propertyKeys.length; j++)
-                contextFeat[propertyKeys[j]] = context[i].properties[propertyKeys[j]];
+                contextFeat[propertyKeys[j]] = context[c].properties[propertyKeys[j]];
 
             feature.context.push(contextFeat);
         }

--- a/lib/util/permute.js
+++ b/lib/util/permute.js
@@ -11,7 +11,7 @@ function all(length, mask) {
     return cacheAll[length];
 }
 
-function continuous(length, mask) {
+function continuous(length) {
     cacheContinuous[length] = cacheContinuous[length] || _continuous(length);
     return cacheContinuous[length];
 }

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -1,6 +1,5 @@
 var Point = require('turf-point');
 var Distance = require('turf-distance');
-var ops = require('./ops');
 var cover = require('tile-cover');
 
 module.exports.distance = distance;

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -1,9 +1,4 @@
-var mp4 = Math.pow(2,4);
-var mp8 = Math.pow(2,8);
 var mp20 = Math.pow(2,20);
-var mp28 = Math.pow(2,28);
-var mp32 = Math.pow(2,32);
-var mp52 = Math.pow(2,52);
 var unidecode = require('unidecode-cxx');
 var idPattern = /^(\S+)\.([0-9]+)$/;
 var nonCJKchar = /[^\s\u1100-\u11FF\u2E80-\u2EFF\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3100-\u312F\u3130-\u318F\u31C0-\u31EF\u31F0-\u31FF\u3200-\u32FF\u3300-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFE30-\uFE4F]/;
@@ -113,14 +108,14 @@ function tokenize(query, lonlat) {
 
     var pretokens = [];
 
-    for (var i = 0; i < normalized.length; i++) {
+    for (var k = 0; k < normalized.length; k++) {
         // keep multi-digit numbers from being split in CJK queries
-        if (normalized[i].length && normalized[i][0].charCodeAt() >= 19968 && normalized[i][0].charCodeAt() <= 40959) {
-            pretokens = pretokens.concat(normalized[i].split(/([0-9０-９]+)/));
-        } else if (/(\d+)-(\d+)[a-z]?/.test(normalized[i])) {
-            pretokens.push(normalized[i]);
+        if (normalized[k].length && normalized[k][0].charCodeAt() >= 19968 && normalized[k][0].charCodeAt() <= 40959) {
+            pretokens = pretokens.concat(normalized[k].split(/([0-9０-９]+)/));
+        } else if (/(\d+)-(\d+)[a-z]?/.test(normalized[k])) {
+            pretokens.push(normalized[k]);
         } else {
-            var splitPhrase = normalized[i].split('-');
+            var splitPhrase = normalized[k].split('-');
             pretokens = pretokens.concat(splitPhrase);
         }
     }
@@ -213,12 +208,12 @@ function getHousenumRangeV3(doc) {
                 var a = doc.properties[props[p]][c_it];
                 var b = doc.properties[props[p+1]][c_it];
 
-                for (var i = 0; i < a.length; i++) {
-                    if (typeof a[i] === "number") a[i] = a[i].toString();
-                    if (typeof b[i] === "number") b[i] = b[i].toString();
+                for (var k = 0; k < a.length; k++) {
+                    if (typeof a[k] === "number") a[k] = a[k].toString();
+                    if (typeof b[k] === "number") b[k] = b[k].toString();
 
-                    var valA = parseSemiNumber(a[i]);
-                    var valB = parseSemiNumber(b[i]);
+                    var valA = parseSemiNumber(a[k]);
+                    var valB = parseSemiNumber(b[k]);
                     if (valA === null || valB === null) continue;
 
                     var min = Math.min(valA, valB);
@@ -371,9 +366,9 @@ function permutations(terms, weights, all) {
             }
             permutation.relev = Math.round(permutation.relev * 5) / 5;
         } else {
-            for (var j = 0; j < length; j++) {
-                if (!(mask & (1<<j))) continue;
-                permutation.push(terms[j]);
+            for (var k = 0; k < length; k++) {
+                if (!(mask & (1<<k))) continue;
+                permutation.push(terms[k]);
             }
         }
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -1,15 +1,11 @@
 var addressItp = require('./pure/addressitp');
 var addressCluster = require('./pure/addresscluster');
-var sm = new(require('sphericalmercator'))();
 var queue = require('d3-queue').queue;
 var context = require('./context');
 var termops = require('./util/termops');
 var feature = require('./util/feature');
 var proximity = require('./util/proximity');
 var bbox = require('./util/bbox');
-
-var mp2_14 = Math.pow(2, 14);
-var mp2_28 = Math.pow(2, 28);
 
 module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
@@ -21,7 +17,6 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     var results = matched.results;
     var sets = matched.sets;
 
-    var contexts = [];
     var q = queue(10);
 
     options.limit_verify = options.limit_verify || 10;
@@ -117,10 +112,11 @@ function dropFeature(geocoder, options, results, callback) {
 function verifyFeatures(query, geocoder, spatial, loaded, options) {
     var meanScore = 1;
     var result = [];
+    var feat;
     for (var pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
 
-        var feat = loaded[pos];
+        feat = loaded[pos];
 
         var spatialmatch = spatial[pos];
         var cover = spatialmatch[0];
@@ -137,8 +133,9 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
             if (address && (feat.properties['carmen:addressnumber'] || feat.properties['carmen:rangetype'])) {
                 feat.properties['carmen:address'] = address.addr;
 
+                var res;
                 if (feat.properties['carmen:addressnumber']) {
-                    var res = addressCluster.forward(feat, address.addr);
+                    res = addressCluster.forward(feat, address.addr);
                     if (res) {
                         feat.geometry = res; 
                         feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;
@@ -147,7 +144,7 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
                 }
 
                 if (!hasAddr && feat.properties['carmen:rangetype']) {
-                    var res = addressItp.forward(feat, address.addr);
+                    res = addressItp.forward(feat, address.addr);
                     if (res) {
                         feat.geometry = res;
                         feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;
@@ -186,7 +183,7 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
     if (result.length) meanScore = Math.pow(meanScore, 1/result.length);
     // Set a score + distance combined heuristic.
     for (var i = 0; i < result.length; i++) {
-        var feat = result[i];
+        feat = result[i];
         // ghost features don't participate
         if (options.proximity && feat.properties["carmen:score"] >= 0) {
             feat.properties["carmen:scoredist"] = Math.max(
@@ -205,8 +202,8 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
     // with identical text.
     var filtered = [];
     var byText = {};
-    for (var i = 0; i < result.length; i++) {
-        var feat = result[i];
+    for (var k = 0; k < result.length; k++) {
+        feat = result[k];
         var text = options.language && feat.properties["carmen:text_"+options.language] ? feat.properties["carmen:text_"+options.language] : feat.properties["carmen:text"];
         if (feat.properties["carmen:scoredist"] >= 0 || !byText[text]) {
             filtered.push(feat);
@@ -259,7 +256,6 @@ function verifyContexts(contexts, sets, groups) {
 
 function verifyContext(context, strict, loose, groups) {
     var addressOrder = context[0].properties['carmen:geocoder_address_order'];
-    var spatialmatch = context[0].properties['carmen:spatialmatch'];
     var gappy = 0;
     var stacky = 0;
     var usedmask = 0;

--- a/package.json
+++ b/package.json
@@ -90,7 +90,11 @@
       "no-constant-condition": 0,
       "no-native-reassign": 0,
       "no-shadow": 0,
-      "key-spacing": 0
+      "key-spacing": 0,
+      "no-unused-vars": [2, { "args": "none" }],
+      "no-redeclare": 2,
+      "no-undef": 2,
+      "block-scoped-var": 2
     },
     "env": {
       "node": true

--- a/test/address.nearest.test.js
+++ b/test/address.nearest.test.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var addressItp = require('../lib/pure/addressitp');
 var test = require('tape');
 var feature = require('../lib/util/feature');

--- a/test/bin.carmen-degenize.test.js
+++ b/test/bin.carmen-degenize.test.js
@@ -1,15 +1,5 @@
-var fs = require('fs');
-var path = require('path');
 var tape = require('tape');
 var spawn = require('child_process').spawn;
-var tmpdir = require('os').tmpdir();
-var bin = path.resolve(path.join(__dirname, '..', 'scripts'));
-
-var Carmen = require('../index.js');
-var MBTiles = require('mbtiles');
-var Memsource = require('../lib/api-mem');
-var tmpindex = path.join(tmpdir, 'test-carmen-index.mbtiles');
-var addFeature = require('../lib/util/addfeature');
 
 tape('carmen-degenize', function(assert) {
     var child = spawn(__dirname + '/../scripts/carmen-degenize.js', []);

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -4,11 +4,9 @@ var tape = require('tape');
 var exec = require('child_process').exec;
 var tmpdir = require('os').tmpdir();
 var bin = path.resolve(path.join(__dirname, '..', 'scripts'));
-var fixture = path.resolve(path.join(__dirname, '..', 'tiles'));
 
 var Carmen = require('../index.js');
 var MBTiles = require('mbtiles');
-var Memsource = require('../lib/api-mem');
 var tmpindex = path.join(tmpdir, 'test-carmen-index.mbtiles');
 var tmpindex2 = path.join(tmpdir, 'test-carmen-index2.mbtiles');
 var addFeature = require('../lib/util/addfeature');

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,5 +1,4 @@
 var Cache = require('../lib/util/cxxcache');
-var fs = require('fs');
 var test = require('tape');
 
 test('.shard', function(s) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -135,6 +135,32 @@ test('contextVector empty VT buffer', function(assert) {
     });
 });
 
+test('proximityVector empty VT buffer', function(assert) {
+    context.getTile.cache.reset();
+
+    var vtile = new mapnik.VectorTile(0,0,0);
+    zlib.gzip(vtile.getData(), function(err, buffer) {
+        assert.ifError(err);
+        var source = {
+            getTile: function(z,x,y,callback) {
+                return callback(null, buffer);
+            },
+            geocoder_layer: 'data',
+            maxzoom: 0,
+            minzoom: 0,
+            name: 'test',
+            type: 'test',
+            id: 'testA',
+            idx: 0
+        };
+        context.proximityVector(source, 0, 0, function(err, data) {
+            assert.ifError(err);
+            assert.deepEqual(data, []);
+            assert.end();
+        });
+    });
+});
+
 test('contextVector ignores negative score', function(assert) {
     context.getTile.cache.reset();
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,9 +1,6 @@
 var fs = require('fs');
-var util = require('util');
 var Carmen = require('..');
-var tilelive = require('tilelive');
 var context = require('../lib/context');
-var UPDATE = process.env.UPDATE;
 var test = require('tape');
 var zlib = require('zlib');
 var path = require('path');
@@ -11,7 +8,6 @@ var mapnik = require('mapnik');
 var addFeature = require('../lib/util/addfeature');
 var queue = require('d3-queue').queue;
 var mem = require('../lib/api-mem');
-var index = require('../lib/index');
 
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'ogr.input'));
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -1,10 +1,6 @@
-var fs = require('fs');
-var util = require('util');
 var Carmen = require('..');
-var MBTiles = require('mbtiles');
 var mem = require('../lib/api-mem');
 var index = require('../lib/index');
-var mem = require('../lib/api-mem');
 var docs = require('./fixtures/mem-docs.json');
 var test = require('tape');
 

--- a/test/dawgcache.test.js
+++ b/test/dawgcache.test.js
@@ -1,11 +1,10 @@
 var tape = require('tape');
 var zlib = require('zlib');
-var encodePhrase = require('../lib/util/termops').encodePhrase;
 var DawgCache = require('../lib/util/dawg');
 
 tape('create', function(assert) {
     var dict = new DawgCache();
-    assert.pass("dawg created")
+    assert.ok(dict, "dawg created")
     assert.end();
 });
 

--- a/test/dedupe.test.js
+++ b/test/dedupe.test.js
@@ -2,7 +2,7 @@ var dedupe = require('../lib/util/dedupe');
 var tape = require('tape');
 
 tape('dedup lowercase vs caps', function(assert) {
-    features = [
+    var features = [
         {
             place_name: '20 main st',
             text: 'main st',

--- a/test/feature.putFeatures.test.js
+++ b/test/feature.putFeatures.test.js
@@ -8,6 +8,7 @@ var conf = { source: source };
 var carmen = new Carmen(conf);
 
 tape('putFeatures', function(assert) {
+    assert.ok(carmen);
     feature.putFeatures(conf.source, [
         {
             _id: 1,

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 //Make sure that capital letters are lowercased on indexing to match input token

--- a/test/geocode-unit.address-bitmask.test.js
+++ b/test/geocode-unit.address-bitmask.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Test geocoder_address formatting + return place_name as germany style address (address number follows name)

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 (function() {

--- a/test/geocode-unit.backy.test.js
+++ b/test/geocode-unit.backy.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.bbox.test.js
+++ b/test/geocode-unit.bbox.test.js
@@ -1,6 +1,5 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.bmask.test.js
+++ b/test/geocode-unit.bmask.test.js
@@ -2,11 +2,7 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
-var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
 
 tape('boundsmask', function(assert) {
     var conf = {
@@ -18,6 +14,7 @@ tape('boundsmask', function(assert) {
     assert.deepEqual(conf.small.bmask, [0,0,0], 'small overlaps with all');
     assert.deepEqual(conf.west.bmask, [0,0,1], 'west overlaps with small');
     assert.deepEqual(conf.east.bmask, [0,1,0], 'east overlaps with small');
+    assert.ok(c);
     assert.end();
 });
 

--- a/test/geocode-unit.byid.test.js
+++ b/test/geocode-unit.byid.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -3,7 +3,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.context-overlap.test.js
+++ b/test/geocode-unit.context-overlap.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.dataterm-only.test.js
+++ b/test/geocode-unit.dataterm-only.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.dataterm-vs-postcode.test.js
+++ b/test/geocode-unit.dataterm-vs-postcode.test.js
@@ -1,6 +1,5 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -1,6 +1,5 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.dict-collision.test.js
+++ b/test/geocode-unit.dict-collision.test.js
@@ -1,11 +1,8 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
-var termops = require('../lib/util/termops.js');
 
 var conf = {
     place: new mem(null, function() {}),

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.fallback.js
+++ b/test/geocode-unit.fallback.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.featurenoop.test.js
+++ b/test/geocode-unit.featurenoop.test.js
@@ -4,7 +4,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // limit_verify 1 implies that the correct result must be the very top

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 //Tests string value for index level geocoder_stack

--- a/test/geocode-unit.geocoder_type.test.js
+++ b/test/geocode-unit.geocoder_type.test.js
@@ -1,6 +1,5 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.index-context.test.js
+++ b/test/geocode-unit.index-context.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Test that geocoder returns index names for context

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.invalid-tokens.test.js
+++ b/test/geocode-unit.invalid-tokens.test.js
@@ -1,8 +1,6 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
 
 (function() {
     var conf = {
@@ -19,6 +17,7 @@ var addFeature = require('../lib/util/addfeature');
     tape('test invalid tokens', function(t) {
         t.throws(function() {
             var c = new Carmen(conf);
+            t.assert(c);
         });
         t.end();
     });

--- a/test/geocode-unit.io-reverse.test.js
+++ b/test/geocode-unit.io-reverse.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.

--- a/test/geocode-unit.language-flag-reverse.test.js
+++ b/test/geocode-unit.language-flag-reverse.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 (function() {

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 (function() {

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;

--- a/test/geocode-unit.localtext.test.js
+++ b/test/geocode-unit.localtext.test.js
@@ -3,9 +3,7 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.lowrelev.test.js
+++ b/test/geocode-unit.lowrelev.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.multiconfig.test.js
+++ b/test/geocode-unit.multiconfig.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var country =new mem(null, function() {});
@@ -21,6 +19,7 @@ var confB = {
 var pre = new Carmen(confA);
 
 tape('index province', function(t) {
+    t.ok(pre);
     addFeature(confA.country, {
         id:1,
         properties: {

--- a/test/geocode-unit.multiload.test.js
+++ b/test/geocode-unit.multiload.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var country = new mem(null, function() {});

--- a/test/geocode-unit.named.test.js
+++ b/test/geocode-unit.named.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.noauto.test.js
+++ b/test/geocode-unit.noauto.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Confirm that disabling autocomplete works, and that in situations where an autocomplete

--- a/test/geocode-unit.numeric-address.test.js
+++ b/test/geocode-unit.numeric-address.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -1,6 +1,5 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.range.test.js
+++ b/test/geocode-unit.range.test.js
@@ -1,9 +1,7 @@
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 // Confirms that you can forward search a ghost feature and that a scored featre will always win

--- a/test/geocode-unit.scoredist.test.js
+++ b/test/geocode-unit.scoredist.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.scorefactor.test.js
+++ b/test/geocode-unit.scorefactor.test.js
@@ -3,7 +3,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;

--- a/test/geocode-unit.spatialmatch.test.js
+++ b/test/geocode-unit.spatialmatch.test.js
@@ -4,7 +4,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.tile-edge.test.js
+++ b/test/geocode-unit.tile-edge.test.js
@@ -2,7 +2,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 (function() {

--- a/test/geocode-unit.translation-noauto.test.js
+++ b/test/geocode-unit.translation-noauto.test.js
@@ -2,10 +2,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 (function() {

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.unicode-replace.test.js
+++ b/test/geocode-unit.unicode-replace.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.unicode.test.js
+++ b/test/geocode-unit.unicode.test.js
@@ -3,10 +3,8 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature');
 
 var conf = {

--- a/test/geocode-unit.unidecollide.test.js
+++ b/test/geocode-unit.unidecollide.test.js
@@ -3,7 +3,6 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var index = require('../lib/index');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');

--- a/test/index.merge.bench.test.js
+++ b/test/index.merge.bench.test.js
@@ -1,6 +1,5 @@
 var Carmen = require('..');
 var index = require('../lib/index');
-var phrasematch = require('../lib/phrasematch');
 var mem = require('../lib/api-mem');
 var tape = require('tape');
 

--- a/test/index.merge.test.js
+++ b/test/index.merge.test.js
@@ -1,20 +1,13 @@
 var fs = require('fs');
 var path = require('path');
 var Stream = require('stream');
-var util = require('util');
 var split = require('split');
 var Carmen = require('..');
-var index = require('../lib/index');
-var MBTiles = require('mbtiles');
 var mem = require('../lib/api-mem');
 var de = require('deep-equal');
 var dawgcache = require('../lib/util/dawg');
 
-var UPDATE = process.env.UPDATE;
 var test = require('tape');
-var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
-var merge = require('../lib/merge');
 
 test('index - streaming interface', function(assert) {
 

--- a/test/index.multimerge.test.js
+++ b/test/index.multimerge.test.js
@@ -1,20 +1,13 @@
 var fs = require('fs');
 var path = require('path');
 var Stream = require('stream');
-var util = require('util');
 var split = require('split');
 var Carmen = require('..');
-var index = require('../lib/index');
-var MBTiles = require('mbtiles');
 var mem = require('../lib/api-mem');
 var de = require('deep-equal');
-var dawgcache = require('../lib/util/dawg');
 var queue = require("d3-queue").queue;
 
-var UPDATE = process.env.UPDATE;
 var test = require('tape');
-var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var merge = require('../lib/merge');
 
 var randomMBtiles = function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,16 +1,13 @@
 var fs = require('fs');
 var path = require('path');
 var Stream = require('stream');
-var util = require('util');
 var Carmen = require('..');
 var index = require('../lib/index');
-var MBTiles = require('mbtiles');
 var mem = require('../lib/api-mem');
 
 var UPDATE = process.env.UPDATE;
 var test = require('tape');
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 
 test('index - streaming interface', function(assert) {
     var inputStream = fs.createReadStream(path.resolve(__dirname, './fixtures/small-docs.jsonl'), { encoding: 'utf8' });
@@ -54,6 +51,7 @@ test('index.update -- error', function(t) {
     var memdocs = require('./fixtures/mem-docs.json');
     var conf = { to: new mem(memdocs, null, function() {}) };
     var carmen = new Carmen(conf);
+    t.ok(carmen);
     t.test('update 1', function(q) {
         index.update(conf.to, [{
             id: 1,
@@ -100,6 +98,7 @@ test('index.update -- error', function(t) {
 test('index.update freq', function(t) {
     var conf = { to: new mem(null, function() {}) };
     var carmen = new Carmen(conf);
+    t.ok(carmen);
     t.test('error no id', function(q) {
         index.update(conf.to, [{ properties: { 'carmen:text': 'main st' } }], { zoom: 6 }, function(err) {
             q.equal('Error: doc has no id', err.toString());
@@ -142,7 +141,7 @@ test('index', function(t) {
         var doc = JSON.parse(chunk.toString());
 
         //Only print on error or else the logs are super long
-        if (!doc.id) assert.ok(doc.id, 'has id: ' + doc.id);
+        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
         done();
     };
 
@@ -238,7 +237,7 @@ test('error -- zoom too high', function(t) {
         var doc = JSON.parse(chunk.toString());
 
         //Only print on error or else the logs are super long
-        if (!doc.id) assert.ok(doc.id, 'has id: ' + doc.id);
+        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
         done();
     };
 
@@ -265,7 +264,7 @@ test('error -- zoom too low', function(t) {
         var doc = JSON.parse(chunk.toString());
 
         //Only print on error or else the logs are super long
-        if (!doc.id) assert.ok(doc.id, 'has id: ' + doc.id);
+        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
         done();
     };
 
@@ -285,6 +284,7 @@ test('error -- zoom too low', function(t) {
 test('index phrase collection', function(assert) {
     var conf = { test:new mem(null, {maxzoom:6}, function() {}) };
     var c = new Carmen(conf);
+    assert.ok(c);
     var docs = [{
         id:1,
         type: 'Feature',
@@ -333,7 +333,7 @@ test('error -- _geometry too high resolution', function(t) {
         var doc = JSON.parse(chunk.toString());
 
         //Only print on error or else the logs are super long
-        if (!doc.id) assert.ok(doc.id, 'has id: ' + doc.id);
+        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
         done();
     };
 
@@ -392,7 +392,7 @@ test('error -- carmen:zxy too large tile-cover', function(t) {
         var doc = JSON.parse(chunk.toString());
 
         //Only print on error or else the logs are super long
-        if (!doc.id) assert.ok(doc.id, 'has id: ' + doc.id);
+        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
         done();
     };
 
@@ -410,7 +410,6 @@ test('error -- carmen:zxy too large tile-cover', function(t) {
 });
 
 test('index.cleanDocs', function(assert) {
-    var docs;
     var sourceWithAddress = {geocoder_address:true};
     var sourceWithoutAddress = {geocoder_address:false};
 

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -1,4 +1,3 @@
-var unidecode = require('unidecode-cxx');
 var token = require('../lib/util/token');
 var test = require('tape');
 

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -3,7 +3,6 @@ var test = require('tape');
 
 test('stackable simple', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('10',2), weight:0.5 };
-    var a2 = { text:"a2", idx:0, zoom:0, mask:parseInt('10',2), weight:0.5 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
     var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
     var debug = stackable([

--- a/test/termops.encodePhrase.test.js
+++ b/test/termops.encodePhrase.test.js
@@ -1,5 +1,4 @@
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('termops.encodePhrase', function(assert) {

--- a/test/termops.encodeTerm.test.js
+++ b/test/termops.encodeTerm.test.js
@@ -1,5 +1,4 @@
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('termops.encodeTerm', function(assert) {

--- a/test/termops.getHousenumRangeV3.test.js
+++ b/test/termops.getHousenumRangeV3.test.js
@@ -1,5 +1,4 @@
 var getHousenumRangeV3 = require('../lib/util/termops').getHousenumRangeV3;
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('termops.getHousenumRangeV3', function(assert) {

--- a/test/termops.getIndexableText.test.js
+++ b/test/termops.getIndexableText.test.js
@@ -3,7 +3,6 @@ var token = require('../lib/util/token');
 var test = require('tape');
 
 test('termops.getIndexableText', function(assert) {
-    var freq = { 0:[2] };
     var replacer;
     var doc;
     var texts;

--- a/test/termops.id.test.js
+++ b/test/termops.id.test.js
@@ -1,5 +1,4 @@
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('id - tests if searching by id', function(q) {

--- a/test/termops.maskAddress.test.js
+++ b/test/termops.maskAddress.test.js
@@ -1,5 +1,4 @@
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('maskAddress', function(q) {

--- a/test/termops.tokenize.test.js
+++ b/test/termops.tokenize.test.js
@@ -1,5 +1,4 @@
 var termops = require('../lib/util/termops');
-var token = require('../lib/util/token');
 var test = require('tape');
 
 test('tokenizes basic strings', function(assert) {

--- a/test/termops.uniqPermutations.test.js
+++ b/test/termops.uniqPermutations.test.js
@@ -1,6 +1,5 @@
 var termops = require('../lib/util/termops');
 var test = require('tape');
-var clone = function(d) { return JSON.parse(JSON.stringify(d)); }
 
 test('termops.uniqPermutations', function(assert) {
     var a = termops.permutations(['a','b','c'], [0.2, 0.2, 0.6]);

--- a/test/verifymatch.test.js
+++ b/test/verifymatch.test.js
@@ -88,7 +88,7 @@ tape('verifymatch.dropFeature', function(t) {
         var res = verifymatch.dropFeature(geocoder, options, results);
         t.equals(res.length, 0);
 
-        var geocoder = {
+        geocoder = {
             byidx: [
                 { stack: ['zz'], type: 'other' },
                 { stack: ['us'], type: 'place' },
@@ -96,11 +96,11 @@ tape('verifymatch.dropFeature', function(t) {
             ]
         };
         //Filter out all but 1 using type/stack
-        var res = verifymatch.dropFeature(geocoder, options, results);
+        res = verifymatch.dropFeature(geocoder, options, results);
         t.equals(res.length, 1);
         t.equals(res[0][0].id, 2);
 
-        var geocoder = {
+        geocoder = {
             byidx: [
                 { stack: ['zz'], type: 'place' },
                 { stack: ['zz'], type: 'place' },
@@ -108,7 +108,7 @@ tape('verifymatch.dropFeature', function(t) {
             ]
         };
         //Filter out non using type/stack
-        var res = verifymatch.dropFeature(geocoder, options, results);
+        res = verifymatch.dropFeature(geocoder, options, results);
         t.equals(res.length, 3);
         t.equals(res[0][0].id, 0);
         t.equals(res[1][0].id, 1);


### PR DESCRIPTION
re-applies fcdcf757c959a25452e890d191525324e4ce877a with a fix:

The current
`var combined = combined.sort(function(a, b) {`
is replaced with
`combined = combined.sort(function(a, b) {`
instead of fcdcf757c959a25452e890d191525324e4ce877a's broken version:
`combined.sort(function(a, b) {`

The `sort` modifies the array in-place but the chained `.filter()` does not:  https://github.com/mapbox/carmen/blob/5e3a306b6f57f8e805f0ce6c0f7df4b6d023ffcd/lib/context.js#L71-L76

@mattficke can you review?