### PR TITLE
replace source tokens after tokenizing query

### DIFF
--- a/bench/replaceTokenPermutation.js
+++ b/bench/replaceTokenPermutation.js
@@ -3,24 +3,25 @@ var suite = new Benchmark.Suite();
 var assert = require('assert');
 var termops = require('../lib/util/termops');
 var token = require('../lib/util/token');
-var tape = require('tape');
 
 module.exports = benchmark;
 
 function benchmark(cb) {
     if (!cb) cb = function() {};
     console.log('# replace tokens');
+    var replacer;
 
     suite
     .add('Permutations all together of 1 token', function() {
         var replacer = token.createReplacer({'Street':'St', 'North':'N'});
-        assert.deepEqual(termops.replaceTokenPermutations(replacer, 'North Main Street').sort(), ['North Main Street', 'N Main St', 'North Main St', 'N Main Street'].sort()
+        assert.deepEqual(termops.replaceTokenPermutations(replacer, ['north', 'main', 'street']),
+            [['north', 'main', 'street'], ['n', 'main', 'st'], ['north', 'main', 'st'], ['n', 'main', 'street']]
         );
     })
     .add('Permutation all together of 3 tokens', function() {
-        replacer = token.createReplacer({'Street':'St', 'North':'N', 'Main':'Mn'});
-        assert.deepEqual(termops.replaceTokenPermutations(replacer, 'North Main Street').sort(), ['N Main St','N Main Street','N Mn St','N Mn Street','North Main St','North Main Street','North Mn St','North Mn Street']);
-
+        var replacer = token.createReplacer({'Street':'St', 'North':'N', 'Main':'Mn'});
+        assert.deepEqual(termops.replaceTokenPermutations(replacer, ['north', 'main', 'street']),
+            [['north', 'main', 'street'], ['n', 'mn', 'st'], ['n', 'main', 'st'], ['north', 'mn', 'st'], ['n', 'mn', 'street'], ['north', 'main', 'st'], ['n', 'main', 'street'], ['north', 'mn', 'street']]);
     })
     .add('##### WITHOUT XREGEXP:\n SPLIT(1)create token replacer', function() {
         replacer = token.createReplacer({'First': '1st','Second': '2nd','Third': '3rd','Fourth': '4th','Fifth': '5th','Sixth': '6th','Seventh': '7th','Eigth': '8th','Ninth': '9th','Tenth': '10th','Eleventh': '11th','Twelfth': '12th','Thirteenth': '13th','Fourteenth': '14th','Fifteenth': '15th','Sixteenth': '16th','Seventeenth': '17th','Eighteenth': '18th','Nineteenth': '19th','Twentieth': '20th','Alley': 'Aly','Arcade': 'Arc','Avenue': 'Ave','Bayoo': 'Byu','Beach': 'Bch','Bluff': 'Blf','Bottom': 'Btm','Boulevard': 'Blvd','Branch': 'Br','Bridge': 'Brg','Brook': 'Brk','Brooks': 'Brks','Burg': 'Bg','Burgs': 'Bgs','Bypass': 'Byp','Calle': 'Cll','Camp': 'Cp','Canyon': 'Cyn','Cape': 'Cpe','Causeway': 'Cswy','Center': 'Ctr','Centers': 'Ctrs','Circle': 'Cir','Circles': 'Cirs','Cliff': 'Clf','Cliffs': 'Clfs','Club': 'Clb','Common': 'Cmn','Corner': 'Cor','Course': 'Crse','Court': 'Ct','Courts': 'Cts','Cove': 'Cv','Creek': 'Crk','Crescent': 'Cres','Crest': 'Crst','Crossing': 'Xing','Curve': 'Curv','Dale': 'Dl','Dam': 'Dm','Divide': 'Dv','Drive': 'Dr','Drives': 'Drs','East': 'E','Estate': 'Est','Estates': 'Ests','Expressway': 'Expy','Extension': 'Ext','Extensions': 'Exts','Falls': 'Fls','Ferry': 'Fry','Field': 'Fld','Fields': 'Flds','Flat': 'Flt','Flats': 'Flts','Ford': 'Frd','Forest': 'Frst','Forge': 'Frg','Forges': 'Frgs','Fork': 'Frk','Fort': 'Ft','Freeway': 'Fwy','Grade': 'Grd','Green': 'Grn','Harbor': 'Hbr','Harbors': 'Hbrs','Haven': 'Hvn','Heights': 'Hts','Highway': 'Hwy','Hill': 'Hl','Hills': 'Hls','Hollow': 'Holw','Industrial': 'Ind','Interstate': 'I','Island': 'Is','Islands': 'Iss','Junction': 'Jct','Junctions': 'Jcts','Junior': 'Jr','Key': 'Ky','Keys': 'Kys','Knoll': 'Knl','Knolls': 'Knls','Lake': 'Lk','Lakes': 'Lks','Landing': 'Lndg','Lane': 'Ln','Lieutenant': 'Lt','Light': 'Lgt','Lights': 'Lgts','Loaf': 'Lf','Lock': 'Lck','Locks': 'Lcks','Lodge': 'Ldg','Mall': 'Mal','Manor': 'Mnr','Manors': 'Mnrs','Meadow': 'Mdw','Meadows': 'Mdws','Mill': 'Ml','Mission': 'Msn','Moorhead': 'Mhd','Motorway': 'Mtwy','Mountain': 'Mtn','Mount': 'Mt','Neck': 'Nck','Northeast': 'NE','North': 'N','Northwest': 'NW','Orchard': 'Orch','Overpass': 'Ovps','Parkway': 'Pky','Passage': 'Psge','Place': 'Pl','Plain': 'Pln','Plains': 'Plns','Plaza': 'Plz','Point': 'Pt','Points': 'Pts','Port': 'Prt','Ports': 'Prts','Prairie': 'Pr','Private': 'Pvt','Radial': 'Radl','Ranch': 'Rnch','Rapid': 'Rpd','Rapids': 'Rpds','Rest': 'Rst','Ridge': 'Rdg','Ridges': 'Rdgs','River': 'Riv','Road': 'Rd','Roads': 'Rds','Route': 'Rte','Saint': 'St','Senior': 'Sr','Sergeant': 'Sgt','Shoal': 'Shl','Shoals': 'Shls','Shore': 'Shr','Shores': 'Shrs','Skyway': 'Sky','Southeast': 'SE','South': 'S','Southwest': 'SW','Spring': 'Spg','Springs': 'Spgs','Square': 'Sq','Squares': 'Sqs','Station': 'Sta','Stream': 'Strm','Streets': 'Sts','Street': 'St','Summit': 'Smt','Terrace': 'Ter','Thoroughfare': 'Thfr','Thruway': 'Thwy','Trace': 'Trce','Trafficway': 'Tfwy','Trail': 'Trl','Tunnel': 'Tunl','Turnpike': 'Tpke','Underpass': 'Unp','Unions': 'Uns','Union': 'Un','Valleys': 'Vlys','Valley': 'Vly','Viaduct': 'Via','Views': 'Vws','View': 'Vw','Villages': 'Vlgs','Village': 'Vlg','Ville': 'Vl','Vista': 'Vis','Walkway': 'Wlky','West': 'W','San Francisco': 'sf'});
@@ -36,10 +37,11 @@ function benchmark(cb) {
         });
     })
     .add('SPLIT (2): filtering tokens', function() {
-        token.tokenReplacerFilter(replacer,'North Main Street');
+        token.tokenReplacerFilter(replacer, ['north', 'main', 'street']);
     })
     .add('SPLIT (3): Permutation of US index tokens with a query regex', function() {
-        assert.deepEqual(termops.replaceTokenPermutations(replacer, 'Suite 123 North Main Street').sort(),[ ' N Main St',' N Main Street',' North Main St',' North Main Street','Suite 123 N Main St','Suite 123 N Main Street','Suite 123 North Main St','Suite 123 North Main Street' ].sort());
+        assert.deepEqual(termops.replaceTokenPermutations(replacer, ['suite', '123', 'north', 'main', 'street']).sort(),
+            [ [ 'suite', '123', 'n', 'main', 'st' ], [ 'suite', '123', 'n', 'main', 'street' ], [ 'suite', '123', 'north', 'main', 'st' ], [ 'suite', '123', 'north', 'main', 'street' ] ].sort());
     })
     .on('cycle', function(event) {
         console.log(String(event.target));

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -30,14 +30,9 @@ module.exports = function phrasematch(source, query, options, callback) {
     // - Mt Drive
     // - Mountain Dr
     // - Mt Dr
-    var queries = termops.replaceTokenPermutations(source.token_replacer, query, termops.tokenize(query).length);
+    var queries = termops.replaceTokenPermutations(source.token_replacer, termops.tokenize(query));
     var subqueries = [];
-    queries.forEach(function(query) {
-        // Split a query string into an array of tokens. Splits phrases along
-        // whitespace and other word boundaries. Example:
-        //
-        // "Lake View Drive" => ["Lake", "View", "Drive"]
-        var tokenized = termops.tokenize(query);
+    queries.forEach(function(tokenized) {
 
         // Get all subquery permutations from the query. Generates subquery
         // objects which represent a grouping of tokens that may be considered

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -578,16 +578,16 @@ function numTokenV3(str) {
 }
 
 module.exports.replaceTokenPermutations = replaceTokenPermutations;
-function replaceTokenPermutations(tokenReplacer, query) {
-    tokenReplacer = token.tokenReplacerFilter(tokenReplacer, query);
-    var queryWithTokenPermutations = [query];
+function replaceTokenPermutations(tokenReplacer, queryTokens) {
+    tokenReplacer = token.tokenReplacerFilter(tokenReplacer, queryTokens);
+    var queryWithTokenPermutations = [queryTokens];
     var permuteTokens = JSON.parse(JSON.stringify(permutations(Object.keys(tokenReplacer),'',true)));
     permuteTokens.forEach(function(pT) {
         var tokenReplacerSubset = []
         pT.forEach(function(tinyTP) {
             tokenReplacerSubset.push(tokenReplacer[tinyTP]);
         });
-        queryWithTokenPermutations.push(token.replaceToken(tokenReplacerSubset, query));
+        queryWithTokenPermutations.push(token.replaceTokenizedQueryTokens(tokenReplacerSubset, queryTokens));
     });
     return queryWithTokenPermutations;
 }

--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -27,32 +27,18 @@ module.exports.createReplacer = function(tokens) {
                 throw new Error('Cannot process \'%s\'; must use either named or numbered capture groups, not both', from);
 
             if (entry.named) {
-                entry.rFrom = new XRegExp('(?<tokenBeginning>\\W|^)' + to + '(?<tokenEnding>\\W|$)', 'gi');
-                entry.rTo = '${tokenBeginning}' + from + '${tokenEnding}';
-                entry.from = new XRegExp('(?<tokenBeginning>\\W|^)' + from + '(?<tokenEnding>\\W|$)', 'gi');
-                entry.to = '${tokenBeginning}' + to + '${tokenEnding}';
+                entry.rFrom = new XRegExp('^' + to + '$', 'gi');
+                entry.rTo = from;
+                entry.from = new XRegExp('^' + from + '$', 'gi');
+                entry.to = to;
             } else if (!to) {
-                entry.from = new RegExp('(\\W|^)' + from + '(\\W|$)', 'gi');
-                entry.to = '$1 $2';
+                entry.from = new RegExp('^' + from + '$', 'gi');
+                entry.to = '';
             } else {
-                entry.from = new RegExp('(\\W|^)' + from + '(\\W|$)', 'gi');
-                entry.rFrom = new RegExp('(\\W|^)' + to + '(\\W|$)', 'gi');
-
-                // increment replacements indexes in `to`
-                var groupReplacements = 0;
-                var to_ = to.replace(/\$(\d+)/g, function(str, index) {
-                    groupReplacements++;
-                    return '$' + (parseInt(index)+1).toString();
-                });
-                entry.to = '$1' + to_ + '$' + (groupReplacements + 2).toString();
-
-                // increment replacement indexes in `from` to generate rTo
-                groupReplacements = 0;
-                var rTo_ = from.replace(/\$(\d+)/g, function(str, index) {
-                    groupReplacements++;
-                    return '$' + (parseInt(index)+1).toString();
-                });
-                entry.rTo = '$1' + rTo_ + '$' + (groupReplacements + 2).toString();
+                entry.from = new RegExp('^' + from + '$', 'gi');
+                entry.rFrom = new RegExp('^' + to + '$', 'gi');
+                entry.to = to;
+                entry.rTo = from;
             }
 
             replacers.push(entry);
@@ -61,7 +47,8 @@ module.exports.createReplacer = function(tokens) {
     return replacers;
 };
 
-module.exports.replaceToken = function(tokens, query) {
+module.exports.replaceToken = replaceToken;
+function replaceToken(tokens, query) {
     var abbr = query;
     for (var i=0; i<tokens.length; i++) {
         if (tokens[i].named)
@@ -72,6 +59,14 @@ module.exports.replaceToken = function(tokens, query) {
 
     return abbr;
 }
+
+module.exports.replaceTokenizedQueryTokens = function(tokens, tokenizedQuery) {
+    var replacedQuery = [];
+    for (var t = 0; t < tokenizedQuery.length; t++) {
+        replacedQuery.push(replaceToken(tokens, tokenizedQuery[t]).toLowerCase());
+    }
+    return replacedQuery;
+};
 
 module.exports.createGlobalReplacer = function(tokens) {
     var replacers = [];
@@ -90,20 +85,27 @@ module.exports.createGlobalReplacer = function(tokens) {
     return replacers;
 }
 
-module.exports.tokenReplacerFilter = function(tokens, query) {
+module.exports.tokenReplacerFilter = function(tokens, queryTokens) {
     var matches = [];
     tokens.forEach(function(token) {
-        if (!token.named) {
-            if (token.from.test(query)) {
-                matches.push({named: token.named, from: token.from, to:token.to});
-            } else if (token.rFrom && token.rFrom.test(query)) {
-                matches.push({named: token.named, from: token.rFrom, to:token.rTo});
-            }
-        } else if (token.named) {
-            if (XRegExp(token.from).test(query)) {
-                matches.push({named: token.named, from: token.from, to:token.to});
-            } else if (token.rFrom && XRegExp(token.rFrom).test(query)) {
-                matches.push({named: token.named, from: token.rFrom, to:token.rTo});
+        for (var q = 0; q < queryTokens.length; q++) {
+            var queryToken = queryTokens[q];
+            if (!token.named) {
+                if (token.from.test(queryToken)) {
+                    matches.push({named: token.named, from: token.from, to:token.to});
+                    return;
+                } else if (token.rFrom && token.rFrom.test(queryToken)) {
+                    matches.push({named: token.named, from: token.rFrom, to:token.rTo});
+                    return;
+                }
+            } else if (token.named) {
+                if (XRegExp(token.from).test(queryToken)) {
+                    matches.push({named: token.named, from: token.from, to:token.to});
+                    return;
+                } else if (token.rFrom && XRegExp(token.rFrom).test(queryToken)) {
+                    matches.push({named: token.named, from: token.rFrom, to:token.rTo});
+                    return;
+                }
             }
         }
     });

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -202,9 +202,9 @@ var tokens = token.createReplacer({
 });
 
 test('token replacement', function(q) {
-    q.deepEqual(token.replaceToken(tokens, 'fargo street northeast, san francisco'),'fargo St NE, sf');
-    q.deepEqual(token.replaceToken(tokens, 'coolstreet'),'coolstreet');
-    q.deepEqual(token.replaceToken(tokens, 'streetwise'),'streetwise');
+    q.deepEqual(token.replaceTokenizedQueryTokens(tokens, ['fargo', 'street', 'northeast', 'san', 'francisco']), ['fargo', 'st', 'ne', 'san', 'francisco']);
+    q.deepEqual(token.replaceTokenizedQueryTokens(tokens, ['coolstreet']),['coolstreet']);
+    q.deepEqual(token.replaceTokenizedQueryTokens(tokens, ['streetwise']),['streetwise']);
     q.end();
 });
 
@@ -217,20 +217,20 @@ test('replacer', function(q) {
         'Street': 'St'
     });
     q.deepEqual(rep.map(function(r) { return r.named; }), [false, false]);
-    q.deepEqual(rep.map(function(r) { return r.to; }), ['$1Rd$2', '$1St$2']);
-    q.deepEqual(rep.map(function(r) { return r.from.toString(); }), ['/(\\W|^)Road(\\W|$)/gi', '/(\\W|^)Street(\\W|$)/gi']);
-    q.deepEqual(rep.map(function(r) { return r.rTo.toString(); }), ['$1Road$2', '$1Street$2']);
-    q.deepEqual(rep.map(function(r) { return r.rFrom; }), [/(\\W|^)Rd(\\W|$)/gi, /(\\W|^)St(\\W|$)/gi]);
+    q.deepEqual(rep.map(function(r) { return r.to; }), ['Rd', 'St']);
+    q.deepEqual(rep.map(function(r) { return r.from.toString(); }), ['/^Road$/gi', '/^Street$/gi']);
+    q.deepEqual(rep.map(function(r) { return r.rTo.toString(); }), ['Road', 'Street']);
+    q.deepEqual(rep.map(function(r) { return r.rFrom; }), [/^Rd$/gi, /^St$/gi]);
 
     rep = token.createReplacer({
         'Maréchal': 'Mal',
         'Monsieur': 'M'
     });
     q.deepEqual(rep.map(function(r) { return r.named; }), [false, false, false]);
-    q.deepEqual(rep.map(function(r) { return r.to; }), ['$1Mal$2', '$1Mal$2', '$1M$2']);
-    q.deepEqual(rep.map(function(r) { return r.from.toString(); }), ['/(\\W|^)Maréchal(\\W|$)/gi', '/(\\W|^)Marechal(\\W|$)/gi', '/(\\W|^)Monsieur(\\W|$)/gi']);
-    q.deepEqual(rep.map(function(r) { return r.rTo.toString(); }), ['$1Maréchal$2', '$1Marechal$2', '$1Monsieur$2']);
-    q.deepEqual(rep.map(function(r) { return r.rFrom; }), [/(\\W|^)Mal(\\W|$)/gi, /(\\W|^)Mal(\\W|$)/gi, /(\\W|^)M(\\W|$)/gi]);
+    q.deepEqual(rep.map(function(r) { return r.to; }), ['Mal', 'Mal', 'M']);
+    q.deepEqual(rep.map(function(r) { return r.from.toString(); }), ['/^Maréchal$/gi', '/^Marechal$/gi', '/^Monsieur$/gi']);
+    q.deepEqual(rep.map(function(r) { return r.rTo.toString(); }), ['Maréchal', 'Marechal', 'Monsieur']);
+    q.deepEqual(rep.map(function(r) { return r.rFrom; }), [/^Mal$/gi, /^Mal$/gi, /^M$/gi]);
 
     q.end();
 });
@@ -241,8 +241,8 @@ test('named/numbered group replacement', function(q) {
         "(1\\d+)": "@@@$1@@@",
         "(?<number>2\\d+)": "###${number}###"
     });
-    q.deepEqual(token.replaceToken(tokens, 'abc 123 def'), 'xyz @@@123@@@ def');
-    q.deepEqual(token.replaceToken(tokens, 'abc 234 def'), 'xyz ###234### def');
+    q.deepEqual(token.replaceTokenizedQueryTokens(tokens, ['abc', '123', 'def']), ['xyz', '@@@123@@@', 'def']);
+    q.deepEqual(token.replaceTokenizedQueryTokens(tokens, ['abc', '234', 'def']), ['xyz', '###234###', 'def']);
     q.end();
 });
 

--- a/test/termops.replaceTokenPermutations.test.js
+++ b/test/termops.replaceTokenPermutations.test.js
@@ -5,50 +5,50 @@ var fixture = require('./fixtures/tokens.json')
 
 test('2 tokens - all match', function(assert) {
     var replacer = token.createReplacer({'Street':'St', 'North':'N'});
-    assert.deepEqual(termops.replaceTokenPermutations(replacer, 'North Main Street'), ['North Main Street', 'N Main St', 'North Main St', 'N Main Street']
-    );
+    assert.deepEqual(termops.replaceTokenPermutations(replacer, ['north', 'main', 'street']), 
+        [['north', 'main', 'street'], ['n', 'main', 'st'], ['north', 'main', 'st'], ['n', 'main', 'street']]);
     assert.end();
 });
 
 test('3 tokens - all match', function(assert) {
     var replacer = token.createReplacer({'Street':'St', 'North':'N', 'Main':'Mn'});
-    assert.deepEqual(termops.replaceTokenPermutations(replacer, 'North Main Street').sort(), [
+    assert.deepEqual(termops.replaceTokenPermutations(replacer, ['north', 'main', 'street']).sort(), [
         // 0 replacements
-        'North Main Street',
+        ['north', 'main', 'street'],
         // 1 at a time
         // 100
         // 010
         // 001
-        'N Main Street',
-        'North Mn Street',
-        'North Main St',
+        ['n', 'main', 'street'],
+        ['north', 'mn', 'street'],
+        ['north', 'main', 'st'],
         // 2 at a time
         // 110
         // 101
         // 011
-        'N Mn Street',
-        'N Main St',
-        'North Mn St',
+        ['n', 'mn', 'street'],
+        ['n', 'main', 'st'],
+        ['north', 'mn', 'st'],
         // 3 at a time
-        'N Mn St',
+        ['n', 'mn', 'st']
     ].sort());
     assert.end();
 });
 
 test('4 tokens - all match', function(assert) {
     var replacer = token.createReplacer({'Street':'St', 'North':'N', 'Main':'Mn', 'West': 'W'});
-    assert.deepEqual(termops.replaceTokenPermutations(replacer, 'North West Main Street').sort(), [
+    assert.deepEqual(termops.replaceTokenPermutations(replacer, ['north', 'west', 'main', 'street']).sort(), [
         // 0 replacements
-        'North West Main Street',
+        ['north', 'west', 'main', 'street'],
         // 1 at a time
         // 1000
         // 0100
         // 0010
         // 0001
-        'N West Main Street',
-        'North W Main Street',
-        'North West Mn Street',
-        'North West Main St',
+        ['n', 'west', 'main', 'street'],
+        ['north', 'w', 'main', 'street'],
+        ['north', 'west', 'mn', 'street'],
+        ['north', 'west', 'main', 'st'],
         // 2 at a time
         //1100
         //1010
@@ -56,23 +56,23 @@ test('4 tokens - all match', function(assert) {
         //0110
         //0101
         //0011
-        'N W Main Street',
-        'N West Mn Street',
-        'N West Main St',
-        'North W Mn Street',
-        'North W Main St',
-        'North West Mn St',
+        ['n', 'w', 'main', 'street'],
+        ['n', 'west', 'mn', 'street'],
+        ['n', 'west', 'main', 'st'],
+        ['north', 'w', 'mn', 'street'],
+        ['north', 'w', 'main', 'st'],
+        ['north', 'west', 'mn', 'st'],
         // 3 at a time
         //1110
         //1101
         //1011
         //0111
-        'N W Mn Street',
-        'N W Main St',
-        'N West Mn St',
-        'North W Mn St',
+        ['n', 'w', 'mn', 'street'],
+        ['n', 'w', 'main', 'st'],
+        ['n', 'west', 'mn', 'st'],
+        ['north', 'w', 'mn', 'st'],
         // 4 at a time
-        'N W Mn St',
+        ['n', 'w', 'mn', 'st']
     ].sort());
     assert.end();
 });
@@ -85,28 +85,35 @@ test('Tokens with regexp', function(assert) {
          'Thirteenth':'13th',
          "(?<number>2\\d+)": "###${number}###"
         });
-    var replaced = token.tokenReplacerFilter(tokens, '243 North Main Street');
+    var replaced = token.tokenReplacerFilter(tokens, termops.tokenize('243 North Main Street'));
 
     assert.deepEqual(replaced[0].named, false);
-    assert.deepEqual(replaced[0].from, /(\W|^)Street(\W|$)/gi);
-    assert.deepEqual(replaced[0].to, '$1St$2');
+    assert.deepEqual(replaced[0].from, /^Street$/gi);
+    assert.deepEqual(replaced[0].to, 'St');
 
     assert.deepEqual(replaced[1].named, false);
-    assert.deepEqual(replaced[1].from, /(\W|^)North(\W|$)/gi);
-    assert.deepEqual(replaced[1].to, '$1N$2');
+    assert.deepEqual(replaced[1].from, /^North$/gi);
+    assert.deepEqual(replaced[1].to, 'N');
 
     assert.deepEqual(replaced[2].named, false);
-    assert.deepEqual(replaced[2].from, /(\W|^)Main(\W|$)/gi);
-    assert.deepEqual(replaced[2].to, '$1Mn$2');
+    assert.deepEqual(replaced[2].from, /^Main$/gi);
+    assert.deepEqual(replaced[2].to, 'Mn');
 
     assert.deepEqual(replaced[3].named, true);
-    assert.deepEqual(replaced[3].from.toString(), /(\W|^)(2\d+)(\W|$)/gi.toString());
+    assert.deepEqual(replaced[3].from.toString(), /^(2\d+)$/gi.toString());
 
     assert.end();
 });
 
 test('Tokens for CJK characters', function(assert) {
     var tokens = token.createReplacer(fixture);
-    assert.deepEqual(termops.replaceTokenPermutations(tokens, '9丁目'), [ '9丁目', '九丁目' ], 'should be equivalent');
+    assert.deepEqual(termops.replaceTokenPermutations(tokens, ['9丁目']), [ ['9丁目'], ['九丁目'] ], 'should be equivalent');
+    assert.end();
+});
+
+test('Word boundaries an unicode characters', function(assert) {
+    var replacer = token.createReplacer({'North':'N'});
+    assert.deepEqual(termops.replaceTokenPermutations(replacer, ['general', 'pirán', 'argentina']),
+        [['general', 'pirán', 'argentina']]);
     assert.end();
 });

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -7,7 +7,7 @@ var tape = require('tape');
             'Street': 'st'
         }
         var tokenReplacer = tokenize.createReplacer(tokens)
-        var expected = [ { from: /(\W|^)Street(\W|$)/gi, named: false, rFrom: /(\W|^)st(\W|$)/gi, rTo: '$1Street$2', to: '$1st$2' } ];
+        var expected = [ { from: /^Street$/gi, named: false, rFrom: /^st$/gi, rTo: 'Street', to: 'st' } ];
         t.deepEquals(tokenReplacer, expected, 'okay, created a regex')
         t.end();
     });
@@ -18,10 +18,10 @@ var tape = require('tape');
         var tokens = {
             'Street': 'st'
         }
-        var query = 'fake street';
+        var query = ['fake', 'street'];
         var tokensRegex = tokenize.createReplacer(tokens)
-        var replace = tokenize.replaceToken(tokensRegex, query);
-        t.deepEquals('fake st', replace, 'okay, replaced the token')
+        var replace = tokenize.replaceTokenizedQueryTokens(tokensRegex, query);
+        t.deepEquals(['fake', 'st'], replace, 'okay, replaced the token')
         t.end();
     });
 })();


### PR DESCRIPTION
This fixes the original issue in #515 where `n => north` would cause "General Pirán Argentina" to become "General Piránorth Argentina".

Source replacement now happens on the tokenized query. This lets the replacement used the word boundaries created by the tokenization. `replaceTokenPermutations` now takes the tokenized form of the query and returns all the variations in their tokenized forms.

:eyes: @yhahn 
