### PR TITLE
Optimizations for spatialmatch.stackable()

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -9,7 +9,7 @@ module.exports.stackable = stackable;
 module.exports.rebalance = rebalance;
 
 function spatialmatch(query, phrasematches, options, callback) {
-    var stacks = stackable(phrasematches);
+    var stacks = stackable([], phrasematches);
     stacks = allowed(stacks, options);
     stacks = stacks.slice(0,30);
     // Rebalance weights, relevs of stacks here.
@@ -163,33 +163,43 @@ function stackByIdx(stack) {
 // For a given set of phrasematch results across multiple indexes,
 // provide all relevant stacking combinations using phrase masks to
 // exclude colliding matches.
-function stackable(phrasematches, idx, mask, nmask, stack, relev) {
+function stackable(stacks, phrasematches, idx, mask, nmask, stack, relev) {
     idx = idx || 0;
     mask = mask || 0;
     nmask = nmask || 0;
     stack = stack || [];
     relev = relev || 0;
 
-    var stacks = [];
-
     if (!phrasematches[idx]) return stacks;
 
     // Recurse, skipping this level
-    stacks = stacks.concat(stackable(phrasematches, idx+1, mask, nmask, stack, relev));
+    stackable(stacks, phrasematches, idx+1, mask, nmask, stack, relev);
+
+    // For each stacked item check the next bmask for its idx.
+    // If the bmask includes the idx these indexes cannot stack
+    // (their geocoder_stack do not intersect at all).
+    var stackFail = 0;
+    var bmask = phrasematches[idx].length && phrasematches[idx][0].bmask;
+    if (bmask) for (var j = 0; j < stack.length; j++) {
+        if (bmask[stack[j].idx]) {
+            stackFail = 1;
+            return stacks;
+        }
+    }
 
     // Recurse, including this level
     for (var i = 0; i < phrasematches[idx].length; i++) {
-        var targetStack = stack.slice(0);
         var targetMask = mask;
         var targetNmask = nmask;
         var next = phrasematches[idx][i];
         var direction;
-        targetStack.relev = relev;
 
         if (targetMask & next.mask) continue;
         if (targetNmask & next.nmask) continue;
 
         // sort by order of input query
+        var targetStack = stack.slice(0);
+        targetStack.relev = relev;
         targetStack.sort(sortByMask);
         // compare index order to input order to determine direction
         if (targetStack.length) {
@@ -197,15 +207,6 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
         }
 
         if (direction === "ascending" && targetMask && targetMask < next.mask) continue;
-
-        // For each stacked item check the next bmask for its idx.
-        // If the bmask includes the idx these indexes cannot stack
-        // (their geocoder_stack do not intersect at all).
-        var stackFail = 0;
-        if (next.bmask) for (var j = 0; j < stack.length; j++) {
-            stackFail = stackFail || (next.bmask[stack[j].idx]);
-        }
-        if (stackFail) continue;
 
         targetMask = targetMask | next.mask;
         targetNmask = targetNmask | next.nmask;
@@ -217,7 +218,7 @@ function stackable(phrasematches, idx, mask, nmask, stack, relev) {
             stacks.push(targetStack);
         }
 
-        stacks = stacks.concat(stackable(phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev));
+        stackable(stacks, phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
     }
 
     if (idx === 0) stacks.sort(sortByRelevLengthIdx);

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -178,13 +178,9 @@ function stackable(stacks, phrasematches, idx, mask, nmask, stack, relev) {
     // For each stacked item check the next bmask for its idx.
     // If the bmask includes the idx these indexes cannot stack
     // (their geocoder_stack do not intersect at all).
-    var stackFail = 0;
     var bmask = phrasematches[idx].length && phrasematches[idx][0].bmask;
     if (bmask) for (var j = 0; j < stack.length; j++) {
-        if (bmask[stack[j].idx]) {
-            stackFail = 1;
-            return stacks;
-        }
+        if (bmask[stack[j].idx]) return stacks;
     }
 
     // Recurse, including this level

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -5,7 +5,7 @@ test('stackable simple', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('10',2), weight:0.5 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
     var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
-    var debug = stackable([
+    var debug = stackable([], [
         [ a1 ],
         [ b1, b2 ],
     ]).map(function(stack) {
@@ -22,7 +22,7 @@ test('stackable nmask', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), nmask:parseInt('1',2), weight:0.33 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), nmask:parseInt('10',2), weight:0.33 };
     var c1 = { text:"c1", idx:2, zoom:1, mask:parseInt('1',2), nmask:parseInt('10',2), weight:0.33 };
-    var debug = stackable([
+    var debug = stackable([], [
         [ a1 ],
         [ b1 ],
         [ c1 ],
@@ -39,7 +39,7 @@ test('stackable nmask', function(assert) {
 test('stackable bmask', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), bmask:[0,1], weight:0.66 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), bmask:[1,0], weight:0.66 };
-    var debug = stackable([
+    var debug = stackable([], [
         [ a1 ],
         [ b1 ],
     ]).map(function(stack) {
@@ -59,7 +59,7 @@ test('stackable complex', function(assert) {
     var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
     var c1 = { text:"c1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.33 };
     var c2 = { text:"c2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
-    var debug = stackable([
+    var debug = stackable([], [
         [ a1, a2 ],
         [ b1, b2 ],
         [ c1, c2 ],
@@ -89,7 +89,7 @@ test('stackable direction change', function(assert) {
     var c2 = { text:"c2", idx:2, zoom:2, mask:parseInt('0010',2), weight:0.25 };
     var d1 = { text:"d1", idx:3, zoom:3, mask:parseInt('1000',2), weight:0.25 };
     var d2 = { text:"d2", idx:3, zoom:3, mask:parseInt('0001',2), weight:0.25 };
-    var debug = stackable([
+    var debug = stackable([], [
         [ a1, a2 ],
         [ b1, b2 ],
         [ c1, c2 ],


### PR DESCRIPTION
- Pass in the stacks array and build it up directly rather than using `.concat()` or `push.apply()` to join 2 arrays. This cuts down on array/object creation on deep permutation trees with a significant speedup.
- Optimize several checks.