### PR TITLE
Let process.stdout finish before exiting

### DIFF
--- a/scripts/carmen-index.js
+++ b/scripts/carmen-index.js
@@ -75,7 +75,7 @@ function index(err) {
     carmen.on('open', function() {
         carmen.index(process.stdin, conf.to, config, function(err) {
             if (err) throw err;
-            process.exit(0);
+            process.exitCode = 0;
         });
     });
 }

--- a/scripts/carmen-index.js
+++ b/scripts/carmen-index.js
@@ -75,7 +75,6 @@ function index(err) {
     carmen.on('open', function() {
         carmen.index(process.stdin, conf.to, config, function(err) {
             if (err) throw err;
-            process.exitCode = 0;
         });
     });
 }


### PR DESCRIPTION
Writes to `process.stdout` aren't necessarily blocking, so calling process.exit() can sometimes end the process before indexing has finished. This change allows `process.stdout` to finish before exiting.

Node documentation reference: https://nodejs.org/api/process.html#process_process_exit_code

Many thanks to @ericfischer for assistance tracking this down.