### PR TITLE
Strip unused address properties from vector output

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -93,77 +93,69 @@ function parseDocs(docs, settings, full) {
             return res;
         } else docs[i] = res;
 
+        docs[i].properties.id = docs[i].id;
+
         var c_it, addr_it, feat;
 
         // Create vectorizable version of doc
         if (docs[i].properties['carmen:addressnumber']) {
-            docs[i].properties.id = docs[i].id;
             for (c_it = 0; c_it < docs[i].properties['carmen:addressnumber'].length; c_it++) {
                 if (!docs[i].properties['carmen:addressnumber'][c_it]) continue;
 
                 for (addr_it = 0; addr_it < docs[i].properties['carmen:addressnumber'][c_it].length; addr_it++) {
-                    feat = JSON.parse(JSON.stringify(docs[i]));
-                    feat.properties['carmen:addressnumber'] = feat.properties['carmen:addressnumber'][c_it][addr_it];
-
-                    // Remove any interpolation-related properties
-                    delete feat.properties['carmen:rangetype'];
-                    delete feat.properties['carmen:parityl'];
-                    delete feat.properties['carmen:parityr'];
-                    delete feat.properties['carmen:lfromhn'];
-                    delete feat.properties['carmen:rfromhn'];
-                    delete feat.properties['carmen:ltohn'];
-                    delete feat.properties['carmen:rtohn'];
-
-                    // Remove internal indexer properties
-                    delete feat.properties['carmen:zxy'];
-
-                    feat = point(feat.geometry.geometries[c_it].coordinates[addr_it], feat.properties);
-                    feat.properties['carmen:center'] = feat.geometry.coordinates;
-                    feat.id = feat.properties.id;
+                    feat = point(docs[i].geometry.geometries[c_it].coordinates[addr_it], vectorProperties(docs[i].properties));
+                    feat.id = docs[i].id;
                     full.vectors.push(feat);
                 }
             }
         }
+
         if (docs[i].properties['carmen:rangetype']) {
-            docs[i].properties.id = docs[i].id;
             for (c_it = 0; c_it < docs[i].geometry.geometries.length; c_it++) {
                 if (docs[i].geometry.geometries[c_it].type !== 'MultiLineString') continue;
 
                 for (addr_it = 0; addr_it < docs[i].geometry.geometries[c_it].coordinates.length; addr_it++) {
-                    feat = JSON.parse(JSON.stringify(docs[i]));
-                    if (feat.properties['carmen:parityl'][c_it]) feat.properties['carmen:parityl'] = [feat.properties['carmen:parityl'][c_it][addr_it]]
-                    if (feat.properties['carmen:parityr'][c_it]) feat.properties['carmen:parityr'] = [feat.properties['carmen:parityr'][c_it][addr_it]]
-                    if (feat.properties['carmen:lfromhn'][c_it]) feat.properties['carmen:lfromhn'] = [feat.properties['carmen:lfromhn'][c_it][addr_it]]
-                    if (feat.properties['carmen:rfromhn'][c_it]) feat.properties['carmen:rfromhn'] = [feat.properties['carmen:rfromhn'][c_it][addr_it]]
-                    if (feat.properties['carmen:ltohn'][c_it]) feat.properties['carmen:ltohn'] = [feat.properties['carmen:ltohn'][c_it][addr_it]]
-                    if (feat.properties['carmen:rtohn'][c_it]) feat.properties['carmen:rtohn'] = [feat.properties['carmen:rtohn'][c_it][addr_it]]
-
-                    // Remove any interpolation-related properties
-                    delete feat.properties['carmen:addressnumber'];
-
-                    // Remove internal indexer properties
-                    delete feat.properties['carmen:zxy'];
-
-                    feat = linestring(feat.geometry.geometries[c_it].coordinates[addr_it], feat.properties);
-                    feat.properties['carmen:center'] = centroid(feat.geometry).geometry.coordinates;
-                    feat.id = feat.properties.id;
+                    feat = linestring(docs[i].geometry.geometries[c_it].coordinates[addr_it], vectorProperties(docs[i].properties));
+                    feat.id = docs[i].id;
                     full.vectors.push(feat);
                 }
             }
         }
 
         if (!docs[i].properties['carmen:addressnumber'] && !docs[i].properties['carmen:rangetype']) {
-            docs[i].properties.id = docs[i].id;
-            feat = JSON.parse(JSON.stringify(docs[i]));
-
-            // Remove internal indexer properties
-            delete feat.properties['carmen:zxy'];
-
-            feat.id = feat.properties.id;
-            full.vectors.push(feat)
+            full.vectors.push({
+                id: docs[i].id,
+                type: 'Feature',
+                geometry: docs[i].geometry,
+                properties: vectorProperties(docs[i].properties)
+            });
         }
     }
 };
+
+function vectorProperties(properties) {
+    var vprops = {};
+    for (var k in properties) {
+        switch (k) {
+        // Remove any address-related properties and
+        // any internal carmen indexer properties.
+        case 'carmen:addressnumber':
+        case 'carmen:rangetype':
+        case 'carmen:parityl':
+        case 'carmen:parityr':
+        case 'carmen:lfromhn':
+        case 'carmen:rfromhn':
+        case 'carmen:ltohn':
+        case 'carmen:rtohn':
+        case 'carmen:zxy':
+            break;
+        default:
+            vprops[k] = properties[k];
+            break;
+        }
+    }
+    return vprops;
+}
 
 function runChecks(doc) {
     var geojsonErr = geojsonHint.hint(doc);

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -94,7 +94,8 @@ function parseDocs(docs, settings, full) {
         } else docs[i] = res;
 
         var c_it, addr_it, feat;
-        //Create vectorizable version of doc
+
+        // Create vectorizable version of doc
         if (docs[i].properties['carmen:addressnumber']) {
             docs[i].properties.id = docs[i].id;
             for (c_it = 0; c_it < docs[i].properties['carmen:addressnumber'].length; c_it++) {
@@ -103,14 +104,28 @@ function parseDocs(docs, settings, full) {
                 for (addr_it = 0; addr_it < docs[i].properties['carmen:addressnumber'][c_it].length; addr_it++) {
                     feat = JSON.parse(JSON.stringify(docs[i]));
                     feat.properties['carmen:addressnumber'] = feat.properties['carmen:addressnumber'][c_it][addr_it];
-                    feat.properties['carmen:center'] = feat.geometry.geometries[c_it].coordinates[addr_it];
+
+                    // Remove any interpolation-related properties
+                    delete feat.properties['carmen:rangetype'];
+                    delete feat.properties['carmen:parityl'];
+                    delete feat.properties['carmen:parityr'];
+                    delete feat.properties['carmen:lfromhn'];
+                    delete feat.properties['carmen:rfromhn'];
+                    delete feat.properties['carmen:ltohn'];
+                    delete feat.properties['carmen:rtohn'];
+
+                    // Remove internal indexer properties
+                    delete feat.properties['carmen:zxy'];
+
                     feat = point(feat.geometry.geometries[c_it].coordinates[addr_it], feat.properties);
+                    feat.properties['carmen:center'] = feat.geometry.coordinates;
                     feat.id = feat.properties.id;
                     full.vectors.push(feat);
                 }
             }
         }
         if (docs[i].properties['carmen:rangetype']) {
+            docs[i].properties.id = docs[i].id;
             for (c_it = 0; c_it < docs[i].geometry.geometries.length; c_it++) {
                 if (docs[i].geometry.geometries[c_it].type !== 'MultiLineString') continue;
 
@@ -122,7 +137,13 @@ function parseDocs(docs, settings, full) {
                     if (feat.properties['carmen:rfromhn'][c_it]) feat.properties['carmen:rfromhn'] = [feat.properties['carmen:rfromhn'][c_it][addr_it]]
                     if (feat.properties['carmen:ltohn'][c_it]) feat.properties['carmen:ltohn'] = [feat.properties['carmen:ltohn'][c_it][addr_it]]
                     if (feat.properties['carmen:rtohn'][c_it]) feat.properties['carmen:rtohn'] = [feat.properties['carmen:rtohn'][c_it][addr_it]]
-                    feat.properties.id = feat.id;
+
+                    // Remove any interpolation-related properties
+                    delete feat.properties['carmen:addressnumber'];
+
+                    // Remove internal indexer properties
+                    delete feat.properties['carmen:zxy'];
+
                     feat = linestring(feat.geometry.geometries[c_it].coordinates[addr_it], feat.properties);
                     feat.properties['carmen:center'] = centroid(feat.geometry).geometry.coordinates;
                     feat.id = feat.properties.id;
@@ -133,7 +154,13 @@ function parseDocs(docs, settings, full) {
 
         if (!docs[i].properties['carmen:addressnumber'] && !docs[i].properties['carmen:rangetype']) {
             docs[i].properties.id = docs[i].id;
-            full.vectors.push(docs[i])
+            feat = JSON.parse(JSON.stringify(docs[i]));
+
+            // Remove internal indexer properties
+            delete feat.properties['carmen:zxy'];
+
+            feat.id = feat.properties.id;
+            full.vectors.push(feat)
         }
     }
 };
@@ -238,14 +265,13 @@ function standardize(doc, zoom) {
         return 'zxy exceeded 10000, doc id:' + doc.id;
     }
 
-    doc.properties['carmen:hash'] = termops.feature(doc.id.toString());
-
     return doc;
 }
 
 function loadDoc(freq, patch, doc, source, zoom, token_replacer) {
     var xy = [];
     var l = doc.properties['carmen:zxy'].length;
+    var coverId = termops.feature(doc.id.toString());
 
     while (l--) {
         var zxy = doc.properties['carmen:zxy'][l].split('/');
@@ -281,7 +307,7 @@ function loadDoc(freq, patch, doc, source, zoom, token_replacer) {
                 var encoded = null;
                 try {
                     encoded = grid.encode({
-                        id: doc.properties['carmen:hash'],
+                        id: coverId,
                         x: xy[l].x,
                         y: xy[l].y,
                         relev: phrases[y].relev,

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -63,6 +63,9 @@ function _addFeature(source, input, vtile_only, callback) {
         zxys = zxyArray(input);
     }
 
+    // Set maxzoom on source if not set
+    if (isNaN(source.maxzoom)) source.maxzoom = zxys[0][0];
+
     input.geometry = input.geometry || {
         type: 'Point',
         coordinates: input.properties['carmen:center']
@@ -113,7 +116,15 @@ function _addFeature(source, input, vtile_only, callback) {
 function vectorize(feat, source, done) {
     var q = new queue();
 
-    var zxys = zxyArray(feat);
+    var zxys = cover.tiles(feat.geometry, {min_zoom: source.maxzoom, max_zoom: source.maxzoom}).map(function(xyz) {
+        var x = xyz[0];
+        var y = xyz[1];
+        var z = xyz[2];
+        if (z < 0 || x < 0 || y < 0) return false;
+        if (x >= Math.pow(2,z) || y >= Math.pow(2,z)) return false;
+        return [ z, x, y ];
+    }).filter(Boolean);
+
     for (var i = 0; i < zxys.length; i++) q.defer(function(zxy, done) {
         source.getTile(zxy[0],zxy[1],zxy[2], function(err, res) {
             if (err) {

--- a/test/fixtures/indexdocs.parseDocs.json
+++ b/test/fixtures/indexdocs.parseDocs.json
@@ -15,67 +15,6 @@
         0
       ],
       "carmen:addressnumber": "100",
-      "carmen:lfromhn": [
-        [],
-        [
-          "1",
-          "101",
-          "201",
-          "301"
-        ]
-      ],
-      "carmen:ltohn": [
-        [],
-        [
-          "99",
-          "199",
-          "299",
-          "399"
-        ]
-      ],
-      "carmen:rfromhn": [
-        [],
-        [
-          "0",
-          "100",
-          "200",
-          "300"
-        ]
-      ],
-      "carmen:rtohn": [
-        [],
-        [
-          "98",
-          "198",
-          "298",
-          "398"
-        ]
-      ],
-      "carmen:parityl": [
-        [],
-        [
-          "O",
-          "O",
-          "O",
-          "O"
-        ]
-      ],
-      "carmen:parityr": [
-        [],
-        [
-          "E",
-          "E",
-          "E",
-          "E"
-        ]
-      ],
-      "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -96,67 +35,6 @@
         0
       ],
       "carmen:addressnumber": "200",
-      "carmen:lfromhn": [
-        [],
-        [
-          "1",
-          "101",
-          "201",
-          "301"
-        ]
-      ],
-      "carmen:ltohn": [
-        [],
-        [
-          "99",
-          "199",
-          "299",
-          "399"
-        ]
-      ],
-      "carmen:rfromhn": [
-        [],
-        [
-          "0",
-          "100",
-          "200",
-          "300"
-        ]
-      ],
-      "carmen:rtohn": [
-        [],
-        [
-          "98",
-          "198",
-          "298",
-          "398"
-        ]
-      ],
-      "carmen:parityl": [
-        [],
-        [
-          "O",
-          "O",
-          "O",
-          "O"
-        ]
-      ],
-      "carmen:parityr": [
-        [],
-        [
-          "E",
-          "E",
-          "E",
-          "E"
-        ]
-      ],
-      "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -177,67 +55,6 @@
         0
       ],
       "carmen:addressnumber": "300",
-      "carmen:lfromhn": [
-        [],
-        [
-          "1",
-          "101",
-          "201",
-          "301"
-        ]
-      ],
-      "carmen:ltohn": [
-        [],
-        [
-          "99",
-          "199",
-          "299",
-          "399"
-        ]
-      ],
-      "carmen:rfromhn": [
-        [],
-        [
-          "0",
-          "100",
-          "200",
-          "300"
-        ]
-      ],
-      "carmen:rtohn": [
-        [],
-        [
-          "98",
-          "198",
-          "298",
-          "398"
-        ]
-      ],
-      "carmen:parityl": [
-        [],
-        [
-          "O",
-          "O",
-          "O",
-          "O"
-        ]
-      ],
-      "carmen:parityr": [
-        [],
-        [
-          "E",
-          "E",
-          "E",
-          "E"
-        ]
-      ],
-      "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -258,67 +75,6 @@
         0
       ],
       "carmen:addressnumber": "400",
-      "carmen:lfromhn": [
-        [],
-        [
-          "1",
-          "101",
-          "201",
-          "301"
-        ]
-      ],
-      "carmen:ltohn": [
-        [],
-        [
-          "99",
-          "199",
-          "299",
-          "399"
-        ]
-      ],
-      "carmen:rfromhn": [
-        [],
-        [
-          "0",
-          "100",
-          "200",
-          "300"
-        ]
-      ],
-      "carmen:rtohn": [
-        [],
-        [
-          "98",
-          "198",
-          "298",
-          "398"
-        ]
-      ],
-      "carmen:parityl": [
-        [],
-        [
-          "O",
-          "O",
-          "O",
-          "O"
-        ]
-      ],
-      "carmen:parityr": [
-        [],
-        [
-          "E",
-          "E",
-          "E",
-          "E"
-        ]
-      ],
-      "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -344,15 +100,6 @@
         0.5,
         0
       ],
-      "carmen:addressnumber": [
-        [
-          "100",
-          "200",
-          "300",
-          "400"
-        ],
-        null
-      ],
       "carmen:lfromhn": [
         "1"
       ],
@@ -372,12 +119,6 @@
         "E"
       ],
       "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -403,15 +144,6 @@
         2.5,
         0
       ],
-      "carmen:addressnumber": [
-        [
-          "100",
-          "200",
-          "300",
-          "400"
-        ],
-        null
-      ],
       "carmen:lfromhn": [
         "101"
       ],
@@ -431,12 +163,6 @@
         "E"
       ],
       "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -462,15 +188,6 @@
         4.5,
         0
       ],
-      "carmen:addressnumber": [
-        [
-          "100",
-          "200",
-          "300",
-          "400"
-        ],
-        null
-      ],
       "carmen:lfromhn": [
         "201"
       ],
@@ -490,12 +207,6 @@
         "E"
       ],
       "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1
@@ -521,15 +232,6 @@
         6.5,
         0
       ],
-      "carmen:addressnumber": [
-        [
-          "100",
-          "200",
-          "300",
-          "400"
-        ],
-        null
-      ],
       "carmen:lfromhn": [
         "301"
       ],
@@ -549,12 +251,6 @@
         "E"
       ],
       "carmen:rangetype": "tiger",
-      "carmen:zxy": [
-        "6/32/32",
-        "6/32/32",
-        "6/33/32"
-      ],
-      "carmen:hash": 1,
       "id": 1
     },
     "id": 1

--- a/test/fixtures/indexdocs.parseDocs.json
+++ b/test/fixtures/indexdocs.parseDocs.json
@@ -14,7 +14,6 @@
         0,
         0
       ],
-      "carmen:addressnumber": "100",
       "id": 1
     },
     "id": 1
@@ -31,10 +30,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        1,
+        0,
         0
       ],
-      "carmen:addressnumber": "200",
       "id": 1
     },
     "id": 1
@@ -51,10 +49,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        2,
+        0,
         0
       ],
-      "carmen:addressnumber": "300",
       "id": 1
     },
     "id": 1
@@ -71,10 +68,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        3,
+        0,
         0
       ],
-      "carmen:addressnumber": "400",
       "id": 1
     },
     "id": 1
@@ -97,28 +93,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        0.5,
+        0,
         0
       ],
-      "carmen:lfromhn": [
-        "1"
-      ],
-      "carmen:ltohn": [
-        "99"
-      ],
-      "carmen:rfromhn": [
-        "0"
-      ],
-      "carmen:rtohn": [
-        "98"
-      ],
-      "carmen:parityl": [
-        "O"
-      ],
-      "carmen:parityr": [
-        "E"
-      ],
-      "carmen:rangetype": "tiger",
       "id": 1
     },
     "id": 1
@@ -141,28 +118,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        2.5,
+        0,
         0
       ],
-      "carmen:lfromhn": [
-        "101"
-      ],
-      "carmen:ltohn": [
-        "199"
-      ],
-      "carmen:rfromhn": [
-        "100"
-      ],
-      "carmen:rtohn": [
-        "198"
-      ],
-      "carmen:parityl": [
-        "O"
-      ],
-      "carmen:parityr": [
-        "E"
-      ],
-      "carmen:rangetype": "tiger",
       "id": 1
     },
     "id": 1
@@ -185,28 +143,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        4.5,
+        0,
         0
       ],
-      "carmen:lfromhn": [
-        "201"
-      ],
-      "carmen:ltohn": [
-        "299"
-      ],
-      "carmen:rfromhn": [
-        "200"
-      ],
-      "carmen:rtohn": [
-        "298"
-      ],
-      "carmen:parityl": [
-        "O"
-      ],
-      "carmen:parityr": [
-        "E"
-      ],
-      "carmen:rangetype": "tiger",
       "id": 1
     },
     "id": 1
@@ -229,28 +168,9 @@
     "properties": {
       "carmen:text": "main street",
       "carmen:center": [
-        6.5,
+        0,
         0
       ],
-      "carmen:lfromhn": [
-        "301"
-      ],
-      "carmen:ltohn": [
-        "399"
-      ],
-      "carmen:rfromhn": [
-        "300"
-      ],
-      "carmen:rtohn": [
-        "398"
-      ],
-      "carmen:parityl": [
-        "O"
-      ],
-      "carmen:parityr": [
-        "E"
-      ],
-      "carmen:rangetype": "tiger",
       "id": 1
     },
     "id": 1

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -131,8 +131,8 @@ var addFeature = require('../lib/util/addfeature');
             id:1,
             properties: {
                 'carmen:text':'china',
-                'carmen:zxy':['6/33/32'],
-                'carmen:center':[360/64,0]
+                'carmen:zxy':['6/34/32'],
+                'carmen:center':[360/64*2,0]
             }
         };
         addFeature(conf.province, province, t.end);
@@ -142,8 +142,8 @@ var addFeature = require('../lib/util/addfeature');
             id:1,
             properties: {
                 'carmen:text':'china',
-                'carmen:zxy':['6/34/32'],
-                'carmen:center':[360/64*2,0]
+                'carmen:zxy':['6/36/32'],
+                'carmen:center':[360/64*4,0]
             }
         };
         addFeature(conf.city, city, t.end);
@@ -185,8 +185,8 @@ var addFeature = require('../lib/util/addfeature');
             properties: {
                 'carmen:score': 10,
                 'carmen:text':'china',
-                'carmen:zxy':['6/33/32'],
-                'carmen:center':[360/64,0]
+                'carmen:zxy':['6/34/32'],
+                'carmen:center':[360/64 * 2,0]
             }
         };
         addFeature(conf.province, province, t.end);
@@ -197,8 +197,8 @@ var addFeature = require('../lib/util/addfeature');
             properties: {
                 'carmen:score': 6,
                 'carmen:text':'china',
-                'carmen:zxy':['6/34/32'],
-                'carmen:center':[360/64*2,0]
+                'carmen:zxy':['6/36/32'],
+                'carmen:center':[360/64 * 4,0]
             }
         };
         addFeature(conf.city, city, t.end);

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -30,7 +30,7 @@ tape('index city', function(t) {
         id:1,
         properties: {
             'carmen:text':'windsor',
-            'carmen:zxy':['6/32/32','6/33/32'],
+            'carmen:zxy':['6/32/32','6/34/32'],
             'carmen:center':[0,0]
         }
     };
@@ -41,8 +41,8 @@ tape('index street', function(t) {
         id:1,
         properties: {
             'carmen:text':'windsor ct',
-            'carmen:zxy':['6/33/32'],
-            'carmen:center':[360/64,0]
+            'carmen:zxy':['6/34/32'],
+            'carmen:center':[360/32,0]
         }
     };
     addFeature(conf.street, street, t.end);

--- a/test/indexdocs.parseDocs.test.js
+++ b/test/indexdocs.parseDocs.test.js
@@ -16,7 +16,16 @@ tape('indexdocs.parseDocs (passthru)', function(assert) {
     var full = { vectors: [] };
     var err = indexdocs.parseDocs(docs, settings, full);
     assert.ifError(err);
-    assert.deepEqual(full.vectors, docs);
+    assert.deepEqual(full.vectors, [{
+        id: 1,
+        type: 'Feature',
+        properties: {
+            id: 1,
+            'carmen:text': 'main street',
+            'carmen:center': [0,0]
+        },
+        geometry: { type: 'Point', coordinates: [0,0] }
+    }]);
     assert.end();
 });
 

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -24,7 +24,6 @@ tape('indexdocs.loadDoc', function(assert) {
             'carmen:text': 'main st',
             'carmen:center': [0, 0],
             'carmen:zxy': ['6/32/32', '6/33/33'],
-            'carmen:hash': 1,
             'carmen:score': 100
         },
         geometry: {
@@ -72,7 +71,7 @@ tape('indexdocs.standardize', function(assert) {
             }
         }, 6, {});
 
-        t.deepEquals(res, { geometry: { coordinates: [ 0, 0 ], type: 'Point' }, id: 1, properties: { 'carmen:center': [ 0, 0 ], 'carmen:hash': 1, 'carmen:text': 'main street', 'carmen:zxy': [ '6/32/32' ] }, type: 'Feature' });
+        t.deepEquals(res, { geometry: { coordinates: [ 0, 0 ], type: 'Point' }, id: 1, properties: { 'carmen:center': [ 0, 0 ], 'carmen:text': 'main street', 'carmen:zxy': [ '6/32/32' ] }, type: 'Feature' });
         t.end();
     });
 
@@ -148,7 +147,7 @@ tape('indexdocs.standardize', function(assert) {
             }
         }, 6, {});
 
-        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:addressnumber":[[9]],"carmen:zxy":["6/32/32"],"carmen:hash":1},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0]]}]}});
+        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:addressnumber":[[9]],"carmen:zxy":["6/32/32"]},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0]]}]}});
         t.end();
     });
 
@@ -167,7 +166,7 @@ tape('indexdocs.standardize', function(assert) {
             }
         }, 6, {});
 
-        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:addressnumber":[['9a']],"carmen:zxy":["6/32/32"],"carmen:hash":1},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0]]}]}});
+        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:addressnumber":[['9a']],"carmen:zxy":["6/32/32"]},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0]]}]}});
         t.end();
     });
 
@@ -211,7 +210,7 @@ tape('indexdocs.standardize', function(assert) {
             }
         }, 6, {});
 
-        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:rangetype":"tiger","carmen:parityl":[["E"]],"carmen:parityr":[["O"]],"carmen:lfromhn":[["2"]],"carmen:ltohn":[["100"]],"carmen:rfromhn":[["1"]],"carmen:rtohn":[["101"]],"carmen:zxy":["6/32/31","6/32/32"],"carmen:hash":1},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiLineString","coordinates":[[[0,0],[1,1]]]}]}});
+        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:rangetype":"tiger","carmen:parityl":[["E"]],"carmen:parityr":[["O"]],"carmen:lfromhn":[["2"]],"carmen:ltohn":[["100"]],"carmen:rfromhn":[["1"]],"carmen:rtohn":[["101"]],"carmen:zxy":["6/32/31","6/32/32"]},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiLineString","coordinates":[[[0,0],[1,1]]]}]}});
         t.end();
     });
 
@@ -236,7 +235,7 @@ tape('indexdocs.standardize', function(assert) {
             }
         }, 6, {});
 
-        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:rangetype":"tiger","carmen:parityl":[["E"]],"carmen:parityr":[["O"]],"carmen:lfromhn":[["2"]],"carmen:ltohn":[["100"]],"carmen:rfromhn":[["1"]],"carmen:rtohn":[["101"]],"carmen:zxy":["6/32/31","6/32/32"],"carmen:hash":1},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiLineString","coordinates":[[[0,0],[1,1]]]}]}});
+        t.deepEquals(res, {"id":1,"type":"Feature","properties":{"carmen:text":"main street","carmen:center":[0,0],"carmen:rangetype":"tiger","carmen:parityl":[["E"]],"carmen:parityr":[["O"]],"carmen:lfromhn":[["2"]],"carmen:ltohn":[["100"]],"carmen:rfromhn":[["1"]],"carmen:rtohn":[["101"]],"carmen:zxy":["6/32/31","6/32/32"]},"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiLineString","coordinates":[[[0,0],[1,1]]]}]}});
         t.end();
     });
 


### PR DESCRIPTION
Removes interpolation properties from point address features and vice versa in vector output.

- [x] IRL integration testing
- [x] Size comparisons/tests with real datasets
- [x] Update proximityVector() to load features

cc @mapbox/geocoding-gang 