### PR TITLE
make sorting more deterministic

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -226,10 +226,14 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
 }
 
 function sortByRelevLengthIdx(a, b) {
-    return (b.relev - a.relev) ||
-        (a.length - b.length) ||
-        (b[b.length-1].scorefactor - a[a.length-1].scorefactor) ||
-        (a[a.length-1].idx - b[b.length-1].idx);
+    var d = (b.relev - a.relev) || (a.length - b.length);
+    if (d) return d;
+    for (var i = a.length - 1; i >= 0; i--) {
+        d = (b[i].scorefactor - a[i].scorefactor) ||
+            (a[i].idx - b[i].idx) ||
+            (b[i].phrase - a[i].phrase);
+        if (d) return d;
+    }
 }
 
 function sortByZoomIdx(a, b) {
@@ -237,9 +241,15 @@ function sortByZoomIdx(a, b) {
 }
 
 function sortByRelev(a, b) {
-    return (b.relev - a.relev) ||
-        (b[0].scoredist - a[0].scoredist) ||
-        (a[0].idx - b[0].idx);
+    var d = b.relev - a.relev;
+    if (d) return d;
+    for (var i = 0; i < a.length; i++) {
+        d = (b[i].scoredist - a[i].scoredist) ||
+            (a[i].idx - b[i].idx) ||
+            (a.length - b.length) ||
+            (a[i].id - b[i].id);
+        if (d) return d;
+    }
 }
 
 function sortByMask(a, b) {

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -49,11 +49,13 @@ var addFeature = require('../lib/util/addfeature');
         c.geocode('place', {  }, function(err, res) {
             t.ifError(err);
             t.equal(res.features.length, 5, 'returns 5 results');
-            t.equal(res.features[0].place_name, 'place 11, United States');
-            t.equal(res.features[1].place_name, 'place 1, United States');
-            t.equal(res.features[2].place_name, 'place 3, United States');
-            t.equal(res.features[3].place_name, 'place 4, United States');
-            t.equal(res.features[4].place_name, 'place 5, United States');
+            t.deepEqual(res.features.map(function(d) { return d.place_name; }), [
+                'place 1, United States',
+                'place 2, United States',
+                'place 3, United States',
+                'place 4, United States',
+                'place 5, United States'
+            ]);
             t.end();
         });
     });
@@ -61,7 +63,7 @@ var addFeature = require('../lib/util/addfeature');
         c.geocode('place', { limit: 1 }, function(err, res) {
             t.ifError(err);
             t.equal(res.features.length, 1, 'returns 1 result');
-            t.equal(res.features[0].place_name, 'place 11, United States');
+            t.equal(res.features[0].place_name, 'place 1, United States');
             t.end();
         });
     });
@@ -69,16 +71,18 @@ var addFeature = require('../lib/util/addfeature');
         c.geocode('place', { limit: 10 }, function(err, res) {
             t.ifError(err);
             t.equal(res.features.length, 10, 'returns 10 results');
-            t.equal(res.features[0].place_name, 'place 11, United States');
-            t.equal(res.features[1].place_name, 'place 1, United States');
-            t.equal(res.features[2].place_name, 'place 3, United States');
-            t.equal(res.features[3].place_name, 'place 4, United States');
-            t.equal(res.features[4].place_name, 'place 5, United States');
-            t.equal(res.features[5].place_name, 'place 6, United States');
-            t.equal(res.features[6].place_name, 'place 7, United States');
-            t.equal(res.features[7].place_name, 'place 8, United States');
-            t.equal(res.features[8].place_name, 'place 9, United States');
-            t.equal(res.features[9].place_name, 'place 10, United States');
+            t.deepEqual(res.features.map(function(d) { return d.place_name; }), [
+                'place 1, United States',
+                'place 2, United States',
+                'place 3, United States',
+                'place 4, United States',
+                'place 5, United States',
+                'place 6, United States',
+                'place 7, United States',
+                'place 8, United States',
+                'place 9, United States',
+                'place 10, United States'
+            ]);
             t.end();
         });
     });
@@ -86,16 +90,18 @@ var addFeature = require('../lib/util/addfeature');
         c.geocode('place', { limit: 11 }, function(err, res) {
             t.ifError(err);
             t.equal(res.features.length, 10, 'hard limit of 10');
-            t.equal(res.features[0].place_name, 'place 11, United States');
-            t.equal(res.features[1].place_name, 'place 1, United States');
-            t.equal(res.features[2].place_name, 'place 3, United States');
-            t.equal(res.features[3].place_name, 'place 4, United States');
-            t.equal(res.features[4].place_name, 'place 5, United States');
-            t.equal(res.features[5].place_name, 'place 6, United States');
-            t.equal(res.features[6].place_name, 'place 7, United States');
-            t.equal(res.features[7].place_name, 'place 8, United States');
-            t.equal(res.features[8].place_name, 'place 9, United States');
-            t.equal(res.features[9].place_name, 'place 10, United States');
+            t.deepEqual(res.features.map(function(d) { return d.place_name; }), [
+                'place 1, United States',
+                'place 2, United States',
+                'place 3, United States',
+                'place 4, United States',
+                'place 5, United States',
+                'place 6, United States',
+                'place 7, United States',
+                'place 8, United States',
+                'place 9, United States',
+                'place 10, United States'
+            ]);
             t.end();
         });
     });

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -30,15 +30,18 @@ test('stackable nmask', function(assert) {
         return stack.map(function(s) { return s.text });
     });
     assert.deepEqual(debug, [
-        [ 'c1', 'a1' ],
         [ 'b1', 'a1' ],
-    ], 'b1 and c1 do not stack (nmask: same geocoder_name)');
+        [ 'c1', 'a1' ],
+    ],
+        'b1 and c1 do not stack (nmask: same geocoder_name)');
     assert.end();
 });
 
 test('stackable bmask', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), bmask:[0,1], weight:0.66 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), bmask:[1,0], weight:0.66 };
+    var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), bmask:[0,1],
+        weight:0.66 };
+    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), bmask:[1,0],
+        weight:0.66 };
     var debug = stackable([
         [ a1 ],
         [ b1 ],
@@ -48,7 +51,8 @@ test('stackable bmask', function(assert) {
     assert.deepEqual(debug, [
         [ 'a1' ],
         [ 'b1' ],
-    ], 'a1 and b1 do not stack (bmask: exclusive bounds)');
+    ],
+        'a1 and b1 do not stack (bmask: exclusive bounds)');
     assert.end();
 });
 
@@ -71,11 +75,11 @@ test('stackable complex', function(assert) {
         '0.99 - a2, b1',
         '0.99 - a1, b2, c1',
         '0.66 - a2',
-        '0.66 - b2, c1',
         '0.66 - a1, c1',
         '0.66 - a1, c2',
         '0.66 - a1, b1',
-        '0.66 - a1, b2'
+        '0.66 - a1, b2',
+        '0.66 - b2, c1',
     ]);
     assert.end();
 });
@@ -106,16 +110,16 @@ test('stackable direction change', function(assert) {
         [ 'a2', 'b2', 'c2' ],
         [ 'a1', 'b2', 'c2' ],
         [ 'a1', 'b1', 'c1' ],
-        [ 'a2', 'b1', 'd2' ],
         [ 'a1', 'b1', 'd1' ],
-        [ 'b1', 'c1', 'd2' ],
-        [ 'a1', 'c2', 'd1' ],
+        [ 'a2', 'b1', 'd2' ],
+        [ 'a2', 'b2', 'd2' ],
+        [ 'a1', 'b2', 'd1' ],
         [ 'a2', 'c1', 'd2' ],
         [ 'a2', 'c2', 'd2' ],
-        [ 'a1', 'b2', 'd1' ],
+        [ 'a1', 'c2', 'd1' ],
         [ 'a1', 'c1', 'd1' ],
         [ 'b2', 'c2', 'd2' ],
-        [ 'a2', 'b2', 'd2' ],
+        [ 'b1', 'c1', 'd2' ],
         [ 'b2', 'c2', 'd1' ],
         [ 'b1', 'c1', 'd1' ]
     ]);


### PR DESCRIPTION
fix #519 

This makes sorting of intermediate results more deterministic so that code changes have less of an impact on results. Without this, unrelated changes can trigger different sorts and cause test failures that are ok but different. This reduces the number of test failures that you need to debug.

The new sorting should only make things stricter. All sorts produced by the new versions could have been produced by the old functions.

@yhahn can you review or tag someone else?

I can merge this as part of #517 but I'd like to get it reviewed earlier so that I can update the tests with confidence.