### PR TITLE
add Phrasematch and PhrasematchResult types 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var path = require('path'),
-    EventEmitter = require('events').EventEmitter,
+var EventEmitter = require('events').EventEmitter,
     queue = require('d3-queue').queue;
 
 var dawgcache = require('./lib/util/dawg');
@@ -9,7 +8,6 @@ var Cache = require('./lib/util/cxxcache'),
     geocode = require('./lib/geocode'),
     analyze = require('./lib/analyze'),
     loadall = require('./lib/loadall'),
-    termops = require('./lib/util/termops'),
     token = require('./lib/util/token'),
     copy = require('./lib/copy'),
     index = require('./lib/index'),
@@ -40,8 +38,6 @@ function Geocoder(indexes, options) {
 
     q.awaitAll(function(err, results) {
         var names = [];
-        var stacks = [];
-        var subtypes = [];
         if (results) results.forEach(function(data, i) {
             var id = data.id;
             var info = data.info;
@@ -237,14 +233,6 @@ function clone(source) {
     return cloned;
 }
 
-function boundsIntersect(a, b) {
-    if (a[2] < b[0]) return false; // a is left of b
-    if (a[0] > b[2]) return false; // a is right of b
-    if (a[3] < b[1]) return false; // a is below b
-    if (a[1] > b[3]) return false; // a is above b
-    return true;
-}
-
 function tokenValidator(token_replacer) {
     for (var i = 0; i < token_replacer.length; i++) {
         if (token_replacer[i].from.toString().indexOf(' ') >= 0 || token_replacer[i].to.toString().indexOf(' ') >= 0) {
@@ -304,7 +292,6 @@ Geocoder.prototype.multimerge = function(froms, to, pointer, callback) {
 
 // Analyze a source's index.
 Geocoder.prototype.analyze = function(source, callback) {
-    var self = this;
     this._open(function(err) {
         if (err) return callback(err);
         analyze(source, callback);
@@ -313,7 +300,6 @@ Geocoder.prototype.analyze = function(source, callback) {
 
 // Load all shards for a source.
 Geocoder.prototype.loadall = function(source, type, concurrency, callback) {
-    var self = this;
     this._open(function(err) {
         if (err) return callback(err);
         loadall.loadall(source, type, concurrency, callback);
@@ -321,7 +307,6 @@ Geocoder.prototype.loadall = function(source, type, concurrency, callback) {
 };
 
 Geocoder.prototype.unloadall = function(source, type, callback) {
-    var self = this;
     this._open(function(err) {
         if (err) return callback(err);
         loadall.unloadall(source, type, callback);
@@ -330,7 +315,6 @@ Geocoder.prototype.unloadall = function(source, type, callback) {
 
 // Copy a source's index to another.
 Geocoder.prototype.copy = function(from, to, callback) {
-    var self = this;
     this._open(function(err) {
         if (err) return callback(err);
         copy(from, to, callback);

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -333,7 +333,7 @@ function forwardGeocode(geocoder, query, options, callback) {
     // search runs `geocoder.search` over each backend with `data.query`,
     // condenses all of the results, and sorts them by potential usefulness.
     for (var dbid in geocoder.indexes) q.defer(phrasematch, geocoder.indexes[dbid], query, options);
-    q.awaitAll(function(err, phrasematches) {
+    q.awaitAll(function(err, phrasematchResults) {
         if (err) return callback(err);
         if (options.stats) {
             stats.spatialmatch.time = +new Date;
@@ -341,18 +341,18 @@ function forwardGeocode(geocoder, query, options, callback) {
         }
         if (options.debug) {
             options.debug.phrasematch = {};
-            for (var idx = 0; idx < phrasematches.length; idx++) {
+            for (var idx = 0; idx < phrasematchResults.length; idx++) {
                 var id = geocoder.byidx[idx].id;
                 options.debug.phrasematch[id] = {};
-                for (var x = 0; x < phrasematches[idx].length; x++) {
-                    var matched = phrasematches[idx][x];
-                    var phraseText = matched.join(' ');
+                for (var x = 0; x < phrasematchResults[idx].phrasematches.length; x++) {
+                    var matched = phrasematchResults[idx].phrasematches[x];
+                    var phraseText = matched.subquery.join(' ');
                     options.debug.phrasematch[id][phraseText] = matched.weight;
                 }
             }
         }
 
-        spatialmatch(queryData.query, phrasematches, options, spatialmatchComplete);
+        spatialmatch(queryData.query, phrasematchResults, options, spatialmatchComplete);
     });
 
     function spatialmatchComplete(err, matched) {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -366,8 +366,9 @@ function forwardGeocode(geocoder, query, options, callback) {
         if (options.debug) {
             options.debug.spatialmatch = null;
             for (var x = 0; x < matched.results.length; x++) {
-                if (matched.results[x][0].id !== options.debug.id) continue;
-                options.debug.spatialmatch = matched.results[x];
+                var spatialmatch = matched.results[x];
+                if (spatialmatch.covers[0].id !== options.debug.id) continue;
+                options.debug.spatialmatch = spatialmatch;
                 options.debug.spatialmatch_position = x;
             }
         }

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -18,7 +18,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     // if not in bbox, skip
     if (options.bbox) {
         var intersects = bb.intersect(options.bbox, source.bounds);
-        if (!intersects) return callback(null, []);
+        if (!intersects) return callback(null, new PhrasematchResult([], getter, loadall, source));
     }
 
     // Get all subquery permutations from the query
@@ -34,12 +34,6 @@ module.exports = function phrasematch(source, query, options, callback) {
 
     subqueries = termops.uniqPermutations(subqueries);
 
-    for (var l = 0; l < subqueries.length; l++) {
-        var phrase = termops.encodePhrase(subqueries[l], options.autocomplete ? subqueries[l].ender : false);
-        subqueries[l].text = termops.encodableText(subqueries[l]);
-        subqueries[l].phrase = phrase;
-    }
-
     loadall(getter, 'freq', [1], function(err) {
         if (err) return callback(err);
 
@@ -48,26 +42,50 @@ module.exports = function phrasematch(source, query, options, callback) {
         // cross-index comparisons.
         var scorefactor = (source._geocoder.get('freq', 1)||[0])[0] || 1;
 
-        var results = [];
+        var phrasematches = [];
 
         var l = subqueries.length;
         while (l--) {
-            if (!source._dictcache.hasPhrase(subqueries[l])) continue;
+            var subquery = subqueries[l];
+            var text = termops.encodableText(subquery);
+            if (!source._dictcache.hasPhrase(text, subquery.ender)) continue;
             // Augment permutations with matched grids,
             // index position and weight relative to input query.
-            subqueries[l].scorefactor = scorefactor;
-            subqueries[l].getter = getter;
-            subqueries[l].loadall = loadall;
-            subqueries[l].cache = source._geocoder;
-            subqueries[l].idx = source.idx;
-            subqueries[l].zoom = source.zoom;
-            subqueries[l].nmask = 1 << source.ndx;
-            subqueries[l].bmask = source.bmask;
-            subqueries[l].weight = subqueries[l].length / tokenized.length;
-            results.push(subqueries[l]);
+            var phrase = termops.encodePhrase(subquery, options.autocomplete ? subquery.ender : false);
+            var weight = subquery.length / tokenized.length;
+            phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder, source.zoom));
         }
 
-        return callback(null, results);
+        return callback(null, new PhrasematchResult(phrasematches, getter, loadall, source));
     });
+};
+
+module.exports.PhrasematchResult = PhrasematchResult;
+function PhrasematchResult(phrasematches, getter, loadall, source) {
+    this.phrasematches = phrasematches;
+    this.getter = getter;
+    this.loadall = loadall;
+    this.idx = source.idx;
+    this.nmask = 1 << source.ndx;
+    this.bmask = source.bmask;
+}
+
+module.exports.Phrasematch = Phrasematch;
+function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom) {
+    this.subquery = subquery;
+    this.weight = weight;
+    this.mask = mask;
+    this.phrase = phrase;
+    this.scorefactor = scorefactor;
+
+    // Attributes used by carmen-cache.
+    // All phrasematches from the same source have the same values.
+    this.idx = idx;
+    this.cache = cache;
+    this.zoom = zoom;
+}
+
+Phrasematch.prototype.clone = function() {
+    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom);
 };
 

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -73,28 +73,20 @@ function spatialmatch(query, phrasematchResults, options, callback) {
             coalesceOpts.bboxzxy = bbox.insideTile(options.bbox, stack[0].zoom);
         }
 
-        coalesce(stack, coalesceOpts, function(err, features) {
+        coalesce(stack, coalesceOpts, function(err, cacheSpatialmatches) {
             // Include text for debugging with each matched feature.
             var byIdx = stackByIdx(stack);
-            var l = features.length;
-            while (l--) {
-                var feature = features[l];
-                var m = feature.length;
-                while (m--) {
-                    var featureStack = byIdx[feature[m].idx];
-                    feature[m].mask = featureStack.mask;
-                    feature[m].text = featureStack.subquery.join(' ');
-                    feature[m].score = feature[m].score * featureStack.scorefactor;
-                    feature[m].scorefactor = featureStack.scorefactor;
-                    feature[m].scoredist = feature[m].scoredist * featureStack.scorefactor;
-                }
-            }
 
-            if (features.length == 0) {
+            if (cacheSpatialmatches.length == 0) {
                 waste.push(Object.keys(byIdx));
             }
 
-            callback(null, features);
+            var spatialmatches = [];
+            for (var i = 0; i < cacheSpatialmatches.length; i++) {
+                spatialmatches.push(new Spatialmatch(cacheSpatialmatches[i], byIdx));
+            }
+
+            callback(null, spatialmatches);
         });
     }
 
@@ -109,26 +101,27 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         var doneAscending = {};
         var doneDescending = {};
         var doneSingle = {};
-        var features = [];
+        var filteredSpatialmatches = [];
         for (var i = 0; i < combined.length; i++) {
-            var feature = combined[i];
-            for (var j = 0; j < feature.length; j++) {
-                sets[feature[j].tmpid] = feature[j];
+            var spatialmatch = combined[i];
+            var covers = spatialmatch.covers;
+            for (var j = 0; j < covers.length; j++) {
+                sets[covers[j].tmpid] = covers[j];
             }
             // only allow one result in each direction
-            if (feature.length > 1 && feature[0].idx > feature[1].idx && !doneDescending[feature[0].tmpid]) {
-                doneDescending[feature[0].tmpid] = true;
-                features.push(feature);
-            } else if (feature.length > 1 && feature[0].idx < feature[1].idx && !doneAscending[feature[0].tmpid]) {
-                doneAscending[feature[0].tmpid] = true;
-                features.push(feature);
-            } else if (feature.length === 1 && !doneAscending[feature[0].tmpid] && !doneDescending[feature[0].tmpid] && !doneSingle[feature[0].tmpid]) {
-                doneSingle[feature[0].tmpid] = true;
-                features.push(feature);
+            if (covers.length > 1 && covers[0].idx > covers[1].idx && !doneDescending[covers[0].tmpid]) {
+                doneDescending[covers[0].tmpid] = true;
+                filteredSpatialmatches.push(spatialmatch);
+            } else if (covers.length > 1 && covers[0].idx < covers[1].idx && !doneAscending[covers[0].tmpid]) {
+                doneAscending[covers[0].tmpid] = true;
+                filteredSpatialmatches.push(spatialmatch);
+            } else if (covers.length === 1 && !doneAscending[covers[0].tmpid] && !doneDescending[covers[0].tmpid] && !doneSingle[covers[0].tmpid]) {
+                doneSingle[covers[0].tmpid] = true;
+                filteredSpatialmatches.push(spatialmatch);
             }
         }
 
-        return callback(null, { results: features, sets: sets, waste: waste });
+        return callback(null, { results: filteredSpatialmatches, sets: sets, waste: waste });
     }
 }
 
@@ -267,8 +260,8 @@ function sortByZoomIdx(a, b) {
 
 function sortByRelev(a, b) {
     return (b.relev - a.relev) ||
-        (b[0].scoredist - a[0].scoredist) ||
-        (a[0].idx - b[0].idx);
+        (b.covers[0].scoredist - a.covers[0].scoredist) ||
+        (a.covers[0].idx - b.covers[0].idx);
 }
 
 function rebalance(query, stack) {
@@ -293,4 +286,30 @@ function rebalance(query, stack) {
     }
 
     return stackClone;
+}
+
+function Spatialmatch(cacheSpatialmatch, stackByIdx) {
+    this.relev = cacheSpatialmatch.relev;
+    this.covers = [];
+    for (var i = 0; i < cacheSpatialmatch.length; i++) {
+        var cacheCover = cacheSpatialmatch[i];
+        this.covers.push(new Cover(cacheCover, stackByIdx[cacheCover.idx]));
+    }
+}
+
+function Cover(cacheCover, phrasematch) {
+    this.x = cacheCover.x;
+    this.y = cacheCover.y;
+    this.relev = cacheCover.relev;
+    this.id = cacheCover.id;
+    this.idx = cacheCover.idx;
+    this.tmpid = cacheCover.tmpid;
+    this.distance = cacheCover.distance;
+
+    this.score = cacheCover.score * phrasematch.scorefactor;
+    this.scoredist = cacheCover.scoredist * phrasematch.scorefactor;
+    this.scorefactor = phrasematch.scorefactor;
+
+    this.mask = phrasematch.mask;
+    this.text = phrasematch.subquery.join(' ');
 }

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -8,8 +8,8 @@ module.exports = spatialmatch;
 module.exports.stackable = stackable;
 module.exports.rebalance = rebalance;
 
-function spatialmatch(query, phrasematches, options, callback) {
-    var stacks = phrasematches.length ? stackable(phrasematches) : [];
+function spatialmatch(query, phrasematchResults, options, callback) {
+    var stacks = phrasematchResults.length ? stackable(phrasematchResults) : [];
     stacks = allowed(stacks, options);
     stacks = stacks.slice(0,30);
     // Rebalance weights, relevs of stacks here.
@@ -29,20 +29,19 @@ function spatialmatch(query, phrasematches, options, callback) {
         for (var i = 0; i < stacks.length; i++) {
             var stack = stacks[i];
             for (var j = 0; j < stack.length; j++) {
-                idx = stack[j].idx;
-                loadables[idx] = loadables[idx] || {
-                    loadall: stack[j].loadall,
-                    getter: stack[j].getter,
-                    ids: []
-                };
-                loadables[idx].ids.push(stack[j].phrase);
+                var phrasematch = stack[j];
+                idx = phrasematch.idx;
+                loadables[idx] = loadables[idx] || [];
+                loadables[idx].push(phrasematch.phrase);
             }
         }
 
         // Then queue loading in a single pass deduping ids.
         var q = queue();
-        for (idx in loadables) {
-            q.defer(loadables[idx].loadall, loadables[idx].getter, 'grid', uniq(loadables[idx].ids));
+        for (var s = 0; s < phrasematchResults.length; s++) {
+            var phrasematchResult = phrasematchResults[s];
+            var sourceLoadables = loadables[phrasematchResult.idx];
+            if (sourceLoadables) q.defer(phrasematchResult.loadall, phrasematchResult.getter, 'grid', uniq(sourceLoadables));
         }
         q.awaitAll(coalesceStacks);
     }
@@ -82,11 +81,12 @@ function spatialmatch(query, phrasematches, options, callback) {
                 var feature = features[l];
                 var m = feature.length;
                 while (m--) {
-                    feature[m].mask = byIdx[feature[m].idx].mask;
-                    feature[m].text = byIdx[feature[m].idx].text;
-                    feature[m].score = feature[m].score * byIdx[feature[m].idx].scorefactor;
-                    feature[m].scorefactor = byIdx[feature[m].idx].scorefactor;
-                    feature[m].scoredist = feature[m].scoredist * byIdx[feature[m].idx].scorefactor;
+                    var featureStack = byIdx[feature[m].idx];
+                    feature[m].mask = featureStack.mask;
+                    feature[m].text = featureStack.subquery.join(' ');
+                    feature[m].score = feature[m].score * featureStack.scorefactor;
+                    feature[m].scorefactor = featureStack.scorefactor;
+                    feature[m].scoredist = feature[m].scoredist * featureStack.scorefactor;
                 }
             }
 
@@ -152,18 +152,14 @@ function allowed(stacks, options) {
 function stackByIdx(stack) {
     var byIdx = {};
     var l = stack.length;
-    while (l--) byIdx[stack[l].idx] = {
-        scorefactor: stack[l].scorefactor,
-        mask: stack[l].mask,
-        text: stack[l].join(' ')
-    };
+    while (l--) byIdx[stack[l].idx] = stack[l];
     return byIdx;
 }
 
 // For a given set of phrasematch results across multiple indexes,
 // provide all relevant stacking combinations using phrase masks to
 // exclude colliding matches.
-function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
+function stackable(phrasematchResults, memo, idx, mask, nmask, stack, relev) {
     if (memo === undefined) {
         memo = {
             stacks: [],
@@ -178,15 +174,17 @@ function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
     }
 
     // Recurse, skipping this level
-    if (phrasematches[idx+1] !== undefined) {
-        stackable(phrasematches, memo, idx+1, mask, nmask, stack, relev);
+    if (phrasematchResults[idx+1] !== undefined) {
+        stackable(phrasematchResults, memo, idx+1, mask, nmask, stack, relev);
     }
+
+    var phrasematchResult = phrasematchResults[idx];
 
     // For each stacked item check the next bmask for its idx.
     // If the bmask includes the idx these indexes cannot stack
     // (their geocoder_stack do not intersect at all).
-    var bmask = phrasematches[idx].length && phrasematches[idx][0].bmask;
-    if (bmask) for (var j = 0; j < stack.length; j++) {
+    var bmask = phrasematchResult.bmask;
+    for (var j = 0; j < stack.length; j++) {
         if (bmask[stack[j].idx]) return;
     }
 
@@ -195,10 +193,11 @@ function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
     var limit = 100;
 
     // Recurse, including this level
-    for (var i = 0; i < phrasematches[idx].length; i++) {
-        var next = phrasematches[idx][i];
+    var phrasematches = phrasematchResult.phrasematches;
+    for (var i = 0; i < phrasematches.length; i++) {
+        var next = phrasematches[i];
         if (mask & next.mask) continue;
-        if (nmask & next.nmask) continue;
+        if (nmask & phrasematchResult.nmask) continue;
 
         // compare index order to input order to determine direction
         if (stack.length &&
@@ -208,7 +207,7 @@ function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
 
         var targetStack = stack.slice(0);
         var targetMask = mask | next.mask
-        var targetNmask = nmask | next.nmask;
+        var targetNmask = nmask | phrasematchResult.nmask;
         targetStack.relev = relev + next.weight;
 
         // ensure order of targetStack maintains lowest mask value at the
@@ -236,8 +235,8 @@ function stackable(phrasematches, memo, idx, mask, nmask, stack, relev) {
         }
 
         // Recurse to next level
-        if (phrasematches[idx+1] !== undefined) {
-            stackable(phrasematches, memo, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
+        if (phrasematchResults[idx+1] !== undefined) {
+            stackable(phrasematchResults, memo, idx+1, targetMask, targetNmask, targetStack, targetStack.relev);
         }
     }
 
@@ -276,28 +275,21 @@ function rebalance(query, stack) {
     var stackMask = 0;
     var stackClone = [];
 
-    //shallow copy stack into stackClone to prevent cases where a stack's
-    //index gets overwritten in deep copies.
-    for (var m = 0; m < stack.length; m++) {
-        stackClone[m] = stack[m].slice();
-        for (var key in stack[m]) {
-            stackClone[m][key] = stack[m][key];
-        }
-    }
-
-    for (var i = 0; i < stackClone.length; i++) {
-        stackMask |= stackClone[i].mask;
+    for (var i = 0; i < stack.length; i++) {
+        stackMask |= stack[i].mask;
     }
 
     var garbage = (query.length === (stackMask.toString(2).split(1).length -1)) ? 0 : 1;
-    var weight = 1/(garbage + stackClone.length);
+    var weight = 1/(garbage + stack.length);
 
     //recompute total relevance from scratch
-    stackClone.relev = 0;
+    stackClone.relev = weight * stack.length;
 
-    for (var k = 0; k < stackClone.length; k++) {
+    //shallow copy stack into stackClone to prevent cases where a stack's
+    //index gets overwritten in deep copies.
+    for (var k = 0; k < stack.length; k++) {
+        stackClone[k] = stack[k].clone();
         stackClone[k].weight = weight;
-        stackClone.relev += stackClone[k].weight;
     }
 
     return stackClone;

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -36,8 +36,8 @@ var ReadCache = function(buf) {
 
 ReadCache.prototype = Object.create(_dawgCache.CompactDawg.prototype);
 
-ReadCache.prototype.hasPhrase = function(subq) {
-    return subq.ender ? this.lookupPrefix(subq.text) : this.lookup(subq.text);
+ReadCache.prototype.hasPhrase = function(text, ender) {
+    return ender ? this.lookupPrefix(text) : this.lookup(text);
 }
 
 var DawgCache = function(buf) {
@@ -55,9 +55,9 @@ ReadCache.prototype.properties = WriteCache.prototype.properties = {
 }
 
 // build a ReadCache at the last minute if hasPhrase is ever called on WriteCache; define after ReadCache to appease the linter
-WriteCache.prototype.hasPhrase = function(phraseObj) {
+WriteCache.prototype.hasPhrase = function(text, ender) {
     if (DEBUG) console.warn("calling hasPhrase on a DAWG WriteCache is very inefficient")
-    return (new ReadCache(this.dump())).hasPhrase(phraseObj);
+    return (new ReadCache(this.dump())).hasPhrase(text, ender);
 }
 
 WriteCache.prototype.iterator = function(string) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -15,31 +15,32 @@ module.exports.sortFeature = sortFeature;
 module.exports.sortContext = sortContext;
 
 function verifymatch(query, stats, geocoder, matched, options, callback) {
-    var results = matched.results;
+    var spatialmatches = matched.results;
     var sets = matched.sets;
-
-    var q = queue(10);
 
     options.limit_verify = options.limit_verify || 10;
 
     // Limit covers based on whether their source is allowed by types & stacks filters.
     if (options.types || options.stacks) {
-        results = results.filter(function(result) {
-            var source = geocoder.byidx[result[0].idx];
+        spatialmatches = spatialmatches.filter(function(spatialmatch) {
+            var firstCover = spatialmatch.covers[0];
+            var source = geocoder.byidx[firstCover.idx];
             // Currently unclear why this might be undefined.
-            if (!source) console.error(new Error('Misuse: source undefined for idx ' + result[0].idx));
+            if (!source) console.error(new Error('Misuse: source undefined for idx ' + firstCover.idx));
             return source && filter.sourceAllowed(source, options);
         });
     }
 
     // Limit initial feature check to the best 20 max.
-    if (results.length > 20) results = results.slice(0,20);
-    for (var i = 0; i < results.length; i++) q.defer(loadFeature, results[i], i);
+    if (spatialmatches.length > 20) spatialmatches = spatialmatches.slice(0,20);
+
+    var q = queue(10);
+    for (var i = 0; i < spatialmatches.length; i++) q.defer(loadFeature, spatialmatches[i], i);
     q.awaitAll(afterFeatures);
 
     // For each result, load the feature from its Carmen index.
     function loadFeature(spatialmatch, pos, callback) {
-        var cover = spatialmatch[0];
+        var cover = spatialmatch.covers[0];
         var source = geocoder.byidx[cover.idx];
 
         // Currently unclear why this might be undefined.
@@ -57,20 +58,20 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 
         // Limit each feature based on whether it is allowed by types & stacks filters.
         if (options.types || options.stacks) {
-            var filteredResults = [];
+            var filteredSpatialmatches = [];
             var filteredLoaded = [];
             loaded.forEach(function(feature, i) {
                 if (!feature || !feature.properties) return;
                 var source = geocoder.indexes[feature.properties['carmen:index']];
                 if (source && filter.featureAllowed(source, feature, options)) {
-                    filteredResults.push(results[i]);
+                    filteredSpatialmatches.push(spatialmatches[i]);
                     filteredLoaded.push(loaded[i]);
                 }
             });
-            verified = verifyFeatures(query, geocoder, filteredResults, filteredLoaded, options);
+            verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options);
         // No filters specified, go straight to verify
         } else {
-            verified = verifyFeatures(query, geocoder, results, loaded, options);
+            verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options);
         }
         // Limit verify results before loading contexts
         verified = verified.slice(0, options.limit_verify);
@@ -79,7 +80,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     }
 }
 
-function verifyFeatures(query, geocoder, spatial, loaded, options) {
+function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     var meanScore = 1;
     var result = [];
     var feat;
@@ -88,8 +89,8 @@ function verifyFeatures(query, geocoder, spatial, loaded, options) {
 
         feat = loaded[pos];
 
-        var spatialmatch = spatial[pos];
-        var cover = spatialmatch[0];
+        var spatialmatch = spatialmatches[pos];
+        var cover = spatialmatch.covers[0];
         var source = geocoder.byidx[cover.idx];
 
         // Calculate to see if there is room for an address in the query based on bitmask
@@ -216,8 +217,9 @@ function verifyContexts(contexts, sets, indexes) {
 
         // Create lookup for covers by tmpid.
         var verify = {};
-        for (var b = 0; b < context[0].properties['carmen:spatialmatch'].length; b++) {
-            var cover = context[0].properties['carmen:spatialmatch'][b];
+        var covers = context[0].properties['carmen:spatialmatch'].covers;
+        for (var b = 0; b < covers.length; b++) {
+            var cover = covers[b];
             verify[cover.tmpid] = cover;
         }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "main": "./index.js",
   "scripts": {
-    "lint": "eslint lib test",
+    "lint": "eslint index.js lib test",
     "test": "npm run lint && (retire -n || echo 'WARNING: retire found insecure packages') && tape ./test/*.js && npm run bench",
     "coverage": "istanbul cover tape test/*.js && coveralls < ./coverage/lcov.info",
     "bench": "for file in bench/*.js; do node $file; done"

--- a/test/dawgcache.test.js
+++ b/test/dawgcache.test.js
@@ -22,12 +22,12 @@ tape('dump/load', function(assert) {
             assert.ifError(err);
             var loaded = new DawgCache(data);
             for (var i = 1; i <= 4; i++) {
-                assert.equal(loaded.hasPhrase({text: "a" + i, ender: false}), true, 'has a' + i);
+                assert.equal(loaded.hasPhrase("a" + i, false), true, 'has a' + i);
             }
-            assert.equal(loaded.hasPhrase({text: "a5", ender: false}), false, 'not a5');
+            assert.equal(loaded.hasPhrase("a5", false), false, 'not a5');
 
-            assert.equal(loaded.hasPhrase({text: "a", ender: false}), false, 'not a');
-            assert.equal(loaded.hasPhrase({text: "a", ender: true}), true, 'has a as degen');
+            assert.equal(loaded.hasPhrase("a", false), false, 'not a');
+            assert.equal(loaded.hasPhrase("a", true), true, 'has a as degen');
             assert.end();
         });
     });

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -287,22 +287,25 @@
                 "carmen:relev": 1,
                 "carmen:distance": 0,
                 "carmen:position": 0,
-                "carmen:spatialmatch": [
-                    {
-                        "x": 24,
-                        "y": 24,
-                        "relev": 1,
-                        "score": 7,
-                        "id": 1,
-                        "idx": 2,
-                        "tmpid": 67108865,
-                        "distance": 0,
-                        "scoredist": 7,
-                        "mask": 1,
-                        "text": "toronto",
-                        "scorefactor": 1
-                    }
-                ],
+                "carmen:spatialmatch": {
+                    "relev": 1,
+                    "covers": [
+                        {
+                            "x": 24,
+                            "y": 24,
+                            "relev": 1,
+                            "id": 1,
+                            "idx": 2,
+                            "tmpid": 67108865,
+                            "distance": 0,
+                            "score": 7,
+                            "scoredist": 7,
+                            "scorefactor": 1,
+                            "mask": 1,
+                            "text": "toronto"
+                        }
+                    ]
+                },
                 "carmen:geocoder_address_order": "ascending",
                 "carmen:scoredist": 1
             },

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -87,10 +87,10 @@ tape('west st, tonawanda, ny', function(t) {
         }, 'debugs matched phrases');
 
         // Found debug feature in spatialmatch results @ position 1
-        t.deepEqual(res.debug.spatialmatch[0].text, 'west st');
-        t.deepEqual(res.debug.spatialmatch[0].relev, 0.3333333333333333);
-        t.deepEqual(res.debug.spatialmatch[1].text, 'ny');
-        t.deepEqual(res.debug.spatialmatch[1].relev, 0.3333333333333333);
+        t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
+        t.deepEqual(res.debug.spatialmatch.covers[0].relev, 0.3333333333333333);
+        t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
+        t.deepEqual(res.debug.spatialmatch.covers[1].relev, 0.3333333333333333);
         t.deepEqual(res.debug.spatialmatch_position, 1);
 
         // Debug feature not found in verifymatch
@@ -121,13 +121,13 @@ tape('west st, tonawanda, ny', function(t) {
         }, 'debugs matched phrases');
 
         // Found debug feature in spatialmatch results @ position 1
-        t.deepEqual(res.debug.spatialmatch[0].id, 5);
-        t.deepEqual(res.debug.spatialmatch[0].text, 'west st');
-        t.deepEqual(res.debug.spatialmatch[0].relev, 0.3333333333333333);
-        t.deepEqual(res.debug.spatialmatch[1].text, 'tonawanda');
-        t.deepEqual(res.debug.spatialmatch[1].relev, 0.3333333333333333);
-        t.deepEqual(res.debug.spatialmatch[2].text, 'ny');
-        t.deepEqual(res.debug.spatialmatch[2].relev, 0.3333333333333333);
+        t.deepEqual(res.debug.spatialmatch.covers[0].id, 5);
+        t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
+        t.deepEqual(res.debug.spatialmatch.covers[0].relev, 0.3333333333333333);
+        t.deepEqual(res.debug.spatialmatch.covers[1].text, 'tonawanda');
+        t.deepEqual(res.debug.spatialmatch.covers[1].relev, 0.3333333333333333);
+        t.deepEqual(res.debug.spatialmatch.covers[2].text, 'ny');
+        t.deepEqual(res.debug.spatialmatch.covers[2].relev, 0.3333333333333333);
         t.deepEqual(res.debug.spatialmatch_position, 0);
 
         // Debug feature not found in verifymatch

--- a/test/spatialmatch.rebalance.test.js
+++ b/test/spatialmatch.rebalance.test.js
@@ -1,25 +1,15 @@
 var rebalance = require('../lib/spatialmatch.js').rebalance;
+var Phrasematch = require('../lib/phrasematch').Phrasematch;
 var test = require('tape');
 
 test('rebalance, no garbage', function(assert) {
     var query = ['100','main','st','12345','seattle','washington'];
-    var stack = [];
-
-    stack[0] = ['1##','main','st'];
-    stack[0].mask = 7;
-    stack[0].weight = 0.5;
-
-    stack[1] = ['12345'];
-    stack[1].mask = 8;
-    stack[1].weight = 0.16666666666666666;
-
-    stack[2] = ['seattle'];
-    stack[2].mask = 16;
-    stack[2].weight = 0.16666666666666666;
-
-    stack[3] = ['washington'];
-    stack[3].mask = 32;
-    stack[3].weight = 0.16666666666666666;
+    var stack = [
+        new Phrasematch(['1##','main','st'], 0.5, 7, null, null, null, null),
+        new Phrasematch(['12345'], 0.16666666666666666, 8, null, null, null, null),
+        new Phrasematch(['seattle'], 0.16666666666666666, 16, null, null, null, null),
+        new Phrasematch(['washington'], 0.16666666666666666, 32, null, null, null, null),
+    ];
 
     stack.relev = 1;
 
@@ -35,19 +25,11 @@ test('rebalance, no garbage', function(assert) {
 test('rebalance, with garbage', function(assert) {
     var query = ['100','main','st','12345','seattle','washington'];
 
-    var stack = [];
-
-    stack[0] = ['1##','main','st'];
-    stack[0].mask = 7;
-    stack[0].weight = 0.5;
-
-    stack[1] = ['12345'];
-    stack[1].mask = 8;
-    stack[1].weight = 0.16666666666666666;
-
-    stack[2] = ['washington'];
-    stack[2].mask = 32;
-    stack[2].weight = 0.16666666666666666;
+    var stack = [
+        new Phrasematch(['1##','main','st'], 0.5, 7, null, null, null, null),
+        new Phrasematch(['12345'], 0.16666666666666666, 8, null, null, null, null),
+        new Phrasematch(['washington'], 0.16666666666666666, 32, null, null, null, null),
+    ];
 
     stack.relev = 0.8333333333333333;
 
@@ -62,23 +44,12 @@ test('rebalance, with garbage', function(assert) {
 test('rebalance copies', function(assert) {
     var query = ['100','main','st','12345','seattle','washington'];
 
-    var stackA = [];
-
-    stackA[0] = ['1##','main','st'];
-    stackA[0].mask = 7;
-    stackA[0].weight = 0.5;
-
-    stackA[1] = ['12345'];
-    stackA[1].mask = 8;
-    stackA[1].weight = 0.16666666666666666;
-
-    stackA[2] = ['seattle'];
-    stackA[2].mask = 16;
-    stackA[2].weight = 0.16666666666666666;
-
-    stackA[3] = ['washington'];
-    stackA[3].mask = 32;
-    stackA[3].weight = 0.16666666666666666;
+    var stackA = [
+        new Phrasematch(['1##','main','st'], 0.5, 7, null, null, null, null),
+        new Phrasematch(['12345'], 0.16666666666666666, 8, null, null, null, null),
+        new Phrasematch(['seattle'], 0.16666666666666666, 16, null, null, null, null),
+        new Phrasematch(['washington'], 0.16666666666666666, 32, null, null, null, null),
+    ];
 
     stackA.relev = 1;
 

--- a/test/spatialmatch.stackable.test.js
+++ b/test/spatialmatch.stackable.test.js
@@ -1,15 +1,18 @@
 var stackable = require('../lib/spatialmatch.js').stackable;
+var phrasematch = require('../lib/phrasematch');
+var Phrasematch = phrasematch.Phrasematch;
+var PhrasematchResult = phrasematch.PhrasematchResult;
 var test = require('tape');
 
 test('stackable simple', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('10',2), weight:0.5 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
-    var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('1',2), weight:0.5 };
+    var a1 = new Phrasematch(['a1'], 0.5, parseInt('10', 2), null, null, 0, null, 0);
+    var b1 = new Phrasematch(['b1'], 0.5, parseInt('1', 2), null, null, 1, null, 1);
+    var b2 = new Phrasematch(['b2'], 0.5, parseInt('1', 2), null, null, 1, null, 1);
     var debug = stackable([
-        [ a1 ],
-        [ b1, b2 ],
+        new PhrasematchResult([a1], null, null, { idx: 0, bmask: {}, ndx: 0 }),
+        new PhrasematchResult([b1, b2], null, null, { idx: 1, bmask: {}, ndx: 1 })
     ]).map(function(stack) {
-        return stack.map(function(s) { return s.text });
+        return stack.map(function(s) { return s.subquery.join(' '); });
     });
     assert.deepEqual(debug, [
         [ 'a1', 'b1' ],
@@ -19,15 +22,15 @@ test('stackable simple', function(assert) {
 });
 
 test('stackable nmask', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), nmask:parseInt('1',2), weight:0.33 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), nmask:parseInt('10',2), weight:0.33 };
-    var c1 = { text:"c1", idx:2, zoom:1, mask:parseInt('1',2), nmask:parseInt('10',2), weight:0.33 };
+    var a1 = new Phrasematch(['a1'], 0.33, parseInt('100', 2), null, null, 0, null, 1);
+    var b1 = new Phrasematch(['b1'], 0.33, parseInt('10', 2), null, null, 1, null, 1);
+    var c1 = new Phrasematch(['c1'], 0.33, parseInt('1', 2), null, null, 2, null, 1);
     var debug = stackable([
-        [ a1 ],
-        [ b1 ],
-        [ c1 ],
+        new PhrasematchResult([a1], null, null, { idx: 0, bmask: {}, ndx: 0 }),
+        new PhrasematchResult([b1], null, null, { idx: 1, bmask: {}, ndx: 1 }),
+        new PhrasematchResult([c1], null, null, { idx: 2, bmask: {}, ndx: 1 })
     ]).map(function(stack) {
-        return stack.map(function(s) { return s.text });
+        return stack.map(function(s) { return s.subquery.join(' ')});
     });
     assert.deepEqual(debug, [
         [ 'b1', 'a1' ],
@@ -37,13 +40,13 @@ test('stackable nmask', function(assert) {
 });
 
 test('stackable bmask', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:1, mask:parseInt('100',2), bmask:[0,1], weight:0.66 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('10',2), bmask:[1,0], weight:0.66 };
+    var a1 = new Phrasematch(['a1'], 0.66, parseInt('100', 2), null, null, 0, null, 1);
+    var b1 = new Phrasematch(['b1'], 0.66, parseInt('10', 2), null, null, 1, null, 1);
     var debug = stackable([
-        [ a1 ],
-        [ b1 ],
+        new PhrasematchResult([a1], null, null, { idx: 0, bmask: [0, 1], ndx: 0 }),
+        new PhrasematchResult([b1], null, null, { idx: 1, bmask: [1, 0], ndx: 1 })
     ]).map(function(stack) {
-        return stack.map(function(s) { return s.text });
+        return stack.map(function(s) { return s.subquery.join(' '); });
     });
     assert.deepEqual(debug, [
         [ 'a1' ],
@@ -53,18 +56,18 @@ test('stackable bmask', function(assert) {
 });
 
 test('stackable complex', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('10',2), weight:0.33 };
-    var a2 = { text:"a2", idx:0, zoom:0, mask:parseInt('110',2), weight:0.66 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.33 };
-    var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
-    var c1 = { text:"c1", idx:1, zoom:1, mask:parseInt('1',2), weight:0.33 };
-    var c2 = { text:"c2", idx:1, zoom:1, mask:parseInt('100',2), weight:0.33 };
+    var a1 = new Phrasematch(['a1'], 0.33, parseInt('10', 2), null, null, 0, null, 0);
+    var a2 = new Phrasematch(['a2'], 0.66, parseInt('110', 2), null, null, 0, null, 0);
+    var b1 = new Phrasematch(['b1'], 0.33, parseInt('1', 2), null, null, 1, null, 1);
+    var b2 = new Phrasematch(['b2'], 0.33, parseInt('100', 2), null, null, 1, null, 1);
+    var c1 = new Phrasematch(['c1'], 0.33, parseInt('1', 2), null, null, 1, null, 1);
+    var c2 = new Phrasematch(['c2'], 0.33, parseInt('100', 2), null, null, 1, null, 1);
     var debug = stackable([
-        [ a1, a2 ],
-        [ b1, b2 ],
-        [ c1, c2 ],
+        new PhrasematchResult([a1, a2], null, null, { idx: 0, bmask: [], ndx: 0 }),
+        new PhrasematchResult([b1, b2], null, null, { idx: 1, bmask: [], ndx: 1 }),
+        new PhrasematchResult([c1, c2], null, null, { idx: 1, bmask: [], ndx: 2 }),
     ]).map(function(stack) {
-        return stack.relev.toFixed(2) + ' - ' + stack.map(function(s) { return s.text }).join(', ');
+        return stack.relev.toFixed(2) + ' - ' + stack.map(function(s) { return s.subquery.join(' ')}).join(', ');
     });
     assert.deepEqual(debug, [
         '0.99 - a2, c1',
@@ -81,21 +84,21 @@ test('stackable complex', function(assert) {
 });
 
 test('stackable direction change', function(assert) {
-    var a1 = { text:"a1", idx:0, zoom:0, mask:parseInt('0001',2), weight:0.25 };
-    var a2 = { text:"a2", idx:0, zoom:0, mask:parseInt('1000',2), weight:0.25 };
-    var b1 = { text:"b1", idx:1, zoom:1, mask:parseInt('0010',2), weight:0.25 };
-    var b2 = { text:"b2", idx:1, zoom:1, mask:parseInt('0100',2), weight:0.25 };
-    var c1 = { text:"c1", idx:2, zoom:2, mask:parseInt('0100',2), weight:0.25 };
-    var c2 = { text:"c2", idx:2, zoom:2, mask:parseInt('0010',2), weight:0.25 };
-    var d1 = { text:"d1", idx:3, zoom:3, mask:parseInt('1000',2), weight:0.25 };
-    var d2 = { text:"d2", idx:3, zoom:3, mask:parseInt('0001',2), weight:0.25 };
+    var a1 = new Phrasematch(['a1'], 0.25, parseInt('0001', 2), null, null, 0, null, 0);
+    var a2 = new Phrasematch(['a2'], 0.25, parseInt('1000', 2), null, null, 0, null, 0);
+    var b1 = new Phrasematch(['b1'], 0.25, parseInt('0010', 2), null, null, 1, null, 1);
+    var b2 = new Phrasematch(['b2'], 0.25, parseInt('0100', 2), null, null, 1, null, 1);
+    var c1 = new Phrasematch(['c1'], 0.25, parseInt('0100', 2), null, null, 2, null, 2);
+    var c2 = new Phrasematch(['c2'], 0.25, parseInt('0010', 2), null, null, 2, null, 2);
+    var d1 = new Phrasematch(['d1'], 0.25, parseInt('1000', 2), null, null, 3, null, 3);
+    var d2 = new Phrasematch(['d2'], 0.25, parseInt('0001', 2), null, null, 3, null, 4);
     var debug = stackable([
-        [ a1, a2 ],
-        [ b1, b2 ],
-        [ c1, c2 ],
-        [ d1, d2 ]
+        new PhrasematchResult([a1, a2], null, null, { idx: 0, bmask: [], ndx: 0 }),
+        new PhrasematchResult([b1, b2], null, null, { idx: 1, bmask: [], ndx: 1 }),
+        new PhrasematchResult([c1, c2], null, null, { idx: 2, bmask: [], ndx: 2 }),
+        new PhrasematchResult([d1, d2], null, null, { idx: 3, bmask: [], ndx: 3 }),
     ]).map(function(stack) {
-        return stack.map(function(s) { return s.text });
+        return stack.map(function(s) { return s.subquery.join(' ')});
     });
     assert.deepEqual(debug, [
         [ 'a2', 'b2', 'c2', 'd2' ],
@@ -149,14 +152,9 @@ test('stackable bench', function(assert) {
                 for (var o = 0; o < matchingTerms; o++) {
                     mask = mask | (1 << (offset + o));
                 }
-                phraseMatches[i] = phraseMatches[i] || [];
-                phraseMatches[i].push({
-                    text: t + '-' + i,
-                    idx: i,
-                    zoom: 0,
-                    mask: mask,
-                    weight: matchingTerms/termCount
-                });
+                phraseMatches[i] = phraseMatches[i] || new PhrasematchResult([], null, null, { idx: i, bmask: [], ndx: i });
+                var weight = matchingTerms / termCount;
+                phraseMatches[i].phrasematches.push(new Phrasematch([t + '-' + i], weight, mask, null, null, i, null, 0));
             }
         }
         var start = +new Date;


### PR DESCRIPTION
this does two things:
- splits some source-level properties (`loadall`, `getter`, `nmask`, `bmask`) into a separate object to make it clearer that they are source-level and to avoid things like [picking a value off of the first phrasematch](https://github.com/mapbox/carmen/blob/7150b4adf4c81b41deb832ef6e38349120d84714/lib/spatialmatch.js#L188)
- adds classes for `Phrasematch` and `PhrasematchResult` so that they are more clearly and rigidly defined

The main changes are in `lib/phrasematch.js`. All the other changes are just adapting to that.

---

motivation:

One of the more confusing things about carmen right now is understanding what type an object is and what properties it has. Sometimes the members of an object are added in multiple places ([1](https://github.com/mapbox/carmen/blob/7150b4adf4c81b41deb832ef6e38349120d84714/lib/phrasematch.js#L31), [2](https://github.com/mapbox/carmen/blob/7150b4adf4c81b41deb832ef6e38349120d84714/lib/phrasematch.js#L39-L40), [3](https://github.com/mapbox/carmen/blob/7150b4adf4c81b41deb832ef6e38349120d84714/lib/phrasematch.js#L58-L66)) making it hard to keep track. This tries to improve things by using named js classes which has worked well in mapbox-gl-js.

@yhahn do you like this approach with classes or do you have other ideas?