### PR TITLE
Robustify language fallback for unmatched suffix

### DIFF
--- a/lib/util/closest-lang.js
+++ b/lib/util/closest-lang.js
@@ -116,7 +116,8 @@ var closestLangLabel = function(target, candidates, prefix) {
     // first check if there's an exact match
     if (candidates[prefix + target]) return target;
 
-    var regexCandidates;
+    var regexCandidates, fb, fb_i, i;
+
     if (prefix) {
         var regexPrefix = new RegExp("^" + escapeRegExp(prefix));
         regexCandidates = Object.keys(candidates)
@@ -125,20 +126,20 @@ var closestLangLabel = function(target, candidates, prefix) {
     } else {
         regexCandidates = Object.keys(candidates);
     }
+
     // then check if there's a case-insensitive, but otherwise exact match
-    for (var i = 0; i < regexCandidates.length; i++) {
+    for (i = 0; i < regexCandidates.length; i++) {
         if (regexCandidates[i].toLowerCase() == target.toLowerCase()) return regexCandidates[i];
     }
 
     // then check if there's a fallback
-    var fb, fb_i;
     fb = fallback[target.toLowerCase()];
     if (fb) for (fb_i = 0; fb_i < fb.length; fb_i++)
         if (candidates[prefix + fb[fb_i]])
             return fb[fb_i];
 
     // then check if there's a language-only match
-    for (var i = 0; i < regexCandidates.length; i++) {
+    for (i = 0; i < regexCandidates.length; i++) {
         if (regexCandidates[i].toLowerCase() == target.split('_')[0].toLowerCase()) return regexCandidates[i];
     }
 

--- a/lib/util/closest-lang.js
+++ b/lib/util/closest-lang.js
@@ -131,8 +131,20 @@ var closestLangLabel = function(target, candidates, prefix) {
     }
 
     // then check if there's a fallback
-    var fb = fallback[target.toLowerCase()] || fallback[target.split('_')[0].toLowerCase()] || [];
-    for (var fb_i = 0; fb_i < fb.length; fb_i++)
+    var fb, fb_i;
+    fb = fallback[target.toLowerCase()];
+    if (fb) for (fb_i = 0; fb_i < fb.length; fb_i++)
+        if (candidates[prefix + fb[fb_i]])
+            return fb[fb_i];
+
+    // then check if there's a language-only match
+    for (var i = 0; i < regexCandidates.length; i++) {
+        if (regexCandidates[i].toLowerCase() == target.split('_')[0].toLowerCase()) return regexCandidates[i];
+    }
+
+    // then check if there's a language-only fallback
+    fb = fallback[target.split('_')[0].toLowerCase()];
+    if (fb) for (fb_i = 0; fb_i < fb.length; fb_i++)
         if (candidates[prefix + fb[fb_i]])
             return fb[fb_i];
 

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -1,0 +1,31 @@
+var tape = require('tape');
+var closestLangLabel = require('../lib/util/closest-lang');
+
+tape('closestLangLabel', function(assert) {
+    // English variations:
+    assert.equal(closestLangLabel('en', {
+        'en': 'English',
+        'es': 'Spanish'
+    }), 'English');
+    assert.equal(closestLangLabel('en-XX', {
+        'en': 'English',
+        'es': 'Spanish'
+    }), 'English');
+
+    // Chinese variations:
+    // Is -/_ and case insensitive but will revert to zh for otherwise unmatched
+    // country suffixes.
+    var zh = '西北部联邦管区';
+    var zht = '西北部聯邦管區';
+    assert.equal(closestLangLabel('zh', { zh: zh, zh_Hant: zht }), zh);
+    assert.equal(closestLangLabel('zh-xx', { zh: zh, zh_Hant: zht }), zh);
+    assert.equal(closestLangLabel('zh-hant', { zh: zh, zh_Hant: zht }), zht);
+    assert.equal(closestLangLabel('zh_hant', { zh: zh, zh_Hant: zht }), zht);
+    assert.equal(closestLangLabel('zh-Hant', { zh: zh, zh_Hant: zht }), zht);
+    assert.equal(closestLangLabel('zh_Hant', { zh: zh, zh_Hant: zht }), zht);
+    assert.equal(closestLangLabel('zh-HANT', { zh: zh, zh_Hant: zht }), zht);
+    assert.equal(closestLangLabel('zh_HANT', { zh: zh, zh_Hant: zht }), zht);
+
+    assert.end();
+});
+

--- a/test/geocode-unit.language-flag-bogus.test.js
+++ b/test/geocode-unit.language-flag-bogus.test.js
@@ -1,0 +1,83 @@
+//Ensure that results that have equal relev in phrasematch
+//are matched against the 0.5 relev bar instead of 0.75
+
+var tape = require('tape');
+var Carmen = require('..');
+var mem = require('../lib/api-mem');
+var context = require('../lib/context');
+var addFeature = require('../lib/util/addfeature');
+
+(function() {
+    var conf = {
+        country: new mem({ maxzoom:6, geocoder_name: 'country' }, function() {})
+    };
+    var c = new Carmen(conf);
+
+    tape('index country', function(t) {
+        var country = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:text_es': 'Estados Unidos',
+                'carmen:text_en': 'United States',
+                'carmen:text': 'United States'
+            },
+            id: 1,
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+                ]
+            },
+            bbox: [0,-5.615985819155337,5.625,0]
+        };
+        addFeature(conf.country, country, t.end);
+    });
+
+    tape('0,0 ?language=en', function(t) {
+        c.geocode('0,0', { language:'en', limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, 'United States');
+            t.equal(res.features[0].id, 'country.1');
+            t.equal(res.features[0].language, 'en', 'language set to "en"');
+            t.end();
+        });
+    });
+
+    tape('0,0 ?language=es', function(t) {
+        c.geocode('0,0', { language:'es', limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, 'Estados Unidos');
+            t.equal(res.features[0].id, 'country.1');
+            t.equal(res.features[0].language, 'es', 'language set to "es"');
+            t.end();
+        });
+    });
+
+    tape('0,0 ?language=es-XX', function(t) {
+        c.geocode('0,0', { language:'es-XX', limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, 'Estados Unidos');
+            t.equal(res.features[0].id, 'country.1');
+            t.equal(res.features[0].language, 'es', 'language set to "es"');
+            t.end();
+        });
+    });
+
+    tape('0,0 ?language=en-XX', function(t) {
+        c.geocode('0,0', { language:'en-XX', limit_verify:1 }, function(err, res) {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, 'United States');
+            t.equal(res.features[0].id, 'country.1');
+            t.equal(res.features[0].language, 'en', 'language set to "en"');
+            t.end();
+        });
+    });
+
+})();
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});


### PR DESCRIPTION
Currently in master, an unmatched language suffix triggers immediate fallback to the next available language, e.g.:

### Before

```
Available data:
  en, es, fr, de

Requested language:
  en-xx => (unmatched, triggers fallback to...) es
```

This PR adds additional handling to make sure that available "fuzzy" language code matches are respected (`zh-hant`, `zh_Hant`, `zh_HANT`, etc. all collapse to the same value) but unknown suffixes first search for a language-only value before proceeding to fallback languages.

### After

```
Available data:
  en, es, fr, de

Requested language:
  en-xx => (unmatched, first checks for language-only value) en
```