### PR TITLE
Fix bug for multitype promotion across types

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -143,33 +143,29 @@ function stackFeatures(geocoder, loaded, options) {
                 }
             }
 
-            // If the promoted type is more specific than the previously set
-            // firstType, hit the reset button letting the promoted type take
-            // precedence.
-            //
-            // Example:
-            //
-            // Let type order be: region, district, place
-            //
-            // feature1: district
-            // feature2: region,place (multitype)
-            //
-            // firstType will initially be set to `district`, but when
-            // encountering feature2 this check will recognize that `place`
-            // is more specific and reset the memo object.
-            if (promoted && firstType && typeOrder[type] > typeOrder[firstType]) {
-                memo = {};
-                firstType = false;
-            }
-
-            if (!memo[type]) {
+            if (memo[type] === undefined) {
                 memo[type] = feature;
                 memo[conflict] = feature;
                 if (!firstType) firstType = type;
                 break;
-            } else if (memo[type] && promoted && firstType === type) {
-                // Remove all references to previously stacked feature
-                for (var a in memo) if (memo[a] === memo[type]) delete memo[a];
+            } else if (memo[type] && promoted && typeOrder[firstType] <= typeOrder[type]) {
+                // Remove references to previously stacked features between
+                // the promoted feature's base type and promoted type. Example:
+                //
+                // Let type order be: region, district, place
+                //
+                // feature1: district
+                // feature2: region,place (multitype)
+                //
+                // Clear out any previously stacked features in region, district, place
+                // and block placement of any other features at those levels.
+                var baseType = feature.properties['carmen:types'][0];
+                for (var t in typeOrder) {
+                    if (typeOrder[t] >= typeOrder[baseType] &&
+                        typeOrder[t] <= typeOrder[type]) {
+                        memo[t] = false;
+                    }
+                }
                 // Stack new feature
                 memo[type] = feature;
                 memo[conflict] = feature;
@@ -194,6 +190,7 @@ function stackFeatures(geocoder, loaded, options) {
     var types = Object.keys(memo);
     for (var k = 0; k < types.length; k++) {
         var toAdd = memo[types[k]];
+        if (!toAdd) continue;
         if (context.indexOf(toAdd) !== -1) continue;
 
         // Strip out context-logic properties for now

--- a/lib/context.js
+++ b/lib/context.js
@@ -74,7 +74,7 @@ module.exports = function(geocoder, position, options, callback) {
 
     q.awaitAll(function(err, loaded) {
         if (err) return callback(err);
-        return callback(null, stackFeatures(loaded, options));
+        return callback(null, stackFeatures(geocoder, loaded, options));
     });
 };
 
@@ -93,8 +93,14 @@ function getSubtypeLookup(types) {
     return subtypeLookup;
 }
 
-function stackFeatures(loaded, options) {
+function stackFeatures(geocoder, loaded, options) {
     if (!loaded.length) return [];
+
+    var typeOrder = Object.keys(geocoder.indexes).reduce(function(memo, id) {
+        var index = geocoder.indexes[id];
+        if (!memo[index.type]) memo[index.type] = memo._counter++;
+        return memo;
+    }, { _counter:0 });
 
     var context = [];
     var memo = {};
@@ -112,7 +118,7 @@ function stackFeatures(loaded, options) {
 
         for (var l = feature.properties['carmen:types'].length - 1; l >= 0; l--) {
             var type = feature.properties['carmen:types'][l];
-            var promoted = l > 0;
+            var promoted = l > 0 && options.full;
             var conflict = feature.properties['carmen:conflict'] || type;
 
             // Reconstruct extid based on selected type
@@ -137,12 +143,31 @@ function stackFeatures(loaded, options) {
                 }
             }
 
+            // If the promoted type is more specific than the previously set
+            // firstType, hit the reset button letting the promoted type take
+            // precedence.
+            //
+            // Example:
+            //
+            // Let type order be: region, district, place
+            //
+            // feature1: district
+            // feature2: region,place (multitype)
+            //
+            // firstType will initially be set to `district`, but when
+            // encountering feature2 this check will recognize that `place`
+            // is more specific and reset the memo object.
+            if (promoted && firstType && typeOrder[type] > typeOrder[firstType]) {
+                memo = {};
+                firstType = false;
+            }
+
             if (!memo[type]) {
                 memo[type] = feature;
                 memo[conflict] = feature;
                 if (!firstType) firstType = type;
                 break;
-            } else if (memo[type] && promoted && firstType === type && options.full) {
+            } else if (memo[type] && promoted && firstType === type) {
                 // Remove all references to previously stacked feature
                 for (var a in memo) if (memo[a] === memo[type]) delete memo[a];
                 // Stack new feature

--- a/test/context.stackFeatures.test.js
+++ b/test/context.stackFeatures.test.js
@@ -2,11 +2,17 @@ var context = require('../lib/context');
 var tape = require('tape');
 
 tape('context.stackFeatures noop', function(assert) {
-    assert.deepEqual(context.stackFeatures([], {}), [], '0 features => []');
+    assert.deepEqual(context.stackFeatures({}, [], {}), [], '0 features => []');
     assert.end();
 });
 
 tape('context.stackFeatures simple', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            country: { type:'country' },
+            region: { type:'region' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -20,11 +26,16 @@ tape('context.stackFeatures simple', function(assert) {
             'carmen:extid': 'region.1'
         }
     }];
-    assert.deepEqual(context.stackFeatures(loaded.slice(0), {}), [loaded[1], loaded[0]], '2 features stacked');
+    assert.deepEqual(context.stackFeatures(geocoderStub, loaded.slice(0), {}), [loaded[1], loaded[0]], '2 features stacked');
     assert.end();
 });
 
 tape('context.stackFeatures type bump', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            country: { type:'country' },
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -38,11 +49,17 @@ tape('context.stackFeatures type bump', function(assert) {
             'carmen:extid': 'country.2'
         }
     }];
-    assert.deepEqual(context.stackFeatures(loaded.slice(0), {}), [loaded[0]], '1 feature stacked, 1 bumped');
+    assert.deepEqual(context.stackFeatures(geocoderStub, loaded.slice(0), {}), [loaded[0]], '1 feature stacked, 1 bumped');
     assert.end();
 });
 
 tape('context.stackFeatures conflict', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            place: { type:'place' },
+            address: { type:'address' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -63,11 +80,17 @@ tape('context.stackFeatures conflict', function(assert) {
             'carmen:extid': 'poi.1'
         }
     }];
-    assert.deepEqual(context.stackFeatures(loaded.slice(0), {}), [loaded[1], loaded[0]], '2 features stacked, 1 bumped');
+    assert.deepEqual(context.stackFeatures(geocoderStub, loaded.slice(0), {}), [loaded[1], loaded[0]], '2 features stacked, 1 bumped');
     assert.end();
 });
 
 tape('context.stackFeatures conflict, dist tiebreak', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            place: { type:'place' },
+            address: { type:'address' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -90,11 +113,17 @@ tape('context.stackFeatures conflict, dist tiebreak', function(assert) {
             'carmen:vtquerydist': 1
         }
     }];
-    assert.deepEqual(context.stackFeatures(loaded.slice(0), {}), [loaded[2], loaded[0]], '2 features stacked, 1 bumped, conflict priorities nearest feature');
+    assert.deepEqual(context.stackFeatures(geocoderStub, loaded.slice(0), {}), [loaded[2], loaded[0]], '2 features stacked, 1 bumped, conflict priorities nearest feature');
     assert.end();
 });
 
 tape('context.stackFeatures multitype', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            region: { type:'region' },
+            place: { type:'place' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -102,13 +131,20 @@ tape('context.stackFeatures multitype', function(assert) {
             'carmen:extid': 'region.1'
         }
     }];
-    var stacked = context.stackFeatures(loaded.slice(0), {});
+    var stacked = context.stackFeatures(geocoderStub, loaded.slice(0), {});
     assert.deepEqual(stacked, [loaded[0]], '1 feature stacked, promoted');
     assert.deepEqual(stacked[0].properties['carmen:extid'], 'place.1', 'alters extid');
     assert.end();
 });
 
 tape('context.stackFeatures multitype, gap', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            region: { type:'region' },
+            place: { type:'place' },
+            poi: { type:'poi' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -122,7 +158,7 @@ tape('context.stackFeatures multitype, gap', function(assert) {
             'carmen:extid': 'poi.1'
         }
     }];
-    var stacked = context.stackFeatures(loaded.slice(0), {});
+    var stacked = context.stackFeatures(geocoderStub, loaded.slice(0), {});
     assert.deepEqual(stacked, [loaded[1],loaded[0]], '2 features stacked, 1 promoted');
     assert.deepEqual(stacked[0].properties['carmen:extid'], 'poi.1');
     assert.deepEqual(stacked[1].properties['carmen:extid'], 'place.1');
@@ -130,6 +166,13 @@ tape('context.stackFeatures multitype, gap', function(assert) {
 });
 
 tape('context.stackFeatures multitype, nogap', function(assert) {
+    var geocoderStub = {
+        indexes: {
+            region: { type:'region' },
+            place: { type:'place' },
+            poi: { type:'poi' }
+        }
+    };
     var loaded = [{
         type: 'Feature',
         properties: {
@@ -149,7 +192,7 @@ tape('context.stackFeatures multitype, nogap', function(assert) {
             'carmen:extid': 'poi.1'
         }
     }];
-    var stacked = context.stackFeatures(loaded.slice(0), {});
+    var stacked = context.stackFeatures(geocoderStub, loaded.slice(0), {});
     assert.deepEqual(stacked, [loaded[2],loaded[0]], '2 features stacked, 1 promoted');
     assert.deepEqual(stacked[0].properties['carmen:extid'], 'poi.1');
     assert.deepEqual(stacked[1].properties['carmen:extid'], 'place.1');

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -48,7 +48,47 @@ tape('index district', function(t) {
             ]]
         },
         properties: {
-            'carmen:text': 'district',
+            'carmen:text': 'district 1',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('index district', function(t) {
+    addFeature(conf.district, {
+        id:2,
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-40,-40],
+                [-40,40],
+                [40,40],
+                [40,-40],
+                [-40,-40]
+            ]]
+        },
+        properties: {
+            'carmen:text': 'district 2',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        id:2,
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-40,-40],
+                [-40,40],
+                [40,40],
+                [40,-40],
+                [-40,-40]
+            ]]
+        },
+        properties: {
+            'carmen:text': 'smallplace',
             'carmen:center': [0,0]
         }
     }, t.end);

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -1,0 +1,86 @@
+// Test multitype behavior when multitype spans across another existing index
+
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),
+    district: new mem({maxzoom:6}, function() {}),
+    place: new mem({maxzoom:6}, function() {}),
+};
+var c = new Carmen(conf);
+
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        id:1,
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-40,-40],
+                [-40,40],
+                [40,40],
+                [40,-40],
+                [-40,-40]
+            ]]
+        },
+        properties: {
+            'carmen:types': ['region', 'place'],
+            'carmen:text': 'capital',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('index district', function(t) {
+    addFeature(conf.district, {
+        id:1,
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-40,-40],
+                [-40,40],
+                [40,40],
+                [40,-40],
+                [-40,-40]
+            ]]
+        },
+        properties: {
+            'carmen:text': 'district',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('multitype reverse', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: capital');
+    assert.comment('note:   shifted reverse');
+    c.geocode('0,0', {}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'capital');
+        assert.deepEqual(res.features[0].id, 'place.1');
+        assert.deepEqual(res.features[0].context, undefined);
+        assert.end();
+    });
+});
+
+tape('multitype forward, q=capital', function(assert) {
+    assert.comment('query:  capital');
+    assert.comment('result: capital');
+    assert.comment('note:   shifted forward');
+    c.geocode('capital', {}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'capital');
+        assert.deepEqual(res.features[0].id, 'place.1');
+        assert.deepEqual(res.features[0].context, undefined);
+        assert.end();
+    });
+});
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+


### PR DESCRIPTION
Handle cornercase in multitype promotion where the feature to by promoted skips one or more levels of hierarchy. Example:

Layer hierarchy:

- region
- district
- place

Overlapping Feature A:

- text: `Icecream Citystate`
- types: region, place

Overlapping Feature B:

- text: `Strawberry District`
- types: district

On a reverse geocode, currently `Strawberry District` will beat `Icecream Citystate`. This is a bug, since `Icecream Citystate` _can_ be promoted to a more specific type than `Strawberry District`, but currently `carmen` is not handling this case.

This PR fixes this issue by considering the most specific promotion possible and comparing to other features' types, allowing more specific promotions to beat those features.