### PR TITLE
Score inheritance (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ geocoder_types          | Optional + advanced. An array of type strings. Only ne
 geocoder_version        | Required. Should be set to **6** for carmen@v11.x. Index versions <= 1 can be used for reverse geocoding but not forward.
 geocoder_cachesize      | Optional + advanced. Maximum number of shards to allow in the `carmen-cache` message cache. Defaults uptream to 65536 (maximum number of possible shards).
 geocoder_address_order  | Optional + advanced. A string that can be set to `ascending` or `descending` to indicate the expected ordering of address components for an index. Defaults to `ascending`.
+geocoder_inherit_score  | Optional + advanced. Set to `true` if features from this index should appear above other identically (ish) named parent features that are part of its context (e.g. promote New York (city) promoted above New York (state)). Defaults to `false`.
 
 *Note: The sum of maxzoom + geocoder_resolution must be no greater than 14.*
 

--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ function Geocoder(indexes, options) {
             source.geocoder_format = info.geocoder_format||false;
             source.geocoder_layer = (info.geocoder_layer||'').split('.').shift();
             source.geocoder_tokens = info.geocoder_tokens||{};
+            source.geocoder_inherit_score = info.geocoder_inherit_score || false;
             source.token_replacer = token.createReplacer(info.geocoder_tokens||{});
 
             if (tokenValidator(source.token_replacer)) {
@@ -115,7 +116,6 @@ function Geocoder(indexes, options) {
             source.idx = i;
             source.ndx = names.indexOf(name);
             source.bounds = info.bounds || [ -180, -85, 180, 85 ];
-            source.prevent_promotion = info.prevent_promotion || false;
 
             // add byname index lookup
             this.byname[name] = this.byname[name] || [];

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -209,6 +209,14 @@ function loadContexts(geocoder, features, sets, options, callback) {
 }
 
 function verifyContexts(contexts, sets, indexes) {
+    // Create lookup for peer contexts for squishy. This allows squishy to
+    // use real loaded feature score values rather than cover `scoredist`
+    // which is a gross approximation based on an index's scorefactor.
+    var peers = {};
+    for (var c = 0; c < contexts.length; c++) {
+        peers[contexts[c][0].properties['carmen:tmpid']] = contexts[c][0];
+    }
+
     for (var a = 0; a < contexts.length; a++) {
         var context = contexts[a];
         context._relevance = 0;
@@ -221,15 +229,15 @@ function verifyContexts(contexts, sets, indexes) {
             verify[cover.tmpid] = cover;
         }
 
-        var strictRelev = verifyContext(context, verify, {}, indexes);
-        var looseRelev = verifyContext(context, verify, sets, indexes);
+        var strictRelev = verifyContext(context, peers, verify, {}, indexes);
+        var looseRelev = verifyContext(context, peers, verify, sets, indexes);
         context._relevance = Math.max(strictRelev, looseRelev);
     }
     contexts.sort(sortContext);
     return contexts;
 }
 
-function verifyContext(context, strict, loose, indexes) {
+function verifyContext(context, peers, strict, loose, indexes) {
     var addressOrder = context[0].properties['carmen:geocoder_address_order'];
     var gappy = 0;
     var stacky = 0;
@@ -258,8 +266,9 @@ function verifyContext(context, strict, loose, indexes) {
         var matched = strict[feat.properties["carmen:tmpid"]] || loose[feat.properties["carmen:tmpid"]];
         if (!matched) continue;
 
-        if (squishyTarget && (c > 0) && loose[feat.properties["carmen:tmpid"]] && textAlike(squishyTarget, feat.properties))
-            squishy += loose[feat.properties["carmen:tmpid"]].scoredist;
+        // Lookup and sum score from a peer feature if eligible.
+        if (squishyTarget && (c > 0) && peers[feat.properties['carmen:tmpid']] && textAlike(squishyTarget, feat.properties))
+            squishy += Math.max(peers[feat.properties['carmen:tmpid']].properties['carmen:score'] || 0, 0);
 
         if (usedmask & matched.mask) continue;
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -239,7 +239,7 @@ function verifyContext(context, strict, loose, indexes) {
     var relevance = 0;
     var direction;
     // 'squishy' checks for nested, identically-named features in indexes
-    //  without prevent_promotion enabled. When they are encountered, avoid
+    //  with geocoder_inherit_score enabled. When they are encountered, avoid
     // applying the gappy penalty and combine their scores on the smallest
     // feature.
     // This ensures that a context of "New York, New York, USA" will return
@@ -248,7 +248,7 @@ function verifyContext(context, strict, loose, indexes) {
     // region feature would be returned as the first result.
     var squishy = 0;
     var squishyTextToMatch = false;
-    if (!indexes[context[0].properties["carmen:index"]].prevent_promotion)
+    if (indexes[context[0].properties["carmen:index"]].geocoder_inherit_score)
         squishyTextToMatch = context[0].properties["carmen:text"].split(',')[0];
 
     for (var c = 0; c < context.length; c++) {

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -258,7 +258,7 @@ function verifyContext(context, strict, loose, indexes) {
         var matched = strict[feat.properties["carmen:tmpid"]] || loose[feat.properties["carmen:tmpid"]];
         if (!matched) continue;
 
-        if (squishyTextToMatch && (c > 0) && loose[feat.properties["carmen:tmpid"]] && (feat.properties["carmen:text"].split(',')[0] === squishyTextToMatch))
+        if (squishyTextToMatch && (c > 0) && loose[feat.properties["carmen:tmpid"]] && (feat.properties["carmen:text"].split(',')[0].indexOf(squishyTextToMatch) !== -1))
             squishy += loose[feat.properties["carmen:tmpid"]].scoredist;
 
         if (usedmask & matched.mask) continue;

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -247,9 +247,9 @@ function verifyContext(context, strict, loose, indexes) {
     // In the absence of this check the place would be gappy-penalized and the
     // region feature would be returned as the first result.
     var squishy = 0;
-    var squishyTextToMatch = false;
+    var squishyTarget = false;
     if (indexes[context[0].properties["carmen:index"]].geocoder_inherit_score)
-        squishyTextToMatch = context[0].properties["carmen:text"].split(',')[0];
+        squishyTarget = context[0].properties;
 
     for (var c = 0; c < context.length; c++) {
         var backy = false;
@@ -258,7 +258,7 @@ function verifyContext(context, strict, loose, indexes) {
         var matched = strict[feat.properties["carmen:tmpid"]] || loose[feat.properties["carmen:tmpid"]];
         if (!matched) continue;
 
-        if (squishyTextToMatch && (c > 0) && loose[feat.properties["carmen:tmpid"]] && (feat.properties["carmen:text"].split(',')[0].indexOf(squishyTextToMatch) !== -1))
+        if (squishyTarget && (c > 0) && loose[feat.properties["carmen:tmpid"]] && textAlike(squishyTarget, feat.properties))
             squishy += loose[feat.properties["carmen:tmpid"]].scoredist;
 
         if (usedmask & matched.mask) continue;
@@ -354,3 +354,25 @@ function sortContext(a, b) {
     if (a[0].id > b[0].id) return 1;
     return 0;
 }
+
+// Used for determining features with alike text for score promotion
+// e.g. boosting New York (city) above New York (state)
+//
+// Given two properties objects with carmen:text* fields, compare each
+// textfield and find likeness between target and candidate. If the text
+// from the target is fully contained within the candidate text for a like
+// language, the feature text is considered alike.
+function textAlike(target, candidate) {
+    var pattern = /^carmen:text/;
+    var keys = Object.keys(target).filter(pattern.test.bind(pattern));
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (typeof target[key] !== 'string' || !target[key]) continue;
+        if (typeof candidate[key] !== 'string' || !candidate[key]) continue;
+        var targetText = target[key].split(',')[0];
+        var candidateText = candidate[key].split(',')[0];
+        if (candidateText.indexOf(targetText) !== -1) return true;
+    }
+    return false;
+}
+

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -11,7 +11,7 @@ var addFeature = require('../lib/util/addfeature');
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
     region: new mem({ maxzoom: 6 }, function() {}),
-    place: new mem({ maxzoom: 6 }, function() {})
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {})
 };
 
 var c = new Carmen(conf);

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -1,12 +1,13 @@
-// Tests New York (place), New York (region), USA (country)
-// identically-named features should reverse the gappy penalty and
-// instead prioritize the highest-index feature
-
 var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
+
+// Tests New York (place), New York (region), USA (country)
+// identically-named features should reverse the gappy penalty and
+// instead prioritize the highest-index feature
+(function() {
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
@@ -102,4 +103,99 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
+
+})();
+
+// Simulate a case where carmen:text has a discrepancy but carmen:text_en
+// allows a text match to occur.
+(function() {
+
+var conf = {
+    country: new mem({ maxzoom: 6 }, function() {}),
+    region: new mem({ maxzoom: 6 }, function() {}),
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {})
+};
+
+var c = new Carmen(conf);
+
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text':'saudi arabia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text': 'مكة',
+            'carmen:text_en':'Makkah'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text':'Makkah Al Mukarramah',
+            'carmen:text_en':'Makkah'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('find makkah', function(t) {
+    c.geocode('makkah', {}, function(err, res) {
+        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].relevance, 0.99);
+        t.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+
+})();
+
 

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -7,8 +7,6 @@ var addFeature = require('../lib/util/addfeature');
 // Tests New York (place), New York (region), USA (country)
 // identically-named features should reverse the gappy penalty and
 // instead prioritize the highest-index feature
-(function() {
-
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
     region: new mem({ maxzoom: 6 }, function() {}),
@@ -104,22 +102,18 @@ tape('teardown', function(assert) {
     assert.end();
 });
 
-})();
-
 // Simulate a case where carmen:text has a discrepancy but carmen:text_en
 // allows a text match to occur.
-(function() {
-
-var conf = {
+var conf2 = {
     country: new mem({ maxzoom: 6 }, function() {}),
     region: new mem({ maxzoom: 6 }, function() {}),
     place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {})
 };
 
-var c = new Carmen(conf);
+var c2 = new Carmen(conf2);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    addFeature(conf2.country, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -140,7 +134,7 @@ tape('index country', function(t) {
 });
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    addFeature(conf2.region, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -162,7 +156,7 @@ tape('index region', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    addFeature(conf2.place, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -184,7 +178,7 @@ tape('index place', function(t) {
 });
 
 tape('find makkah', function(t) {
-    c.geocode('makkah', {}, function(err, res) {
+    c2.geocode('makkah', {}, function(err, res) {
         t.equal(res.features[0].id, 'place.1');
         t.equal(res.features[0].relevance, 0.99);
         t.end();
@@ -195,7 +189,4 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-
-})();
-
 

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -44,8 +44,8 @@ tape('index region', function(t) {
         properties: {
             'carmen:center': [0,0],
             'carmen:score': 1,
-            'carmen:text':'new york',
-            'carmen:text_en':'state of new york'
+            'carmen:text':'state of new york, new york',
+            'carmen:text_es':'nueva york'
         },
         geometry: {
             type: 'Polygon',
@@ -67,7 +67,7 @@ tape('index place', function(t) {
             'carmen:center': [0,0],
             'carmen:score': 1,
             'carmen:text':'new york',
-            'carmen:text_en':'state of new york'
+            'carmen:text_es':'nueva york'
         },
         geometry: {
             type: 'Polygon',
@@ -90,8 +90,8 @@ tape('find new york', function(t) {
     });
 });
 
-tape('find new york, language=en', function(t) {
-    c.geocode('new york usa', { language: 'en' }, function(err, res) {
+tape('find nueva york, language=es', function(t) {
+    c.geocode('nueva york usa', { language: 'es' }, function(err, res) {
         t.equal(res.features[0].id, 'place.1');
         t.equal(res.features[0].relevance, 1);
         t.end();

--- a/test/geocode-unit.promote-on-identical-name.test.js
+++ b/test/geocode-unit.promote-on-identical-name.test.js
@@ -12,8 +12,8 @@ var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
     region: new mem({ maxzoom: 6 }, function() {}),
     district: new mem({ maxzoom: 6 }, function() {}),
-    place: new mem({ maxzoom: 6 }, function() {}),
-    poi: new mem({ maxzoom: 14, prevent_promotion: true }, function() {})
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {}),
+    poi: new mem({ maxzoom: 14 }, function() {})
 };
 
 var c = new Carmen(conf);
@@ -174,9 +174,9 @@ tape('teardown', function(assert) {
 
 var conf2 = {
     country: new mem({ maxzoom: 6 }, function() {}),
-    region: new mem({ maxzoom: 6 }, function() {}),
-    district: new mem({ maxzoom: 6 }, function() {}),
-    place: new mem({ maxzoom: 6 }, function() {})
+    region: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {}),
+    district: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {}),
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {})
 };
 var c2 = new Carmen(conf2);
 

--- a/test/geocode-unit.promote-score.test.js
+++ b/test/geocode-unit.promote-score.test.js
@@ -1,0 +1,115 @@
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+// Tests New York (place), New York (region), USA (country)
+// identically-named features should reverse the gappy penalty and
+// instead prioritize the highest-index feature
+var conf = {
+    country: new mem({ maxzoom: 6 }, function() {}),
+    region: new mem({ maxzoom: 6 }, function() {}),
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true }, function() {})
+};
+
+var c = new Carmen(conf);
+
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1000000,
+            'carmen:text':'usa',
+            'carmen:text_en':'usa'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index country', function(t) {
+    addFeature(conf.country, {
+        id: 2,
+        properties: {
+            'carmen:center': [45,45],
+            'carmen:score': 10,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [40,40],
+                [40,50],
+                [50,50],
+                [50,40],
+                [40,40],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 50,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        id: 1,
+        properties: {
+            'carmen:center': [45,45],
+            'carmen:score': 1,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [40,40],
+                [40,50],
+                [50,50],
+                [50,40],
+                [40,40],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('find georgia', function(t) {
+    c.geocode('georgia', {}, function(err, res) {
+        t.equal(res.features[0].id, 'region.1');
+        t.equal(res.features[0].relevance, 0.99);
+        t.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -153,12 +153,12 @@ tape('china poi returns poi.landmark also', function(t) {
     });
 });
 
-// place wins without type filter
+// country wins without type filter
 tape('china', function(t) {
     c.geocode('china', { limit_verify:4 }, function(err, res) {
         t.ifError(err);
         t.deepEqual(res.features.length, 4, '4 results');
-        t.deepEqual(res.features[0].id, 'place.1', 'place wins');
+        t.deepEqual(res.features[0].id, 'country.1', 'country wins');
         t.end();
     });
 });
@@ -178,8 +178,8 @@ tape('china', function(t) {
     c.geocode('china', { limit_verify:3, types:['region','place'] }, function(err, res) {
         t.ifError(err);
         t.deepEqual(res.features.length, 2, '2 results');
-        t.deepEqual(res.features[0].id, 'place.1', 'place #1');
-        t.deepEqual(res.features[1].id, 'region.1', 'region #2');
+        t.deepEqual(res.features[0].id, 'region.1', 'region #1');
+        t.deepEqual(res.features[1].id, 'place.1', 'place #2');
         t.end();
     });
 });


### PR DESCRIPTION
- Switch score inheritance from opt-out to opt-in on a per index basis to make this feature 100% optional: `prevent_promotion => geocoder_inherit_score`
- Compares `carmen:text` and all `carmen:text_{language}` strings (between the same language codes) for the target and candidate features.
- Considers text matching if target text is fully present as a substring of the candidate text.

Functionally this helps cover cases like:

- Bern (city) within, Canton of Bern (administrative region)
  - Requires substring text match between candidate + target
- Inconsistent use of `carmen:text` (known issue where the language is often indeterminate/inconsistent) making one or more of the `carmen:text_{language}` properties often more suitable for consistent/robust comparison
  - Requires considering all `carmen:text*` fields

------

Running IRL tests to make sure this is a safe change. While this alters an API (`prevent_promotion`), as this API was internal/undocumented I feel ok about this being a minor version bump.

cc @sbma44 @mapbox/geocoding-gang 