### PR TITLE
fix test

### DIFF
--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -10,7 +10,7 @@ test('ops#toFeature', function(t) {
             "short_code": "ca"
         }
     }];
-    feat._relevance = 1.1;
+    feat._relevance = 1;
     t.deepEqual(ops.toFeature(feat), {
         id: 'country.1833980151',
         type: 'Feature',


### PR DESCRIPTION
updates the test for https://github.com/mapbox/carmen/pull/538/commits/cfb03d634530d37317ad2a465585f60c91170f07#diff-302a6bf18604609e84634fc6a0cd2f42L109

> relev > 1.0 was possible in an earlier draft of that branch which necessitated the min but we moved away from that

Going to merge once ci passes.