### PR TITLE
Use a sort to stabilize context results

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -341,7 +341,9 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, c
             // Exclude features with a distance > tolerance (not yet
             // enforced upstream in mapnik).
             results.sort(function(a, b) {
-                return a.distance - b.distance || a.id() - b.id();
+                a._sortId = a._sortId || a.attributes().id || a.id();
+                b._sortId = b._sortId || b.attributes().id || b.id();
+                return a.distance - b.distance || b._sortId - a._sortId;
             });
             for (var i = 0; i < results.length; i++) {
                 if (results[i].distance > 1000) continue;

--- a/lib/context.js
+++ b/lib/context.js
@@ -340,6 +340,9 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, c
             // Exclude features with a negative score.
             // Exclude features with a distance > tolerance (not yet
             // enforced upstream in mapnik).
+            results.sort(function(a, b) {
+                return a.distance - b.distance || a.id() - b.id();
+            });
             for (var i = 0; i < results.length; i++) {
                 if (results[i].distance > 1000) continue;
                 if (results[i].distance > dist) continue;
@@ -350,7 +353,6 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, c
 
                 // If geojson has an id in properties use that otherwise use VT id
                 attr.id = attr.id || results[i].id();
-                if (feat && attr.id > feat.id) continue;
 
                 var tmpid = (source.idx*mp25) + termops.feature(attr.id);
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -310,7 +310,7 @@ test('contextVector matched negative score', function(assert) {
             {
                 "type": "Feature",
                 "geometry": { "type": "Point", "coordinates": [ 0,0 ] },
-                "properties": { "_id": 1, "_text": "A", "_score": -1 }
+                "properties": { "id": 1, "carmen:text": "A", "carmen:score": -1 }
             }
         ]
     }),"data");
@@ -435,12 +435,12 @@ test('contextVector restricts distance', function(assert) {
             {
                 "type": "Feature",
                 "geometry": { "type": "Point", "coordinates": [-0.001,0.001] },
-                "properties": { "_id":1, "_text": "A" }
+                "properties": { "id":1, "carmen:text": "A" }
             },
             {
                 "type": "Feature",
                 "geometry": { "type": "Point", "coordinates": [0.001,0.001] },
-                "properties": { "_id":2, "_text": "B" }
+                "properties": { "id":2, "carmen:text": "B" }
             }
         ]
     };


### PR DESCRIPTION
Feature id check was way too aggressive as a way to stabilize same distance feature results.

- [ ] Unit test to recreate failure on `master`
- [ ] IRL tests