### PR TITLE
make `--debug` more verbose

### DIFF
--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -117,8 +117,29 @@ carmen.geocode(argv.query, {
     }
 
     if (argv.debug) {
-        console.log('Debug\n-----');
-        console.log(data.debug);
+        console.log('Debug');
+        console.log('=====');
+        console.log('id:', data.debug.id);
+        console.log('extid:', data.debug.extid);
+        console.log();
+
+        console.log('PhraseMatch');
+        console.log('-----------');
+        Object.keys(data.debug.phrasematch).forEach(function(idx) {
+            console.log('  ', idx, JSON.stringify(data.debug.phrasematch[idx]));
+        });
+        console.log()
+
+        console.log('SpatialMatch');
+        console.log('------------');
+        console.log('spatialmatch position:', data.debug.spatialmatch_position);
+        console.log(JSON.stringify(data.debug.spatialmatch, null, 2));
+        console.log();
+
+        console.log('VerifyMatch');
+        console.log('-----------');
+        console.log('verifymatch position:', data.debug.verifymatch_position);
+        console.log(JSON.stringify(data.debug.verifymatch, null, 2));
         console.log();
     }
 

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -93,11 +93,11 @@ tape('bin/carmen DEBUG', function(t) {
     exec(bin + '/carmen.js ' + tmpindex + ' --query="canada" --debug="38"', function(err, stdout, stderr) {
         t.ifError(err);
         t.equal(/0\.99 Canada/.test(stdout), true, 'finds canada');
-        t.ok(stdout.indexOf('phrasematch:') !== -1, 'debug phrase match');
-        t.ok(stdout.indexOf('spatialmatch:') !== -1, 'debug spatial');
-        t.ok(stdout.indexOf('spatialmatch_position:') !== -1, 'debug spatial');
-        t.ok(stdout.indexOf('verifymatch:') !== -1, 'debug verify match');
-        t.ok(stdout.indexOf('verifymatch_position:') !== -1, 'debug verify match');
+        t.ok(stdout.indexOf('PhraseMatch\n-----------') !== -1, 'debug phrase match');
+        t.ok(stdout.indexOf('SpatialMatch\n------------') !== -1, 'debug spatial');
+        t.ok(stdout.indexOf('spatialmatch position: 0') !== -1, 'debug spatial');
+        t.ok(stdout.indexOf('VerifyMatch\n-----------') !== -1, 'debug verify match');
+        t.ok(stdout.indexOf('verifymatch position: 0') !== -1, 'debug verify match');
         t.end();
     });
 });


### PR DESCRIPTION
builds on @ingalls' excellent idea, but goes for the full `JSON.stringify` now that we are debugging implementations that rely more heavily on feature scores and don't want them hidden away as `[ Object ]`s. Cleaned up formatting a little bit while I was at it.