### PR TITLE
use exceptions instead of string return values for error handling

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -36,15 +36,10 @@ function indexdocs(docs, source, options, callback) {
     var full = { grid: {}, text:[], docs:[], vectors:[] };
     var settings = { source:source, zoom: options.zoom, geocoder_tokens: options.geocoder_tokens, tokens: options.tokens};
 
-    function error(err) {
-        if (!callback) return;
-        callback(err);
-        callback = false;
-    }
-
-    var err = parseDocs(docs, settings, full);
-    if (err) {
-        return error(new Error(err));
+    try {
+        parseDocs(docs, settings, full);
+    } catch (err) {
+        return callback(err);
     }
 
     if (TIMER) console.time('update:freq');
@@ -90,10 +85,7 @@ function parseDocs(docs, settings, full) {
     var token_replacer = token.createReplacer(settings.geocoder_tokens);
 
     for (var i = 0; i < docs.length; i++) {
-        var res = standardize(docs[i], zoom, token_replacer);
-        if (typeof res === 'string') {
-            return res;
-        } else docs[i] = res;
+        docs[i] = standardize(docs[i], zoom, token_replacer);
 
         docs[i].properties.id = docs[i].id;
 
@@ -163,18 +155,18 @@ function runChecks(doc) {
     var geojsonErr = geojsonHint.hint(doc);
 
     if (!doc.id) {
-        return 'doc has no id';
+        throw Error('doc has no id');
     } else if (geojsonErr.length) {
-        return geojsonErr[0].message + ' on id:' + doc.id;
+        throw Error(geojsonErr[0].message + ' on id:' + doc.id);
     } else if (!doc.geometry) {
-        return 'doc has no geometry on id: ' + doc.id;
+        throw Error('doc has no geometry on id: ' + doc.id);
     } else if (!doc.properties) {
-        return 'doc has no properties on id:' + doc.id;
+        throw Error('doc has no properties on id:' + doc.id);
     } else if (!doc.properties["carmen:text"]) {
-        return 'doc has no carmen:text on id:' + doc.id;
+        throw Error('doc has no carmen:text on id:' + doc.id);
     } else if (doc.properties["carmen:geocoder_stack"] &&
         typeof doc.properties["carmen:geocoder_stack"] !== 'string') {
-        return 'geocoder_stack must be a string value';
+        throw Error('geocoder_stack must be a string value');
     }
 
     if (doc.geometry.type === 'Polygon' || doc.geometry.type === 'MultiPolygon') {
@@ -196,15 +188,13 @@ function runChecks(doc) {
             }
         }
         if (vertices > 50000) {
-            return 'Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:' + doc.id;
+            throw Error('Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:' + doc.id);
         }
     }
-    return '';
 }
 
 function standardize(doc, zoom) {
-    var err = runChecks(doc, zoom);
-    if (err) return err;
+    runChecks(doc, zoom);
 
     var tiles = [];
     if (doc.geometry.type === 'GeometryCollection' && !doc.properties['carmen:zxy']) {
@@ -234,7 +224,7 @@ function standardize(doc, zoom) {
             doc.id, doc.properties["carmen:text"]);
         doc.properties["carmen:center"] = centroid(doc.geometry).geometry.coordinates;
         if (!verifyCenter(doc.properties["carmen:center"], tiles)) {
-            return 'Invalid carmen:center provided, and unable to calculate corrected centroid. Verify validity of doc.geometry for doc id:' + doc.id;
+            throw Error('Invalid carmen:center provided, and unable to calculate corrected centroid. Verify validity of doc.geometry for doc id:' + doc.id);
         } else {
             console.warn('new: carmen:center: ', doc.properties["carmen:center"]);
             console.warn('new: zxy:    ', doc.properties['carmen:zxy']);
@@ -242,11 +232,7 @@ function standardize(doc, zoom) {
     }
 
     //Standardize all addresses to GeometryCollections
-    try {
-        doc = feature.addrTransform(doc);
-    } catch (err) {
-        return doc;
-    }
+    doc = feature.addrTransform(doc);
 
     if (!doc.bbox && (doc.geometry.type === 'MultiPolygon' || doc.geometry.type === 'Polygon')) {
         doc.bbox = extent(doc.geometry);
@@ -254,12 +240,12 @@ function standardize(doc, zoom) {
 
     // zxy must be set at this point
     if (!doc.properties['carmen:zxy']) {
-        return 'doc.properties[\'carmen:zxy\'] undefined, failed indexing, doc id:' + doc.id;
+        throw Error('doc.properties[\'carmen:zxy\'] undefined, failed indexing, doc id:' + doc.id);
     }
 
     // Limit carmen:zxy length
     if (doc.properties['carmen:zxy'] && doc.properties['carmen:zxy'].length > 10000) {
-        return 'zxy exceeded 10000, doc id:' + doc.id;
+        throw Error('zxy exceeded 10000, doc id:' + doc.id);
     }
 
     return doc;

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -242,8 +242,11 @@ function standardize(doc, zoom) {
     }
 
     //Standardize all addresses to GeometryCollections
-    doc = feature.addrTransform(doc);
-    if (typeof doc === 'string') return doc; //Error in addr transform
+    try {
+        doc = feature.addrTransform(doc);
+    } catch (err) {
+        return doc;
+    }
 
     if (!doc.bbox && (doc.geometry.type === 'MultiPolygon' || doc.geometry.type === 'Polygon')) {
         doc.bbox = extent(doc.geometry);

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -60,9 +60,11 @@ function addrTransform(doc) {
 
     //All ITP (like PT) are converted to GeometryCollections internally
     if (doc.properties['carmen:rangetype'] && doc.geometry) {
+        var rangePropKeys = ['carmen:parityl', 'carmen:parityr', 'carmen:lfromhn', 'carmen:rfromhn', 'carmen:ltohn', 'carmen:rtohn'];
+
         if (doc.geometry.type === 'LineString' || doc.geometry.type === 'MultiLineString') {
-            ['parityl', 'parityr', 'lfromhn', 'rfromhn', 'ltohn', 'rtohn'].forEach(function(type) {
-                doc.properties['carmen:'+type] = doc.geometry.type === 'LineString' ?  [[doc.properties['carmen:'+type]]] : [doc.properties['carmen:'+type]];
+            rangePropKeys.forEach(function(key) {
+                doc.properties[key] = doc.geometry.type === 'LineString' ?  [[doc.properties[key]]] : [doc.properties[key]];
             });
 
             doc.geometry = {
@@ -81,8 +83,8 @@ function addrTransform(doc) {
                 throw Error('ITP geometries in a GeometryCollection must be MultiLineStrings');;
             }
 
-            ['parityl', 'parityr', 'lfromhn', 'rfromhn', 'ltohn', 'rtohn'].forEach(function(type) {
-                doc.properties['carmen:'+type][c_it] = doc.properties['carmen:'+type][c_it] ? doc.properties['carmen:'+type][c_it] : [];
+            rangePropKeys.forEach(function(key) {
+                if (!doc.properties[key][c_it]) doc.properties[key][c_it] = [];
             });
         }
     }

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -27,29 +27,33 @@ function addrTransform(doc) {
                 ]
             }
         } else if (doc.geometry.type !== 'GeometryCollection') {
-            return 'carmen:addressnumber must be MultiPoint or GeometryCollection';
+            throw Error('carmen:addressnumber must be MultiPoint or GeometryCollection');
         }
 
-        if (doc.properties['carmen:addressnumber'].length !== doc.geometry.geometries.length) {
-            return 'carmen:addressnumber array must be equal to geometry.geometries array';
+        var addressClusters = doc.properties['carmen:addressnumber'];
+
+        if (addressClusters.length !== doc.geometry.geometries.length) {
+            throw Error('carmen:addressnumber array must be equal to geometry.geometries array');
         }
 
-        for (c_it = 0; c_it < doc.properties['carmen:addressnumber'].length; c_it++) {
-            if (!doc.properties['carmen:addressnumber'][c_it] || !doc.properties['carmen:addressnumber'][c_it].length) continue;
+        for (c_it = 0; c_it < addressClusters.length; c_it++) {
+            var addressNumbers = addressClusters[c_it];
+            var addressPoints = doc.geometry.geometries[c_it];
+            if (!addressNumbers || !addressNumbers.length) continue;
 
-            if (doc.properties['carmen:addressnumber'][c_it].length !== doc.geometry.geometries[c_it].coordinates.length) {
-                return 'carmen:addressnumber[i] array must be equal to geometry.geometries[i] array';
+            if (addressNumbers.length !== addressPoints.coordinates.length) {
+                throw Error('carmen:addressnumber[i] array must be equal to geometry.geometries[i] array');
             }
 
-            if (doc.geometry.geometries[c_it].type !== 'MultiPoint') {
-                return 'non-null carmen:addressnumbers must parallel with MultiPoint geometries in GeometryCollection';
+            if (addressPoints.type !== 'MultiPoint') {
+                throw Error('non-null carmen:addressnumbers must parallel with MultiPoint geometries in GeometryCollection');
             }
 
-            for (var addr_it = 0; addr_it < doc.properties['carmen:addressnumber'][c_it].length; addr_it++) {
-                doc.properties['carmen:addressnumber'][c_it][addr_it] =
-                    typeof doc.properties['carmen:addressnumber'][c_it][addr_it] === 'string' ?
-                    doc.properties['carmen:addressnumber'][c_it][addr_it].toLowerCase() :
-                    doc.properties['carmen:addressnumber'][c_it][addr_it];
+            for (var addr_it = 0; addr_it < addressNumbers.length; addr_it++) {
+                addressNumbers[addr_it] =
+                    typeof addressNumbers[addr_it] === 'string' ?
+                    addressNumbers[addr_it].toLowerCase() :
+                    addressNumbers[addr_it];
             }
         }
     }
@@ -69,11 +73,13 @@ function addrTransform(doc) {
                 }]
             }
         } else if (doc.geometry.type !== 'GeometryCollection') {
-            return 'ITP results must be a LineString, MultiLineString, or GeometryCollection';
+            throw Error('ITP results must be a LineString, MultiLineString, or GeometryCollection');
         }
 
         for (c_it = 0; c_it < doc.geometry.geometries.length; c_it++) {
-            if (doc.geometry.geometries[c_it].type === 'LineString') return 'ITP geometries in a GeometryCollection must be MultiLineStrings';
+            if (doc.geometry.geometries[c_it].type === 'LineString') {
+                throw Error('ITP geometries in a GeometryCollection must be MultiLineStrings');;
+            }
 
             ['parityl', 'parityr', 'lfromhn', 'rfromhn', 'ltohn', 'rtohn'].forEach(function(type) {
                 doc.properties['carmen:'+type][c_it] = doc.properties['carmen:'+type][c_it] ? doc.properties['carmen:'+type][c_it] : [];
@@ -210,8 +216,11 @@ function getFeatureByCover(source, cover, callback) {
         var feature;
         for (var id in loaded) {
             if (loaded[id].properties['carmen:zxy'].indexOf(zxy) === -1) continue;
-            feature = normalizeLoaded(source, loaded[id]);
-            if (typeof feature === 'string') return callback(feature);
+            try {
+                feature = normalizeLoaded(source, loaded[id]);
+            } catch (err) {
+                return callback(err);
+            }
             break;
         }
 
@@ -241,12 +250,13 @@ function getFeatureById(source, id, callback) {
             return callback();
         }
 
-        feature = normalizeLoaded(source, feature);
-        if (typeof feature === 'string') {
-            return callback(feature);
-        } else {
-            return callback(null, feature);
+        try {
+            feature = normalizeLoaded(source, feature);
+        } catch (err) {
+            return callback(err)
         }
+
+        return callback(null, feature);
     });
 }
 
@@ -272,12 +282,13 @@ function getFeatureByLegacyId(source, id, callback) {
             return callback();
         }
 
-        feature = normalizeLoaded(source, feature);
-        if (typeof feature === 'string') {
-            return callback(feature);
-        } else {
-            return callback(null, feature);
+        try {
+            feature = normalizeLoaded(source, feature);
+        } catch (err) {
+            return callback(err);
         }
+
+        return callback(null, feature);
     });
 }
 
@@ -298,8 +309,11 @@ function putFeatures(source, docs, callback) {
         var doc = docs[i];
         if (doc._text) doc = transform(doc);
         else {
-            doc = addrTransform(doc);
-            if (typeof doc === 'string') return callback(doc);
+            try {
+                doc = addrTransform(doc);
+            } catch (err) {
+                return callback(err);
+            }
         }
 
         if (!doc.properties['carmen:zxy']) {

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -76,59 +76,62 @@ tape('indexdocs.standardize', function(assert) {
     });
 
     assert.test('indexdocs.standardize - Must be MultiPoint or GeometryCollection', function(t) {
-        var res = indexdocs.standardize({
-            id: 1,
-            type: 'Feature',
-            properties: {
-                'carmen:text': 'main street',
-                'carmen:center': [0,0],
-                'carmen:addressnumber': [9]
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [0,0]
-            }
-        }, 6, {});
+        t.throws(function(t) {
+            indexdocs.standardize({
+                id: 1,
+                type: 'Feature',
+                properties: {
+                    'carmen:text': 'main street',
+                    'carmen:center': [0,0],
+                    'carmen:addressnumber': [9]
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0,0]
+                }
+            }, 6, {});
+        }, /carmen:addressnumber must be MultiPoint or GeometryCollection/);
 
-        t.deepEquals(res, 'carmen:addressnumber must be MultiPoint or GeometryCollection');
         t.end();
     });
 
     assert.test('indexdocs.standardize - Must be MultiPoint or GeometryCollection', function(t) {
-        var res = indexdocs.standardize({
-            id: 1,
-            type: 'Feature',
-            properties: {
-                'carmen:text': 'main street',
-                'carmen:center': [0,0],
-                'carmen:addressnumber': [9]
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [0,0]
-            }
-        }, 6, {});
+        t.throws(function(t) {
+            indexdocs.standardize({
+                id: 1,
+                type: 'Feature',
+                properties: {
+                    'carmen:text': 'main street',
+                    'carmen:center': [0,0],
+                    'carmen:addressnumber': [9]
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0,0]
+                }
+            }, 6, {});
+        }, /carmen:addressnumber must be MultiPoint or GeometryCollection/);
 
-        t.deepEquals(res, 'carmen:addressnumber must be MultiPoint or GeometryCollection');
         t.end();
     });
 
     assert.test('indexdocs.standardize - carmen:addressnumber parallel arrays must equal', function(t) {
-        var res = indexdocs.standardize({
-            id: 1,
-            type: 'Feature',
-            properties: {
-                'carmen:text': 'main street',
-                'carmen:center': [0,0],
-                'carmen:addressnumber': [9]
-            },
-            geometry: {
-                type: 'MultiPoint',
-                coordinates: [[0,0], [0,0]]
-            }
-        }, 6, {});
+        t.throws(function() {
+            indexdocs.standardize({
+                id: 1,
+                type: 'Feature',
+                properties: {
+                    'carmen:text': 'main street',
+                    'carmen:center': [0,0],
+                    'carmen:addressnumber': [9]
+                },
+                geometry: {
+                    type: 'MultiPoint',
+                    coordinates: [[0,0], [0,0]]
+                }
+            }, 6, {});
+        }, /carmen:addressnumber\[i\] array must be equal to geometry.geometries\[i\] array/);
 
-        t.deepEquals(res, 'carmen:addressnumber[i] array must be equal to geometry.geometries[i] array');
         t.end();
     });
 
@@ -171,21 +174,22 @@ tape('indexdocs.standardize', function(assert) {
     });
 
     assert.test('indexdocs.standardize - carmen:rangetype invalid', function(t) {
-        var res = indexdocs.standardize({
-            id: 1,
-            type: 'Feature',
-            properties: {
-                'carmen:text': 'main street',
-                'carmen:center': [0,0],
-                'carmen:rangetype': 'tiger'
-            },
-            geometry: {
-                type: 'MultiPoint',
-                coordinates: [[0,0]]
-            }
-        }, 6, {});
+        t.throws(function(t) {
+            indexdocs.standardize({
+                id: 1,
+                type: 'Feature',
+                properties: {
+                    'carmen:text': 'main street',
+                    'carmen:center': [0,0],
+                    'carmen:rangetype': 'tiger'
+                },
+                geometry: {
+                    type: 'MultiPoint',
+                    coordinates: [[0,0]]
+                }
+            }, 6, {});
+        }, /ITP results must be a LineString, MultiLineString, or GeometryCollection/);
 
-        t.deepEquals(res, 'ITP results must be a LineString, MultiLineString, or GeometryCollection');
         t.end();
     });
 
@@ -249,67 +253,86 @@ tape('indexdocs.verifyCenter', function(assert) {
 });
 
 tape('indexdocs.runChecks', function(assert) {
-    assert.equal(indexdocs.runChecks({
-    }), 'doc has no id');
+    assert.throws(function(t) {
+        indexdocs.runChecks({});
+    }, /doc has no id/);
 
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {},
-        geometry: {
-            type: 'Point',
-            coordinates: [0,0]
-        }
-    }), 'doc has no carmen:text on id:1');
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text':'Main Street'
-        }
-    }), '"geometry" property required on id:1');
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text':'Main Street',
-            'carmen:center':[0,0]
-        },
-        geometry: { type: 'Polygon', coordinates: [new Array(60e3)] }
-    }, 12), 'a number was found where a coordinate array should have been found: this needs to be nested more deeply on id:1');
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text':'Main Street',
-            'carmen:center':[0,0]
-        },
-        geometry: { type: 'Polygon', coordinates: [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})] }
-    }, 12), 'Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:1');
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text':'Main Street',
-            'carmen:center':[0,0]
-        },
-        geometry: { type: 'MultiPolygon', coordinates: [[new Array(30e3)],[new Array(30e3)]] }
-    }, 12), 'a number was found where a coordinate array should have been found: this needs to be nested more deeply on id:1');
-    assert.equal(indexdocs.runChecks({
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text':'Main Street',
-            'carmen:center':[0,0]
-        },
-        geometry: {
-            type: 'MultiPolygon',
-            coordinates: [
-                [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})],
-                [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})]
-            ]
-        }
-    }, 12), 'Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:1');
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        }));
+    }, /doc has no carmen:text on id:1/);
+
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'Main Street'
+            }
+        }));
+    }, /"geometry" property required on id:1/);
+
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'Main Street',
+                'carmen:center':[0,0]
+            },
+            geometry: { type: 'Polygon', coordinates: [new Array(60e3)] }
+        }, 12));
+    }, /a number was found where a coordinate array should have been found: this needs to be nested more deeply on id:1/);
+
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'Main Street',
+                'carmen:center':[0,0]
+            },
+            geometry: { type: 'Polygon', coordinates: [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})] }
+        }, 12));
+    }, /Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:1/);
+
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'Main Street',
+                'carmen:center':[0,0]
+            },
+            geometry: { type: 'MultiPolygon', coordinates: [[new Array(30e3)],[new Array(30e3)]] }
+        }, 12));
+    }, /a number was found where a coordinate array should have been found: this needs to be nested more deeply on id:1/);
+
+    assert.throws(function(t) {
+        assert.equal(indexdocs.runChecks({
+            id:1,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'Main Street',
+                'carmen:center':[0,0]
+            },
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})],
+                    [Array.apply(null, Array(50001)).map(function() {return [1.1,1.1]})]
+                ]
+            }
+        }, 12));
+    }, /Polygons may not have more than 50k vertices. Simplify your polygons, or split the polygon into multiple parts on id:1/);
+
     assert.equal(indexdocs.runChecks({
         id:1,
         type: 'Feature',
@@ -318,7 +341,7 @@ tape('indexdocs.runChecks', function(assert) {
             'carmen:center':[0,0]
         },
         geometry: { type: 'Point', coordinates: [0,0] }
-    }, 12), '');
+    }, 12), undefined);
     assert.end();
 });
 


### PR DESCRIPTION
- switches from returning strings for errors to throwing exceptions
- cleans up a couple minor things like string concatenation and long lines

---

- [x] fix error / tests
- [x] review @yhahn (or assign to someone else)
- [x] stage indexing and test