### PR TITLE
Handle Un-decodable Text like Emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 17.6.1
+
+- Fixes bug where unencodable text like emojis wasn't being ignored.
+
 ## 17.6.0
 
 - Adds index-level option `geocoder_inherit_score` for promoting features that nest within other similar named parent features (e.g. promote New York (city) promoted above New York (state)).

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,12 +167,12 @@ function update(source, docs, options, callback) {
             }, data, type);
         }
 
-        function setText(text) {
+        function setText(textArray) {
             var dictcache = source._dictcache;
             if (dictcache.properties.needsText) {
-                for (var i = 0; i < text.length; i++) {
-                    if ((text[i] !== null) && (text[i].trim().length > 0)) {
-                        dictcache.setText(text[i]);
+                for (var i = 0; i < textArray.length; i++) {
+                    if ((textArray[i] !== null) && (textArray[i].trim().length > 0)) {
+                        dictcache.setText(textArray[i]);
                     }
                 }
             }

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -2,11 +2,13 @@ var termops = require('./util/termops');
 var token = require('./util/token');
 var bb = require('./util/bbox');
 
-// # phrasematch
-//
-// @param {Object} source a Geocoder datasource
-// @param {Array} query a list of terms composing the query to Carmen
-// @param {Function} callback called with `(err, features, result, stats)`
+/**
+* phrasematch
+*
+* @param {Object} source a Geocoder datasource
+* @param {Array} query a list of terms composing the query to Carmen
+* @param {Function} callback called with `(err, features, result, stats)`
+*/
 module.exports = function phrasematch(source, query, options, callback) {
     options = options || {};
     options.autocomplete = options.autocomplete || false;
@@ -48,12 +50,14 @@ module.exports = function phrasematch(source, query, options, callback) {
         while (l--) {
             var subquery = subqueries[l];
             var text = termops.encodableText(subquery);
-            if (!source._dictcache.hasPhrase(text, subquery.ender)) continue;
-            // Augment permutations with matched grids,
-            // index position and weight relative to input query.
-            var phrase = termops.encodePhrase(subquery, options.autocomplete ? subquery.ender : false);
-            var weight = subquery.length / tokenized.length;
-            phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder, source.zoom));
+            if (text) {
+                if (!source._dictcache.hasPhrase(text, subquery.ender)) continue;
+                // Augment permutations with matched grids,
+                // index position and weight relative to input query.
+                var phrase = termops.encodePhrase(subquery, options.autocomplete ? subquery.ender : false);
+                var weight = subquery.length / tokenized.length;
+                phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder, source.zoom));
+            }
         }
 
         return callback(null, new PhrasematchResult(phrasematches, getter, loadall, source));

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -60,12 +60,19 @@ function terms(tokens) {
  *                 done to separate language families from one another for
  *                 purposes of matching unidecoded strings in the index.
  *
- * @param {Array} tokens Tokenized array of user's input query
+ * @param {Array} tokens - Tokenized array of user's input query
+ * @return {String} If tokens are encodable, returns
+ *                 encoded string. Otherwise returns ''.
  */
 function encodableText(tokens) {
-    var text = (typeof tokens === 'string') ?  tokens : tokens.join(' ');
-    return unidecode((nonCJKchar.test(text) ? 'x' : 'z') + text).toLowerCase().trim().replace(/\s+/g, ' ');
-}
+    var text = (typeof tokens === 'string') ? tokens : tokens.join(' ');
+    var decodedText = unidecode((nonCJKchar.test(text) ? 'x' : 'z') + text);
+    if (decodedText.length > 1) {
+        return decodedText.toLowerCase().trim().replace(/\s+/g, ' ');
+    } else {
+        return '';
+    };
+};
 
 function encodePhrase(tokens, degen) {
     var text = encodableText(tokens);
@@ -415,6 +422,12 @@ function uniqPermutations(permutations) {
     return uniq;
 }
 
+/**
+* getIndexablePhrases 
+*
+* @param {Array} tokens
+* @param {Object} freq
+*/
 module.exports.getIndexablePhrases = getIndexablePhrases;
 function getIndexablePhrases(tokens, freq) {
     var uniq = {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "17.6.0",
+  "version": "17.6.1",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",

--- a/test/geocode-unit.emoji.test.js
+++ b/test/geocode-unit.emoji.test.js
@@ -1,0 +1,74 @@
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    country: new mem({ maxzoom: 6 }, function() {})
+};
+
+var c = new Carmen(conf);
+tape('index emoji country', function(assert) {
+    addFeature(conf.country, {
+        id: 1,
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        },
+        properties: {
+            // Line smiley
+            'carmen:text': decodeURIComponent('%E2%98%BA'),
+            'carmen:center': [0,0]
+        }
+    }, assert.end);
+});
+
+tape('index non-emoji country', function(assert) {
+    addFeature(conf.country, {
+        id: 2,
+        geometry: {
+            type: 'Point',
+            coordinates: [10,10]
+        },
+        properties: {
+            // Line smiley
+            'carmen:text': 'Anarres',
+            'carmen:center': [10,10]
+        }
+    }, assert.end);
+});
+
+tape('should not find emoji feaure', function(assert) {
+    // Line smiley
+    c.geocode(decodeURIComponent('%E2%98%BA'), {}, function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.features.length, 0, 'finds no features');
+        assert.end();
+    });
+});
+
+tape('should not find feaure (atm or ever -- different emoji)', function(assert) {
+    // Filled smiley
+    c.geocode(decodeURIComponent('%E2%98%BB'), {}, function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.features.length, 0, 'finds no features');
+        assert.end();
+    });
+});
+
+tape('should handle a query including emoji', function(assert) {
+    // Black star
+    var query = 'Anarres ' + decodeURIComponent('%E2%98%85');
+    c.geocode(query, {}, function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.features[0].id, 'country.2', 'finds Anarres');
+        assert.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/termops.encodableText.test.js
+++ b/test/termops.encodableText.test.js
@@ -1,0 +1,9 @@
+var termops = require('../lib/util/termops');
+var test = require('tape');
+
+test('termops.encodableText', function(assert) {
+    assert.deepEqual(termops.encodableText('New York'), 'xnew york', 'encodes latin range');
+    assert.deepEqual(termops.encodableText('京都市'), 'zjing du shi', 'encodes CJK range');
+    assert.deepEqual(termops.encodableText(decodeURIComponent('%E2%98%BA')) === '', true, 'encodes an emoji to an actually empty string');
+    assert.end();
+});


### PR DESCRIPTION
We previously failed to properly decode emojis, but our character set check resulted in these queries becoming `'x'` instead of `''` after decoding. 

This PR:
- Checks the length of the text after the character check, and returns `''` for un-decodable text.
- Tests for correct behavior
- Tidies up some docstrings and a variable name.

Fixes https://github.com/mapbox/api-geocoder/issues/1129