### PR TITLE
Benchmark and further optimize spatialmatch.stackable()

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -9,7 +9,7 @@ module.exports.stackable = stackable;
 module.exports.rebalance = rebalance;
 
 function spatialmatch(query, phrasematches, options, callback) {
-    var stacks = stackable([], phrasematches);
+    var stacks = phrasematches.length ? stackable(phrasematches) : [];
     stacks = allowed(stacks, options);
     stacks = stacks.slice(0,30);
     // Rebalance weights, relevs of stacks here.
@@ -163,20 +163,23 @@ function stackByIdx(stack) {
 // For a given set of phrasematch results across multiple indexes,
 // provide all relevant stacking combinations using phrase masks to
 // exclude colliding matches.
-function stackable(stacks, phrasematches, limit, max, idx, mask, nmask, stack, relev) {
-    if (idx === undefined) {
+function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
+    if (memo === undefined) {
+        memo = {
+            stacks: [],
+            maxStacks: [],
+            maxRelev: 0
+        };
         idx = 0;
-        limit = 30;
         mask = 0;
         nmask = 0;
         stack = [];
         relev = 0;
-        max = { stacks:[], relev:0, count:0, calls: 0 };
     }
 
     // Recurse, skipping this level
     if (phrasematches[idx+1] !== undefined) {
-        stackable(stacks, phrasematches, limit, max, idx+1, mask, nmask, stack, relev);
+        stackable(phrasematches, memo, idx+1, mask, nmask, stack, relev);
     }
 
     // For each stacked item check the next bmask for its idx.
@@ -186,6 +189,10 @@ function stackable(stacks, phrasematches, limit, max, idx, mask, nmask, stack, r
     if (bmask) for (var j = 0; j < stack.length; j++) {
         if (bmask[stack[j].idx]) return;
     }
+
+    // Though spatialmatches are sliced to 30 elements after this step
+    // leave some headroom as this step does not include type filtering.
+    var limit = 100;
 
     // Recurse, including this level
     for (var i = 0; i < phrasematches[idx].length; i++) {
@@ -213,43 +220,46 @@ function stackable(stacks, phrasematches, limit, max, idx, mask, nmask, stack, r
         }
 
         if (targetStack.relev > 0.5) {
-            if (targetStack.relev > max.relev) {
-                max.count = 1;
-                max.relev = targetStack.relev;
-                max.stacks = [ targetStack ];
-                stacks.push(targetStack);
-            } else if (targetStack.relev === max.relev) {
-                max.count++;
-                max.stacks.push(targetStack);
-                if (max.count < limit) {
-                    stacks.push(targetStack);
-                } else if (max.count === limit) {
-                    stacks = max.stacks;
+            if (targetStack.relev > memo.maxRelev) {
+                if (memo.maxStacks.length >= limit) {
+                    memo.stacks = memo.maxStacks;
+                    memo.maxStacks = [ targetStack ];
+                } else {
+                    memo.maxStacks.push(targetStack);
                 }
-            } else if (max.count < limit) {
-                stacks.push(targetStack);
+                memo.maxRelev = targetStack.relev;
+            } else if (targetStack.relev === memo.maxRelev) {
+                memo.maxStacks.push(targetStack);
+            } else if (memo.maxStacks.length < limit) {
+                memo.stacks.push(targetStack);
             }
         }
 
         // Recurse to next level
         if (phrasematches[idx+1] !== undefined) {
-            stackable(stacks, phrasematches, limit, max, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
+            stackable(phrasematches, memo, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
         }
     }
 
     if (idx === 0) {
+        var stacks;
+        stacks = memo.stacks.concat(memo.maxStacks);
         stacks.forEach(function(stack) { stack.sort(sortByZoomIdx); });
         stacks.sort(sortByRelevLengthIdx);
-        stacks = stacks.slice(0, limit);
-        return stacks;
+        return stacks.slice(0, limit);
     }
 }
 
 function sortByRelevLengthIdx(a, b) {
-    return (b.relev - a.relev) ||
+    var first = (b.relev - a.relev) ||
         (a.length - b.length) ||
-        (b[b.length-1].scorefactor - a[a.length-1].scorefactor) ||
-        (a[a.length-1].idx - b[b.length-1].idx);
+        (b[b.length-1].scorefactor - a[a.length-1].scorefactor);
+    if (first) return first;
+
+    for (var end = a.length - 1; end >= 0; end--) {
+        var second = a[end].idx - b[end].idx;
+        if (second) return second;
+    }
 }
 
 function sortByZoomIdx(a, b) {

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -163,63 +163,86 @@ function stackByIdx(stack) {
 // For a given set of phrasematch results across multiple indexes,
 // provide all relevant stacking combinations using phrase masks to
 // exclude colliding matches.
-function stackable(stacks, phrasematches, idx, mask, nmask, stack, relev) {
-    idx = idx || 0;
-    mask = mask || 0;
-    nmask = nmask || 0;
-    stack = stack || [];
-    relev = relev || 0;
-
-    if (!phrasematches[idx]) return stacks;
+function stackable(stacks, phrasematches, limit, max, idx, mask, nmask, stack, relev) {
+    if (idx === undefined) {
+        idx = 0;
+        limit = 30;
+        mask = 0;
+        nmask = 0;
+        stack = [];
+        relev = 0;
+        max = { stacks:[], relev:0, count:0, calls: 0 };
+    }
 
     // Recurse, skipping this level
-    stackable(stacks, phrasematches, idx+1, mask, nmask, stack, relev);
+    if (phrasematches[idx+1] !== undefined) {
+        stackable(stacks, phrasematches, limit, max, idx+1, mask, nmask, stack, relev);
+    }
 
     // For each stacked item check the next bmask for its idx.
     // If the bmask includes the idx these indexes cannot stack
     // (their geocoder_stack do not intersect at all).
     var bmask = phrasematches[idx].length && phrasematches[idx][0].bmask;
     if (bmask) for (var j = 0; j < stack.length; j++) {
-        if (bmask[stack[j].idx]) return stacks;
+        if (bmask[stack[j].idx]) return;
     }
 
     // Recurse, including this level
     for (var i = 0; i < phrasematches[idx].length; i++) {
-        var targetMask = mask;
-        var targetNmask = nmask;
         var next = phrasematches[idx][i];
-        var direction;
+        if (mask & next.mask) continue;
+        if (nmask & next.nmask) continue;
 
-        if (targetMask & next.mask) continue;
-        if (targetNmask & next.nmask) continue;
-
-        // sort by order of input query
-        var targetStack = stack.slice(0);
-        targetStack.relev = relev;
-        targetStack.sort(sortByMask);
         // compare index order to input order to determine direction
-        if (targetStack.length) {
-            direction = targetStack[0].idx < next.idx ? "descending" : "ascending";
+        if (stack.length &&
+            stack[0].idx >= next.idx &&
+            mask &&
+            mask < next.mask) continue;
+
+        var targetStack = stack.slice(0);
+        var targetMask = mask | next.mask
+        var targetNmask = nmask | next.nmask;
+        targetStack.relev = relev + next.weight;
+
+        // ensure order of targetStack maintains lowest mask value at the
+        // first position. ensure direction check above works.
+        if (next.mask < mask) {
+            targetStack.unshift(next);
+        } else {
+            targetStack.push(next);
         }
-
-        if (direction === "ascending" && targetMask && targetMask < next.mask) continue;
-
-        targetMask = targetMask | next.mask;
-        targetNmask = targetNmask | next.nmask;
-        targetStack.push(next);
-        targetStack.relev += next.weight;
 
         if (targetStack.relev > 0.5) {
-            targetStack.sort(sortByZoomIdx);
-            stacks.push(targetStack);
+            if (targetStack.relev > max.relev) {
+                max.count = 1;
+                max.relev = targetStack.relev;
+                max.stacks = [ targetStack ];
+                stacks.push(targetStack);
+            } else if (targetStack.relev === max.relev) {
+                max.count++;
+                max.stacks.push(targetStack);
+                if (max.count < limit) {
+                    stacks.push(targetStack);
+                } else if (max.count === limit) {
+                    stacks = max.stacks;
+                }
+            } else if (max.count < limit) {
+                stacks.push(targetStack);
+            }
         }
 
-        stackable(stacks, phrasematches, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
+        // Recurse to next level
+        if (phrasematches[idx+1] !== undefined) {
+            stackable(stacks, phrasematches, limit, max, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
+        }
     }
 
-    if (idx === 0) stacks.sort(sortByRelevLengthIdx);
-
-    return stacks;
+    if (idx === 0) {
+        stacks.forEach(function(stack) { stack.sort(sortByZoomIdx); });
+        stacks.sort(sortByRelevLengthIdx);
+        stacks = stacks.slice(0, limit);
+        return stacks;
+    }
 }
 
 function sortByRelevLengthIdx(a, b) {
@@ -230,19 +253,13 @@ function sortByRelevLengthIdx(a, b) {
 }
 
 function sortByZoomIdx(a, b) {
-    return (a.zoom - b.zoom) || (b.idx - a.idx);
+    return (a.zoom - b.zoom) || (b.idx - a.idx) || (b.mask - a.mask);
 }
 
 function sortByRelev(a, b) {
     return (b.relev - a.relev) ||
         (b[0].scoredist - a[0].scoredist) ||
         (a[0].idx - b[0].idx);
-}
-
-function sortByMask(a, b) {
-    if (!b) return 1;
-    if (!a) return 0;
-    return (a.mask - b.mask);
 }
 
 function rebalance(query, stack) {

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -122,3 +122,47 @@ test('stackable direction change', function(assert) {
     assert.end();
 });
 
+test('stackable bench', function(assert) {
+    runBench(5, 10);
+    runBench(6, 10);
+    runBench(7, 10);
+    runBench(8, 10);
+    runBench(9, 10);
+    runBench(10, 10);
+
+    function runBench(indexCount, termCount) {
+        var time = 0;
+        var runs = 5;
+        for (var i = 0; i < runs; i++) time += bench(indexCount, termCount);
+        assert.comment('bench x' + runs + ' (indexCount=' + indexCount + ', termCount=' + termCount + ')');
+        assert.ok(true, 'avg time ' + Math.round(time/runs) + 'ms');
+    }
+
+    // Suppose each index matches each term
+    function bench(indexCount, termCount) {
+        var phraseMatches = [];
+        for (var i = 0; i < indexCount; i++) {
+            for (var t = 0; t < termCount; t++) {
+                var matchingTerms = Math.round(Math.random() * termCount * 0.5);
+                var offset = Math.floor(Math.random() * (termCount - matchingTerms));
+                var mask = 0;
+                for (var o = 0; o < matchingTerms; o++) {
+                    mask = mask | (1 << (offset + o));
+                }
+                phraseMatches[i] = phraseMatches[i] || [];
+                phraseMatches[i].push({
+                    text: t + '-' + i,
+                    idx: i,
+                    zoom: 0,
+                    mask: mask,
+                    weight: matchingTerms/termCount
+                });
+            }
+        }
+        var start = +new Date;
+        var stacked = stackable([], phraseMatches);
+        return (+new Date) - start;
+    }
+    assert.end();
+});
+

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -5,7 +5,7 @@ test('stackable simple', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('10',2), weight:0.5 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
     var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
-    var debug = stackable([], [
+    var debug = stackable([
         [ a1 ],
         [ b1, b2 ],
     ]).map(function(stack) {
@@ -22,7 +22,7 @@ test('stackable nmask', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), nmask:parseInt('1',2), weight:0.33 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), nmask:parseInt('10',2), weight:0.33 };
     var c1 = { text:"c1", idx:2, zoom:1, mask:parseInt('1',2), nmask:parseInt('10',2), weight:0.33 };
-    var debug = stackable([], [
+    var debug = stackable([
         [ a1 ],
         [ b1 ],
         [ c1 ],
@@ -30,8 +30,8 @@ test('stackable nmask', function(assert) {
         return stack.map(function(s) { return s.text });
     });
     assert.deepEqual(debug, [
-        [ 'c1', 'a1' ],
         [ 'b1', 'a1' ],
+        [ 'c1', 'a1' ],
     ], 'b1 and c1 do not stack (nmask: same geocoder_name)');
     assert.end();
 });
@@ -39,7 +39,7 @@ test('stackable nmask', function(assert) {
 test('stackable bmask', function(assert) {
     var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), bmask:[0,1], weight:0.66 };
     var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), bmask:[1,0], weight:0.66 };
-    var debug = stackable([], [
+    var debug = stackable([
         [ a1 ],
         [ b1 ],
     ]).map(function(stack) {
@@ -59,7 +59,7 @@ test('stackable complex', function(assert) {
     var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
     var c1 = { text:"c1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.33 };
     var c2 = { text:"c2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
-    var debug = stackable([], [
+    var debug = stackable([
         [ a1, a2 ],
         [ b1, b2 ],
         [ c1, c2 ],
@@ -71,11 +71,11 @@ test('stackable complex', function(assert) {
         '0.99 - a2, b1',
         '0.99 - a1, b2, c1',
         '0.66 - a2',
-        '0.66 - b2, c1',
         '0.66 - a1, c1',
         '0.66 - a1, c2',
         '0.66 - a1, b1',
-        '0.66 - a1, b2'
+        '0.66 - a1, b2',
+        '0.66 - b2, c1'
     ]);
     assert.end();
 });
@@ -89,7 +89,7 @@ test('stackable direction change', function(assert) {
     var c2 = { text:"c2", idx:2, zoom:2, mask:parseInt('0010',2), weight:0.25 };
     var d1 = { text:"d1", idx:3, zoom:3, mask:parseInt('1000',2), weight:0.25 };
     var d2 = { text:"d2", idx:3, zoom:3, mask:parseInt('0001',2), weight:0.25 };
-    var debug = stackable([], [
+    var debug = stackable([
         [ a1, a2 ],
         [ b1, b2 ],
         [ c1, c2 ],
@@ -104,20 +104,20 @@ test('stackable direction change', function(assert) {
         [ 'a1', 'b1', 'c1', 'd1' ],
         [ 'a2', 'b1', 'c1' ],
         [ 'a2', 'b2', 'c2' ],
-        [ 'a1', 'b2', 'c2' ],
         [ 'a1', 'b1', 'c1' ],
+        [ 'a1', 'b2', 'c2' ],
+        [ 'a1', 'b2', 'd1' ],
+        [ 'a2', 'b2', 'd2' ],
         [ 'a2', 'b1', 'd2' ],
         [ 'a1', 'b1', 'd1' ],
-        [ 'b1', 'c1', 'd2' ],
-        [ 'a1', 'c2', 'd1' ],
-        [ 'a2', 'c1', 'd2' ],
-        [ 'a2', 'c2', 'd2' ],
-        [ 'a1', 'b2', 'd1' ],
         [ 'a1', 'c1', 'd1' ],
+        [ 'a1', 'c2', 'd1' ],
+        [ 'a2', 'c2', 'd2' ],
+        [ 'a2', 'c1', 'd2' ],
         [ 'b2', 'c2', 'd2' ],
-        [ 'a2', 'b2', 'd2' ],
-        [ 'b2', 'c2', 'd1' ],
-        [ 'b1', 'c1', 'd1' ]
+        [ 'b1', 'c1', 'd2' ],
+        [ 'b1', 'c1', 'd1' ],
+        [ 'b2', 'c2', 'd1' ]
     ]);
     assert.end();
 });
@@ -160,7 +160,7 @@ test('stackable bench', function(assert) {
             }
         }
         var start = +new Date;
-        stackable([], phraseMatches);
+        stackable(phraseMatches);
         return (+new Date) - start;
     }
     assert.end();

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -160,7 +160,7 @@ test('stackable bench', function(assert) {
             }
         }
         var start = +new Date;
-        var stacked = stackable([], phraseMatches);
+        stackable([], phraseMatches);
         return (+new Date) - start;
     }
     assert.end();


### PR DESCRIPTION
### Background: what does spatialmatch.stackable() do?

For a given set of phrasematches, `spatialmatch.stackable()` generates all the possible/allowed stacking permutations that we should consider as potential geocoding matches in the real world.

**Simplified example:** If we matched

```
100 main street (poi)
100 main street (address)
new york (city)
new york (state)
```

Stackable says we need to check for:

```
100 main street (poi)
100 main street (address)
new york (city)
new york (state)
100 main street (poi), new york (city)
100 main street (poi), new york (state)
100 main street (address), new york (city)
100 main street (address), new york (state)
```

Then would sort these in order of most likely relevance.

------

### What are we trying to improve?

With long queries that match many possible phrases across a lot of indexes, this list of permutation grows exponentially and takes a very long time to generate.

**Goal:** make it faster, and make it not crash under extreme conditions.

- **Adds synthetic stress tests for `spatialmatch.stackable()`.** These tests are pretty unrealistic but telling -- they simulate many indexes matching many possible combinations of phrases and then time how quickly stackable can generate permutations for them.
- **Optimizes `spatialmatch.stackable()`.** Because we use only the top 30 permutations, sorted by relev, the biggest strategy here is to store the maximum relev we've seen as we generate permutations and strategically throw out permutations as we go that don't meet the maximum relev threshold. A bunch of other micro JS optimizations tune things further but are more tweaks.

------

### Results

Test | Before | After
--- | --- | ---
5 indexes x 10 terms | 23ms | 17ms
6 indexes x 10 terms | 92ms | 33ms
7 indexes x 10 terms | 551ms | 90ms
8 indexes x 10 terms | 1631ms | 225ms
9 indexes x 10 terms | 7098ms | 360ms
10 indexes x 10 terms | n/a* | 8297ms

n/a - under certain circumstances this testrun on `master` will crash, likely from running out of memory.

```
<--- Last few GCs --->

  192174 ms: Mark-sweep 1399.5 (1457.3) -> 1399.5 (1457.3) MB, 2488.6 / 0 ms [last resort gc].
  192177 ms: Scavenge 1399.5 (1457.3) -> 1399.5 (1457.3) MB, 3.1 / 0 ms [allocation failure].
  192181 ms: Scavenge 1399.5 (1457.3) -> 1399.5 (1457.3) MB, 2.8 / 0 ms [allocation failure].
  194626 ms: Mark-sweep 1399.5 (1457.3) -> 1399.5 (1457.3) MB, 2444.6 / 0 ms [last resort gc].
  197077 ms: Mark-sweep 1399.5 (1457.3) -> 1399.5 (1457.3) MB, 2451.7 / 0 ms [last resort gc].


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x2a0e013b4629 <JS Object>
    2: InnerArraySort [native array.js:~670] [pc=0x29130511e4b7] (this=0x3439b8004231 <JS Array[5]>,v=5,aC=0x1e71f2abad31 <JS Function sortByMask (SharedFunctionInfo 0x1e71f2a3d939)>)
    3: sort [native array.js:~885] [pc=0x291304e3d822] (this=0x3439b8004231 <JS Array[5]>,aC=0x1e71f2abad31 <JS Function sortByMask (SharedFunctionInfo 0x1e71f2a3d939)>)
    4: stackable(aka stackable) [/home/mapb...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
Aborted (core dumped)
```

------

- [x] Integration/staging testrun
- [x] Roll new release

cc @mapbox/geocoding-gang @ianshward 