### PR TITLE
Fix type filtering for multitype indexes on forward geocodes

### DIFF
--- a/lib/util/filter.js
+++ b/lib/util/filter.js
@@ -34,13 +34,16 @@ function sourceMatchesStacks(source, options) {
 }
 
 function sourceMatchesTypes(source, options) {
-    // Matches a type
-    if (options.types.indexOf(source.type) !== -1) return true;
-    // Matches a subtype
-    var subtypes = source.scoreranges ? Object.keys(source.scoreranges) : [];
-    for (var st = 0; st < subtypes.length; st++) {
-        var subtype = source.type + "." + subtypes[st];
-        if (options.types.indexOf(subtype) !== -1) return true;
+    for (var t = 0; t < source.types.length; t++) {
+        var type = source.types[t];
+        // Matches a type
+        if (options.types.indexOf(type) !== -1) return true;
+        // Matches a subtype
+        var subtypes = source.scoreranges ? Object.keys(source.scoreranges) : [];
+        for (var st = 0; st < subtypes.length; st++) {
+            var subtype = type + "." + subtypes[st];
+            if (options.types.indexOf(subtype) !== -1) return true;
+        }
     }
     // No matches
     return false;

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -22,24 +22,24 @@ tape('filter.sourceMatchesStacks', function(assert) {
 
 tape('filter.sourceMatchesTypes', function(assert) {
     assert.ok(filter.sourceMatchesTypes({
-        type: 'region'
+        types: ['region']
     }, {
         types: ['region','place']
     }), 'allowed: source with matching type');
     assert.ok(filter.sourceMatchesTypes({
-        type: 'region',
+        types: ['region'],
         scoreranges: {a:[],b:[]}
     }, {
         types: ['region.a','region.d']
     }), 'allowed: source with matching subtype');
     assert.ok(filter.sourceMatchesTypes({
-        type: 'region',
+        types: ['region'],
         scoreranges: {a:[],b:[]}
     }, {
         types:['region.b','region.d']
     }), 'allowed: source with matching subtype');
     assert.notOk(filter.sourceMatchesTypes({
-        type: 'region',
+        types: ['region'],
         scoreranges: {a:[],b:[]}
     }, {
         types: ['region.c','region.d']

--- a/test/geocode-unit.multitype.test.js
+++ b/test/geocode-unit.multitype.test.js
@@ -189,6 +189,18 @@ tape('multitype forward, q=caracas', function(assert) {
     });
 });
 
+tape('multitype forward, q=caracas, types=place', function(assert) {
+    assert.comment('query:  caracas');
+    assert.comment('result: caracas');
+    assert.comment('note:   returns caracas with shift');
+    c.geocode('caracas', { types: ['place'] }, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].id, 'place.1');
+        assert.end();
+    });
+});
+
 tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();


### PR DESCRIPTION
Needed to ensure a query like `caracas?types=place` works when the feature needs to come from the region index.