### PR TITLE
Don't use push.apply to avoid max call stack errors

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -175,7 +175,7 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
     if (!phrasematches[idx]) return stacks;
 
     // Recurse, skipping this level
-    stacks.push.apply(stacks, stackable(phrasematches, idx+1, mask, nmask, stack, relev));
+    stacks = stacks.concat(stackable(phrasematches, idx+1, mask, nmask, stack, relev));
 
     // Recurse, including this level
     for (var i = 0; i < phrasematches[idx].length; i++) {
@@ -217,7 +217,7 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
             stacks.push(targetStack);
         }
 
-        stacks.push.apply(stacks, stackable(phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev));
+        stacks = stacks.concat(stackable(phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev));
     }
 
     if (idx === 0) stacks.sort(sortByRelevLengthIdx);


### PR DESCRIPTION
Removes last of our `push.apply()` ways of adding onto arrays.