### PR TITLE
Stopgap handling for features with > 10k zxy's

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -10,6 +10,7 @@ var point = require('turf-point');
 var linestring = require('turf-linestring');
 var geojsonHint = require('geojsonhint');
 var feature = require('../util/feature');
+var center2zxy = require('../util/proximity').center2zxy;
 var TIMER = process.env.TIMER;
 
 module.exports = {};
@@ -243,9 +244,22 @@ function standardize(doc, zoom) {
         throw Error('doc.properties[\'carmen:zxy\'] undefined, failed indexing, doc id:' + doc.id);
     }
 
-    // Limit carmen:zxy length
+    // Limit carmen:zxy length to 10000 covers.
+    // Stopgap: If covers exceed this amount drop covers furthest from
+    // the center of this feature. This breaks forward geocode stacking
+    // for any of the dropped covers.
     if (doc.properties['carmen:zxy'] && doc.properties['carmen:zxy'].length > 10000) {
-        throw Error('zxy exceeded 10000, doc id:' + doc.id);
+        console.warn('carmen:zxy exceeded 10000, truncating to 10000 (doc id: %s, text: %s)', doc.id, doc.properties['carmen:text']);
+        var centerCover = center2zxy(doc.properties['carmen:center'], zoom);
+        var sortedCovers = doc.properties['carmen:zxy'].slice(0);
+        sortedCovers.sort(function(a, b) {
+            a = a.split('/');
+            b = b.split('/');
+            var aDist = Math.sqrt(Math.pow(centerCover[1]-parseInt(a[1],10),2) + Math.pow(centerCover[2]-parseInt(a[2],10),2));
+            var bDist = Math.sqrt(Math.pow(centerCover[1]-parseInt(b[1],10),2) + Math.pow(centerCover[2]-parseInt(b[2],10),2));
+            return aDist - bDist;
+        });
+        doc.properties['carmen:zxy'] = sortedCovers.slice(0,10000);
     }
 
     return doc;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -351,64 +351,6 @@ test('error -- _geometry too high resolution', function(t) {
     });
 });
 
-test('error -- carmen:zxy too large tile-cover', function(t) {
-    var tiles = [];
-    for (var i = 0; i < 10002; i++) { tiles.push('6/32/32'); }
-
-    var docs = [{
-        id: 1,
-        type: 'Feature',
-        properties: {
-            'carmen:text': 'fake street',
-            'carmen:center': [0,0],
-            'carmen:zxy': ['6/32/32']
-        },
-        geometry: {
-            type: 'Point',
-            coordinates: [0,0]
-        }
-    }, {
-        id:1,
-        type: 'Feature',
-        properties: {
-            'carmen:text': 'fake street',
-            'carmen:center': [0,0],
-            'carmen:zxy': tiles
-        },
-        geometry: {
-            type: 'Point',
-            coordinates: [0,0]
-        }
-    }];
-
-    var s = new Stream.Readable();
-    s._read = function noop() {}; // redundant? see update below
-    s.push(JSON.stringify(docs[0]) + '\n');
-    s.push(JSON.stringify(docs[1]) + '\n');
-    s.push(null);
-
-    var outputStream = new Stream.Writable();
-    outputStream._write = function(chunk, encoding, done) {
-        var doc = JSON.parse(chunk.toString());
-
-        //Only print on error or else the logs are super long
-        if (!doc.id) t.ok(doc.id, 'has id: ' + doc.id);
-        done();
-    };
-
-    var conf = {
-        to: new mem(docs, null, function() {})
-    };
-    var carmen = new Carmen(conf);
-    carmen.index(s, conf.to, {
-        zoom: 6,
-        output: outputStream
-    }, function(err) {
-        t.equal('Error: zxy exceeded 10000, doc id:1', err.toString());
-        t.end();
-    });
-});
-
 test('index.cleanDocs', function(assert) {
     var sourceWithAddress = {geocoder_address:true};
     var sourceWithoutAddress = {geocoder_address:false};

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -243,6 +243,37 @@ tape('indexdocs.standardize', function(assert) {
         t.end();
     });
 
+    assert.test('indexdocs.standardize - carmen:zxy exceeds 10000 covers', function(t) {
+        // Build a zxy list with covers of varying distance from center.
+        var central = ['6/32/32','6/33/33','6/31/31','6/32/30','6/30/32'];
+        var covers = [];
+        var i;
+        for (i = 0; i < 10000; i++) { covers.push('6/40/40'); }
+        for (i = 0; i < 100; i++) central.forEach(function(central) {
+            covers.push(central);
+        });
+
+        var res = indexdocs.standardize({
+            id: 1,
+            type: 'Feature',
+            properties: {
+                'carmen:text': 'main street',
+                'carmen:center': [0,0],
+                'carmen:zxy': covers
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        }, 6, {});
+
+        assert.deepEqual(res.properties['carmen:zxy'].length, 10000, 'truncates carmen:zxy to 10000');
+        central.forEach(function(cover) {
+            assert.deepEqual(res.properties['carmen:zxy'].filter(function(zxy) { return zxy === cover; }).length, 100, 'sort preserves covers closest to center: ' + cover);
+        });
+        t.end();
+    });
+
     assert.end();
 });
 


### PR DESCRIPTION
Carmen `master` currently throws when a feature's ZXY tile cover list exceeds 10k features. This is a hard limit put in place to make sure

- grid cache sizes don't blow up too large
- carmen-cache's `spatialmatch` performs reasonably well

On the flipside, this limitation has forced us to come up with various half-measures for indexing very large polygon features (e.g. huge features in northern Canada or Russia that get gigantized by Web Mercator).

------

### The ideal solution

We'd make use of [multi-zoom tile covers](https://github.com/mapbox/tile-cover#polygons) to reduce the size of the zxy list. There are a lot of challenges in the path to doing this, however.

### Carmen-level stopgap

This branch implements a carmen-level stopgap:

- Warn when we hit a feature with 10k tile covers
- Sort the tile cover list prioritizing covers closest to the feature's center
- Truncate the list at 10k

It's not perfect but it will get us:

- Full reverse geocoding for these affected features
- Reasonable forward geocoding -- we'll be able to find the feature, and the feature will be able to stack with any features within the 10k covers that were prioritized
- Reasonable/parity performance with where we are now

What it will affect is:

- Forward geocodes that should stack with the periphery of these features will have lower relevance than expected

------

:green_apple: moral compass: this is better than where we are now until we can get a multizoom approach into our cover index.