### PR TITLE
Add tests for indexdocs.parseDocs

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -15,6 +15,7 @@ var TIMER = process.env.TIMER;
 module.exports = {};
 module.exports = indexdocs;
 module.exports.loadDoc = loadDoc;
+module.exports.parseDocs = parseDocs;
 module.exports.runChecks = runChecks;
 module.exports.standardize = standardize;
 module.exports.verifyCenter = verifyCenter;

--- a/test/fixtures/indexdocs.parseDocs.json
+++ b/test/fixtures/indexdocs.parseDocs.json
@@ -1,0 +1,562 @@
+[
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        0,
+        0
+      ],
+      "carmen:addressnumber": "100",
+      "carmen:lfromhn": [
+        [],
+        [
+          "1",
+          "101",
+          "201",
+          "301"
+        ]
+      ],
+      "carmen:ltohn": [
+        [],
+        [
+          "99",
+          "199",
+          "299",
+          "399"
+        ]
+      ],
+      "carmen:rfromhn": [
+        [],
+        [
+          "0",
+          "100",
+          "200",
+          "300"
+        ]
+      ],
+      "carmen:rtohn": [
+        [],
+        [
+          "98",
+          "198",
+          "298",
+          "398"
+        ]
+      ],
+      "carmen:parityl": [
+        [],
+        [
+          "O",
+          "O",
+          "O",
+          "O"
+        ]
+      ],
+      "carmen:parityr": [
+        [],
+        [
+          "E",
+          "E",
+          "E",
+          "E"
+        ]
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        1,
+        0
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        1,
+        0
+      ],
+      "carmen:addressnumber": "200",
+      "carmen:lfromhn": [
+        [],
+        [
+          "1",
+          "101",
+          "201",
+          "301"
+        ]
+      ],
+      "carmen:ltohn": [
+        [],
+        [
+          "99",
+          "199",
+          "299",
+          "399"
+        ]
+      ],
+      "carmen:rfromhn": [
+        [],
+        [
+          "0",
+          "100",
+          "200",
+          "300"
+        ]
+      ],
+      "carmen:rtohn": [
+        [],
+        [
+          "98",
+          "198",
+          "298",
+          "398"
+        ]
+      ],
+      "carmen:parityl": [
+        [],
+        [
+          "O",
+          "O",
+          "O",
+          "O"
+        ]
+      ],
+      "carmen:parityr": [
+        [],
+        [
+          "E",
+          "E",
+          "E",
+          "E"
+        ]
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        2,
+        0
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        2,
+        0
+      ],
+      "carmen:addressnumber": "300",
+      "carmen:lfromhn": [
+        [],
+        [
+          "1",
+          "101",
+          "201",
+          "301"
+        ]
+      ],
+      "carmen:ltohn": [
+        [],
+        [
+          "99",
+          "199",
+          "299",
+          "399"
+        ]
+      ],
+      "carmen:rfromhn": [
+        [],
+        [
+          "0",
+          "100",
+          "200",
+          "300"
+        ]
+      ],
+      "carmen:rtohn": [
+        [],
+        [
+          "98",
+          "198",
+          "298",
+          "398"
+        ]
+      ],
+      "carmen:parityl": [
+        [],
+        [
+          "O",
+          "O",
+          "O",
+          "O"
+        ]
+      ],
+      "carmen:parityr": [
+        [],
+        [
+          "E",
+          "E",
+          "E",
+          "E"
+        ]
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        3,
+        0
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        3,
+        0
+      ],
+      "carmen:addressnumber": "400",
+      "carmen:lfromhn": [
+        [],
+        [
+          "1",
+          "101",
+          "201",
+          "301"
+        ]
+      ],
+      "carmen:ltohn": [
+        [],
+        [
+          "99",
+          "199",
+          "299",
+          "399"
+        ]
+      ],
+      "carmen:rfromhn": [
+        [],
+        [
+          "0",
+          "100",
+          "200",
+          "300"
+        ]
+      ],
+      "carmen:rtohn": [
+        [],
+        [
+          "98",
+          "198",
+          "298",
+          "398"
+        ]
+      ],
+      "carmen:parityl": [
+        [],
+        [
+          "O",
+          "O",
+          "O",
+          "O"
+        ]
+      ],
+      "carmen:parityr": [
+        [],
+        [
+          "E",
+          "E",
+          "E",
+          "E"
+        ]
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          0,
+          0
+        ],
+        [
+          1,
+          0
+        ]
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        0.5,
+        0
+      ],
+      "carmen:addressnumber": [
+        [
+          "100",
+          "200",
+          "300",
+          "400"
+        ],
+        null
+      ],
+      "carmen:lfromhn": [
+        "1"
+      ],
+      "carmen:ltohn": [
+        "99"
+      ],
+      "carmen:rfromhn": [
+        "0"
+      ],
+      "carmen:rtohn": [
+        "98"
+      ],
+      "carmen:parityl": [
+        "O"
+      ],
+      "carmen:parityr": [
+        "E"
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ]
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        2.5,
+        0
+      ],
+      "carmen:addressnumber": [
+        [
+          "100",
+          "200",
+          "300",
+          "400"
+        ],
+        null
+      ],
+      "carmen:lfromhn": [
+        "101"
+      ],
+      "carmen:ltohn": [
+        "199"
+      ],
+      "carmen:rfromhn": [
+        "100"
+      ],
+      "carmen:rtohn": [
+        "198"
+      ],
+      "carmen:parityl": [
+        "O"
+      ],
+      "carmen:parityr": [
+        "E"
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          4,
+          0
+        ],
+        [
+          5,
+          0
+        ]
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        4.5,
+        0
+      ],
+      "carmen:addressnumber": [
+        [
+          "100",
+          "200",
+          "300",
+          "400"
+        ],
+        null
+      ],
+      "carmen:lfromhn": [
+        "201"
+      ],
+      "carmen:ltohn": [
+        "299"
+      ],
+      "carmen:rfromhn": [
+        "200"
+      ],
+      "carmen:rtohn": [
+        "298"
+      ],
+      "carmen:parityl": [
+        "O"
+      ],
+      "carmen:parityr": [
+        "E"
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  },
+  {
+    "type": "Feature",
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          6,
+          0
+        ],
+        [
+          7,
+          0
+        ]
+      ]
+    },
+    "properties": {
+      "carmen:text": "main street",
+      "carmen:center": [
+        6.5,
+        0
+      ],
+      "carmen:addressnumber": [
+        [
+          "100",
+          "200",
+          "300",
+          "400"
+        ],
+        null
+      ],
+      "carmen:lfromhn": [
+        "301"
+      ],
+      "carmen:ltohn": [
+        "399"
+      ],
+      "carmen:rfromhn": [
+        "300"
+      ],
+      "carmen:rtohn": [
+        "398"
+      ],
+      "carmen:parityl": [
+        "O"
+      ],
+      "carmen:parityr": [
+        "E"
+      ],
+      "carmen:rangetype": "tiger",
+      "carmen:zxy": [
+        "6/32/32",
+        "6/32/32",
+        "6/33/32"
+      ],
+      "carmen:hash": 1,
+      "id": 1
+    },
+    "id": 1
+  }
+]

--- a/test/indexdocs.parseDocs.test.js
+++ b/test/indexdocs.parseDocs.test.js
@@ -1,0 +1,79 @@
+var fs = require('fs');
+var indexdocs = require('../lib/indexer/indexdocs.js');
+var tape = require('tape');
+
+tape('indexdocs.parseDocs (passthru)', function(assert) {
+    var docs = [{
+        id: 1,
+        type: 'Feature',
+        properties: {
+            'carmen:text': 'main street',
+            'carmen:center': [0,0]
+        },
+        geometry: { type: 'Point', coordinates: [0,0] }
+    }];
+    var settings = { zoom: 6, geocoder_tokens: {} };
+    var full = { vectors: [] };
+    var err = indexdocs.parseDocs(docs, settings, full);
+    assert.ifError(err);
+    assert.deepEqual(full.vectors, docs);
+    assert.end();
+});
+
+tape('indexdocs.parseDocs (address MultiPoint)', function(assert) {
+    var docs = [{
+        id: 1,
+        type: 'Feature',
+        properties: {
+            'carmen:text': 'main street',
+            'carmen:center': [0,0],
+            'carmen:addressnumber': [
+                [ '100', '200', '300', '400' ],
+                null
+            ],
+            'carmen:lfromhn': [ null, ['1', '101', '201', '301']],
+            'carmen:ltohn': [ null, ['99', '199', '299', '399']],
+            'carmen:rfromhn': [ null, ['0', '100', '200', '300']],
+            'carmen:rtohn': [ null, ['98', '198', '298', '398']],
+            'carmen:parityl': [ null, ['O','O','O','O']],
+            'carmen:parityr': [ null, ['E','E','E','E']],
+            'carmen:rangetype': 'tiger'
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [
+                {
+                    type: 'MultiPoint',
+                    coordinates: [
+                        [0,0],
+                        [1,0],
+                        [2,0],
+                        [3,0]
+                    ]
+                },
+                {
+                    type: 'MultiLineString',
+                    coordinates: [
+                        [[0,0], [1,0]],
+                        [[2,0], [3,0]],
+                        [[4,0], [5,0]],
+                        [[6,0], [7,0]]
+                    ]
+                }
+            ]
+        }
+    }];
+    var settings = { zoom: 6, geocoder_tokens: {} };
+    var full = { vectors: [] };
+    var err = indexdocs.parseDocs(docs, settings, full);
+    assert.ifError(err);
+
+    if (process.env.UPDATE) {
+        fs.writeFileSync(__dirname + '/fixtures/indexdocs.parseDocs.json', JSON.stringify(full.vectors, null, 2));
+    }
+    var expected = JSON.parse(fs.readFileSync(__dirname + '/fixtures/indexdocs.parseDocs.json'));
+
+    assert.deepEqual(full.vectors, expected);
+    assert.end();
+});
+


### PR DESCRIPTION
Test-only changes for demonstrating what `indexdocs.parseDocs` does on `master` now for comparison with upcoming changes.