### PR TITLE
Refactor types/limits code flow + requirements

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -28,11 +28,8 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     var full = options.full || false;
     var matched = options.matched || {};
     var language = options.language || false;
-    var limit = options.limit || false;
 
     index_ids = index_ids.slice(0, maxidx);
-
-    if (limit && (!options.types || options.types.length !== 1)) return callback('limit can only be used with a single type for reverse geocodes');
 
     // No-op context.
     if (!index_ids.length) return callback(null, context);
@@ -42,43 +39,12 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     for (var index_ids_it = 0; index_ids_it < index_ids.length; index_ids_it++) {
         var source = indexes[index_ids[index_ids_it]];
         var bounds = source.bounds;
-
         if (lat >= bounds[1] && lat <= bounds[3] && lon >= bounds[0] && lon <= bounds[2]) {
-            //Setting the limit/type results in only the first level results being returned.
-            if (limit) {
-                if (options.types[0] !== source.type) continue;
-                q.defer(proximityVector, source, lon, lat);
-            } else {
-                q.defer(contextVector, source, lon, lat, full, matched, language);
-            }
+            q.defer(contextVector, source, lon, lat, full, matched, language);
         }
     }
 
-    if (limit) {
-        q.awaitAll(proximityFormatter);
-    } else {
-        q.awaitAll(contextFormatter);
-    }
-
-    function proximityFormatter(err, res) {
-        if (err) return callback(err);
-
-        var combined = [];
-        for (var res_it = 0; res_it < res.length; res_it++) {
-            combined = combined.concat(res[res_it]);
-        }
-
-        combined.sort(function(a, b) {
-            if (a['carmen:vtquerydist'] > b['carmen:vtquerydist']) return 1;
-            if (a['carmen:vtquerydist'] < b['carmen:vtquerydist']) return -1;
-        });
-
-        combined = combined.slice(0, options.limit);
-
-        return callback(null, combined);
-    }
-
-    function contextFormatter(err, res) {
+    q.awaitAll(function(err, res) {
         if (err) return callback(err);
         var stack = [];
         var memo = {};
@@ -143,7 +109,7 @@ module.exports = function(geocoder, lon, lat, options, callback) {
             stack.push(memo[types[k]]);
         }
         callback(null, stack);
-    }
+    });
 };
 
 // Returns an array of lon, lat pairs of features closest to the query point.

--- a/lib/context.js
+++ b/lib/context.js
@@ -146,6 +146,42 @@ module.exports = function(geocoder, lon, lat, options, callback) {
     }
 };
 
+// Returns an array of lon, lat pairs of features closest to the query point.
+// This is used as a first pass when reverse geocoding multiple results when limit
+// type is set. Each point is then reverse geocoded separately.
+//
+// @param {Object} geocoder: geocoder instance
+// @param {Float} lon: input longitude
+// @param {Float} lat: input latitude
+// @param {String} type: source type
+// @param {Number} limit: number of points to return
+// @param {Function} callback
+function nearest(geocoder, lon, lat, type, limit, callback) {
+    var indexes = geocoder.indexes;
+    var index_ids = Object.keys(indexes);
+    var q = queue();
+
+    for (var index_ids_it = 0; index_ids_it < index_ids.length; index_ids_it++) {
+        var source = indexes[index_ids[index_ids_it]];
+        var bounds = source.bounds;
+        if (lat >= bounds[1] && lat <= bounds[3] && lon >= bounds[0] && lon <= bounds[2]) {
+            if (type !== source.type) continue;
+            q.defer(nearestPoints, source, lon, lat);
+        }
+    }
+
+    q.awaitAll(function(err, res) {
+        if (err) return callback(err);
+        var combined = [];
+        for (var res_it = 0; res_it < res.length; res_it++) {
+            combined = combined.concat(res[res_it]);
+        }
+        combined.sort(function(a, b) { return a.distance - b.distance; });
+        combined = combined.slice(0, limit);
+        return callback(null, combined);
+    });
+}
+
 var getTile = Locking(function(options, unlock) {
     var source = options.source;
     var z = parseInt(options.z,10);
@@ -176,7 +212,8 @@ getTile.setVtCacheSize = function(size) {
 }
 
 module.exports.getTile = getTile;
-module.exports.proximityVector = proximityVector;
+module.exports.nearest = nearest;
+module.exports.nearestPoints = nearestPoints;
 module.exports.contextVector = contextVector;
 
 function tileCover(source, lon, lat, cb) {
@@ -199,9 +236,9 @@ function tileCover(source, lon, lat, cb) {
     getTile(options, cb);
 }
 
-//For a given type & limit load each source of that type, gather n results
-//and return results in a flat array. (No context is returned)
-function proximityVector(source, lon, lat, callback) {
+// For a source return an array of nearest feature hit points/center points as
+// a flat array of lon,lat coordinates.
+function nearestPoints(source, lon, lat, callback) {
     tileCover(source, lon, lat, query);
 
     function query(err, vt) {
@@ -212,37 +249,34 @@ function proximityVector(source, lon, lat, callback) {
         vt.query(lon, lat, {
             tolerance: 1000,
             layer: source.geocoder_layer
-        }, function(err, results) {
-            if (err) return callback(err);
-            if (!results || !results.length) return callback(null, []);
+        }, afterQuery);
+    }
 
-            var loaded = [];
-            for (var results_it = 0; results_it < results.length; results_it++) {
-                var attr = results[results_it].attributes();
+    function afterQuery(err, results) {
+        if (err) return callback(err);
+        if (!results || !results.length) return callback(null, []);
 
-                if ((source.data && source.data.geocoder_version) < 5 || attr._text) { attr = feature.transform(attr); }
-
-                // If geojson has an id in properties use that otherwise use VT id
-                attr.id = attr.id || results[results_it].id();
-
-                if ((attr["carmen:score"] || (attr.properties && attr.properties["carmen:score"])) < 0) continue;
-                attr['carmen:vtquerydist'] = results[results_it].distance;
-                attr['carmen:geomtype'] = results[results_it].geometry().type();
-
-                if (results[results_it].x_hit) {
-                    attr['carmen:geom'] = [results[results_it].x_hit, results[results_it].y_hit];
-                }
-                if (!attr['carmen:geom'] && attr['carmen:center']) {
-                    var coords = attr['carmen:center'][0] === '[' ?
-                        JSON.parse(attr['carmen:center']) :
-                        attr['carmen:center'].split(',');
-                    attr['carmen:geom'] = [parseFloat(coords[0]), parseFloat(coords[1])];
-                }
-                loaded.push(attr);
+        var loaded = [];
+        for (var results_it = 0; results_it < results.length; results_it++) {
+            var result = results[results_it];
+            var attr = result.attributes();
+            if ((attr['carmen:score'] || (attr.properties && attr.properties['carmen:score'])) < 0) continue;
+            var hit;
+            if (result.x_hit) {
+                hit = [result.x_hit, result.y_hit];
+                hit.distance = result.distance;
+            } else if (attr['carmen:center']) {
+                hit = attr['carmen:center'][0] === '[' ?
+                    JSON.parse(attr['carmen:center']) :
+                    attr['carmen:center'].split(',');
+                hit[0] = parseFloat(hit[0]);
+                hit[1] = parseFloat(hit[1]);
+                hit.distance = result.distance;
             }
+            if (hit) loaded.push(hit);
+        }
 
-            return callback(null, loaded);
-        });
+        return callback(null, loaded);
     }
 }
 

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -158,18 +158,13 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
     };
 
     if (options.limit > 1) {
-        context(geocoder, queryData.query[0], queryData.query[1], {
-            full: false,
-            types: options.types,
-            stacks: options.stacks,
-            limit: options.limit
-        }, function(err, feats) {
+        context.nearest(geocoder, queryData.query[0], queryData.query[1], options.types[0], options.limit, function(err, feats) {
             if (err) return callback(err);
 
             var q = queue();
 
             for (var feat_it = 0; feat_it < feats.length; feat_it++) {
-                var coords = feats[feat_it]['carmen:geom'];
+                var coords = feats[feat_it];
                 q.defer(context, geocoder, coords[0], coords[1], {
                     full: true,
                     types: options.types,

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -135,7 +135,7 @@ test('contextVector empty VT buffer', function(assert) {
     });
 });
 
-test('proximityVector empty VT buffer', function(assert) {
+test('nearestPoints empty VT buffer', function(assert) {
     context.getTile.cache.reset();
 
     var vtile = new mapnik.VectorTile(0,0,0);
@@ -153,7 +153,7 @@ test('proximityVector empty VT buffer', function(assert) {
             id: 'testA',
             idx: 0
         };
-        context.proximityVector(source, 0, 0, function(err, data) {
+        context.nearestPoints(source, 0, 0, function(err, data) {
             assert.ifError(err);
             assert.deepEqual(data, []);
             assert.end();

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -106,15 +106,16 @@ var addFeature = require('../lib/util/addfeature');
         place: new mem({
             maxzoom: 6
         }, function() {}),
+        address: new mem({
+            maxzoom: 12,
+            geocoder_name: 'address',
+            geocoder_type: 'address',
+            geocoder_address: true
+        }, function() {}),
         poi: new mem({
             maxzoom: 12,
             geocoder_name: 'poi',
             geocoder_type: 'poi'
-        }, function() {}),
-        address: new mem({
-            maxzoom: 12,
-            geocoder_name: 'poi',
-            geocoder_type: 'address'
         }, function() {})
     };
     var c = new Carmen(conf);
@@ -161,29 +162,27 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index address', function(t) {
-        var q = queue(1);
-        for (var i = 6; i < 11; i++) q.defer(function(i, done) {
-            addFeature(conf.address, {
-                id: i-5,
-                properties: {
-                    'carmen:text':'address ' + i,
-                    'carmen:center': coords[i-1],
-                },
-                geometry: {
-                    type: "Point",
-                    coordinates: coords[i-1]
-                }
-            }, done);
-        }, i);
-        q.awaitAll(t.end);
+        addFeature(conf.address, {
+            id: 1,
+            properties: {
+                'carmen:addressnumber': [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+                'carmen:text':'main road',
+                'carmen:center': coords[0],
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: coords
+            }
+        }, t.end);
     });
 
     tape('default response is 1 features (reverse)', function(t) {
-        c.geocode('-79.37745451927184,38.83420867393712', {  }, function(err, res) {
+        c.geocode('-79.37745451927184,38.83420867393712', { }, function(err, res) {
             t.ifError(err);
-            t.equal(res.features.length, 2, 'returns 1 result of 2 context');
-            t.equal(res.features[0].place_name, 'seneca rocks 5, west virginia');
-            t.equal(res.features[1].place_name, 'west virginia');
+            t.equal(res.features.length, 3, 'returns 1 result of 3 context');
+            t.equal(res.features[0].place_name, 'seneca rocks 5, main road, west virginia');
+            t.equal(res.features[1].place_name, '5 main road, west virginia');
+            t.equal(res.features[2].place_name, 'west virginia');
             t.end();
         });
     });
@@ -203,11 +202,11 @@ var addFeature = require('../lib/util/addfeature');
     tape('limit 5 results (reverse)', function(t) {
         c.geocode('-79.37745451927184,38.83420867393712', { limit: 5, types: ['poi'] }, function(err, res) {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'seneca rocks 5, west virginia');
-            t.equal(res.features[1].place_name, 'seneca rocks 2, west virginia');
-            t.equal(res.features[2].place_name, 'seneca rocks 3, west virginia');
-            t.equal(res.features[3].place_name, 'seneca rocks 4, west virginia');
-            t.equal(res.features[4].place_name, 'seneca rocks 1, west virginia');
+            t.equal(res.features[0].place_name, 'seneca rocks 5, main road, west virginia');
+            t.equal(res.features[1].place_name, 'seneca rocks 2, main road, west virginia');
+            t.equal(res.features[2].place_name, 'seneca rocks 3, main road, west virginia');
+            t.equal(res.features[3].place_name, 'seneca rocks 4, main road, west virginia');
+            t.equal(res.features[4].place_name, 'seneca rocks 1, main road, west virginia');
             t.equal(res.features.length, 5, 'returns 5 results');
             t.end();
         });
@@ -215,11 +214,23 @@ var addFeature = require('../lib/util/addfeature');
     tape('limit 6 results (reverse)', function(t) {
         c.geocode('-79.37745451927184,38.83420867393712', { limit: 6, types: ['poi'] }, function(err, res) {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'seneca rocks 5, west virginia');
-            t.equal(res.features[1].place_name, 'seneca rocks 2, west virginia');
-            t.equal(res.features[2].place_name, 'seneca rocks 3, west virginia');
-            t.equal(res.features[3].place_name, 'seneca rocks 4, west virginia');
-            t.equal(res.features[4].place_name, 'seneca rocks 1, west virginia');
+            t.equal(res.features[0].place_name, 'seneca rocks 5, main road, west virginia');
+            t.equal(res.features[1].place_name, 'seneca rocks 2, main road, west virginia');
+            t.equal(res.features[2].place_name, 'seneca rocks 3, main road, west virginia');
+            t.equal(res.features[3].place_name, 'seneca rocks 4, main road, west virginia');
+            t.equal(res.features[4].place_name, 'seneca rocks 1, main road, west virginia');
+            t.equal(res.features.length, 5, 'returns 5 results - hard limit');
+            t.end();
+        });
+    });
+    tape('limit 5 results (address)', function(t) {
+        c.geocode('-79.37745451927184,38.83420867393712', { limit: 5, types: ['address'] }, function(err, res) {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, '5 main road, west virginia');
+            t.equal(res.features[1].place_name, '6 main road, west virginia');
+            t.equal(res.features[2].place_name, '2 main road, west virginia');
+            t.equal(res.features[3].place_name, '3 main road, west virginia');
+            t.equal(res.features[4].place_name, '8 main road, west virginia');
             t.equal(res.features.length, 5, 'returns 5 results - hard limit');
             t.end();
         });


### PR DESCRIPTION
Turns out the types/limits flow was already loading features per need in https://github.com/mapbox/carmen/pull/503. This PR does some cleanup/refactoring to make this clearer.

- `types + limit` reverse query mode is now only a concept handled by `reverseGeocode()`.
- `context()` always returns a single context.
- Adds `context.nearest()` for playing the role that the proximity context mode played before -- returns a flat array of `[ lon, lat ]` points that can then be `context()` queried for full features.
- Adds additional unit test to demonstrate that in types/limits mode reverse geocodes do indeed load full features/derive address points properly.

cc @ingalls for the review