### PR TITLE
context: Defer language resolution

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -5,8 +5,7 @@ var mapnik = require('mapnik'),
     queue = require('d3-queue').queue,
     Locking = require('locking'),
     addressCluster = require('./pure/addresscluster'),
-    addressItp = require('./pure/addressitp'),
-    closestLang = require('./util/closest-lang');
+    addressItp = require('./pure/addressitp');
 var cover = require('tile-cover');
 
 // Returns a hierarchy of features ("context") for a given lon, lat pair.

--- a/lib/context.js
+++ b/lib/context.js
@@ -455,18 +455,15 @@ function loadFeature(source, feat, full, query, language, callback) {
                 properties['carmen:center'].split(',');
             loaded.properties['carmen:center'] = [parseFloat(coords[0]), parseFloat(coords[1])];
         }
-        var languageLabel = language ? closestLang.closestLangLabel(language, properties, "carmen:text_") : false;
-        if (languageLabel) {
-            loaded.properties['carmen:text'] = properties["carmen:text_" + languageLabel];
-            loaded.properties.language = languageLabel.replace("_", "-");
-        } else {
-            loaded.properties['carmen:text'] = properties['carmen:text'];
-        }
 
-        // copy non-carmen:* properties
+        // copy carmen:text* and non-carmen:* properties
+        // carmen:text* will get resolved to language-specific output
+        // at the very end of the geocoding process in ops.toFeature()
         var propertyKeys = Object.keys(properties);
         for (var propi = 0; propi < propertyKeys.length; propi++) {
-            if (!/^(carmen:|id$)/.test(propertyKeys[propi])) {
+            if (/^(carmen:text)/.test(propertyKeys[propi])) {
+                loaded.properties[propertyKeys[propi]] = properties[propertyKeys[propi]];
+            } else if (!/^(carmen:|id$)/.test(propertyKeys[propi])) {
                 loaded.properties[propertyKeys[propi]] = properties[propertyKeys[propi]];
             }
         }

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -33,13 +33,12 @@ function toFeature(context, format, language, debug) {
     var _gettext = function(f) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
         if (!language)
-            return { text: f.properties['carmen:text'].split(',')[0], language: false };
+            return { text: f.properties['carmen:text'].split(',')[0] };
         var languageLabel = closestLang.closestLangLabel(language, f.properties, "carmen:text_");
         var languageText = languageLabel ? f.properties["carmen:text_" + languageLabel] : false;
-        return {
-            text: (languageText||f.properties['carmen:text']||'').split(',')[0],
-            language: languageText ? languageLabel.replace('_', '-') : undefined
-        };
+        var text = { text: (languageText||f.properties['carmen:text']||'').split(',')[0] };
+        if (languageText) text.language = languageLabel.replace('_', '-');
+        return text;
     };
     var gettext = function(f) {
         return _gettext(f).text;

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -38,7 +38,7 @@ function toFeature(context, format, language, debug) {
         var languageText = languageLabel ? f.properties["carmen:text_" + languageLabel] : false;
         return {
             text: (languageText||f.properties['carmen:text']||'').split(',')[0],
-            language: languageText ? languageLabel : false
+            language: languageText ? languageLabel.replace('_', '-') : undefined
         };
     };
     var gettext = function(f) {
@@ -136,10 +136,8 @@ function toFeature(context, format, language, debug) {
         feature.context = [];
         for (var c = 1; c < context.length; c++) {
             if (!context[c].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
-            var contextFeat = {
-                id: context[c].properties['carmen:extid'],
-                text: gettext(context[c])
-            };
+            var contextFeat = _gettext(context[c]);
+            contextFeat.id = context[c].properties['carmen:extid'];
 
             // copy over all non-'carmen:*' properties
             var propertyKeys = Object.keys(context[c].properties).filter(function(prop) {

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -1,0 +1,105 @@
+// Tests New York (place), New York (region), USA (country)
+// identically-named features should reverse the gappy penalty and
+// instead prioritize the highest-index feature
+
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    country: new mem({ maxzoom: 6 }, function() {}),
+    region: new mem({ maxzoom: 6 }, function() {}),
+    place: new mem({ maxzoom: 6 }, function() {})
+};
+
+var c = new Carmen(conf);
+
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text':'usa',
+            'carmen:text_en':'usa'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text':'new york',
+            'carmen:text_en':'state of new york'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text':'new york',
+            'carmen:text_en':'state of new york'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('find new york', function(t) {
+    c.geocode('new york usa', {}, function(err, res) {
+        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].relevance, 1);
+        t.end();
+    });
+});
+
+tape('find new york, language=en', function(t) {
+    c.geocode('new york usa', { language: 'en' }, function(err, res) {
+        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].relevance, 1);
+        t.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+


### PR DESCRIPTION
**The problem:**

- The goal of `squishy` was to be able to promote a feature like `New York (place), New York (region)` past `New York (region)` on the basis of its text matching its parents.
- When localization is introduced, there's some ambiguity about what ^^ means. Is the text supposed to match between localized versions? Non-localized versions? What if there's some mixture of scripts or language because of language fallback handling?
- Currently in `master` you can lose the effect of the `squishy` adjustment when using the `language:` option because `context()` is resolving the localized version of `carmen:text` early, but the top feature in the stack is being resolved late.

**The fix:**

- `context()` is going to pass all `carmen:text*` properties onto the caller. It's the caller's job to localize text and clean up the properties for final output.
- The `squishy` logic is going to always operate only on `carmen:text` before it's been localized, for now. So there's no confusion about whether we're squishing based on localized text, fallback logic, etc.

This PR adds unit tests for the behavior above and makes the adjustment to context.

------

### TODO

- [ ] Integration/IRL tests + staging

cc @sbma44 @mapbox/geocoding-gang 

