### PR TITLE
Guard against feature load misses

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -59,6 +59,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             var filteredResults = [];
             var filteredLoaded = [];
             loaded.forEach(function(feature, i) {
+                if (!feature || !feature.properties) return;
                 var source = geocoder.byidx[feature.properties['carmen:dbidx']];
                 if (source && filter.featureAllowed(source, feature, options)) {
                     filteredResults.push(results[i]);


### PR DESCRIPTION
Not all feature loads succeed, example:

https://github.com/mapbox/carmen/blob/master/lib/util/feature.js#L204-L207

This fix guards against this by skipping unloaded features.