### PR TITLE
Trim whitespace from text values

### DIFF
--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -33,10 +33,10 @@ function toFeature(context, format, language, debug) {
     var _gettext = function(f) {
         if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
         if (!language)
-            return { text: f.properties['carmen:text'].split(',')[0] };
+            return { text: f.properties['carmen:text'].split(',')[0].trim() };
         var languageLabel = closestLang.closestLangLabel(language, f.properties, "carmen:text_");
         var languageText = languageLabel ? f.properties["carmen:text_" + languageLabel] : false;
-        var text = { text: (languageText||f.properties['carmen:text']||'').split(',')[0] };
+        var text = { text: (languageText||f.properties['carmen:text']||'').split(',')[0].trim() };
         if (languageText) text.language = languageLabel.replace('_', '-');
         return text;
     };

--- a/test/geocode-unit.text-trim.test.js
+++ b/test/geocode-unit.text-trim.test.js
@@ -1,0 +1,82 @@
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+(function() {
+    var conf = {
+        country: new mem({ maxzoom: 6 }, function() {}), 
+        region: new mem({ maxzoom: 6, geocoder_format: '{region._name}, {country._name}'}, function() {}),
+    };
+    var c = new Carmen(conf);
+    tape('index country', function(t) {
+        addFeature(conf.country, {
+            id:1,
+            properties: {
+                'carmen:text': '  Colombia\n',
+                'carmen:text_en': ' Colombia\n',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        }, t.end);
+    });
+    tape('index region', function(t) {
+        addFeature(conf.region, {
+            id:1,
+            properties: {
+                'carmen:text': ' Bogotá ',
+                'carmen:text_en': ' Bogota ',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        }, t.end);
+    });
+    tape('trims text (forward)', function(t) {
+        c.geocode('Bogota', { limit_verify: 1 }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Bogotá, Colombia');
+            t.equals(res.features[0].text, 'Bogotá');
+            t.equals(res.features[0].context[0].text, 'Colombia');
+            t.end();
+        });
+    });
+    tape('trims text (reverse)', function(t) {
+        c.geocode('0,0', { limit_verify: 1 }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Bogotá, Colombia');
+            t.equals(res.features[0].text, 'Bogotá');
+            t.equals(res.features[0].context[0].text, 'Colombia');
+            t.end();
+        });
+    });
+    tape('trims text (forward, ?language=en)', function(t) {
+        c.geocode('Bogota', { limit_verify: 1, language: 'en' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Bogota, Colombia');
+            t.equals(res.features[0].text, 'Bogota');
+            t.equals(res.features[0].context[0].text, 'Colombia');
+            t.end();
+        });
+    });
+    tape('trims text (reverse, ?language=en)', function(t) {
+        c.geocode('0,0', { limit_verify: 1, language: 'en' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Bogota, Colombia');
+            t.equals(res.features[0].text, 'Bogota');
+            t.equals(res.features[0].context[0].text, 'Colombia');
+            t.end();
+        });
+    });
+})();
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});

--- a/test/geocode-unit.text-trim.test.js
+++ b/test/geocode-unit.text-trim.test.js
@@ -16,6 +16,7 @@ var addFeature = require('../lib/util/addfeature');
             properties: {
                 'carmen:text': '  Colombia\n',
                 'carmen:text_en': ' Colombia\n',
+                'carmen:text_zh': ' 哥伦比亚\n',
                 'carmen:center': [0,0]
             },
             geometry: {
@@ -30,6 +31,7 @@ var addFeature = require('../lib/util/addfeature');
             properties: {
                 'carmen:text': ' Bogotá ',
                 'carmen:text_en': ' Bogota ',
+                'carmen:text_zh': ' 波哥大 ',
                 'carmen:center': [0,0]
             },
             geometry: {
@@ -71,6 +73,24 @@ var addFeature = require('../lib/util/addfeature');
             t.equals(res.features[0].place_name, 'Bogota, Colombia');
             t.equals(res.features[0].text, 'Bogota');
             t.equals(res.features[0].context[0].text, 'Colombia');
+            t.end();
+        });
+    });
+    tape('trims text (forward, ?language=zh)', function(t) {
+        c.geocode('Bogota', { limit_verify: 1, language: 'zh' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '波哥大, 哥伦比亚');
+            t.equals(res.features[0].text, '波哥大');
+            t.equals(res.features[0].context[0].text, '哥伦比亚');
+            t.end();
+        });
+    });
+    tape('trims text (reverse, ?language=en)', function(t) {
+        c.geocode('0,0', { limit_verify: 1, language: 'zh' }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '波哥大, 哥伦比亚');
+            t.equals(res.features[0].text, '波哥大');
+            t.equals(res.features[0].context[0].text, '哥伦比亚');
             t.end();
         });
     });


### PR DESCRIPTION
### Context

Data is messy. Carmen doesn't do a ton of automated cleanup but whitespace at the front/back of text values seems simple enough to do safely.

### Fixes/Adds

- Unit tests for preceding/trailing whitespace in source data
  - Assertions check that `text`, `place_name` and context feature `text` all get whitespace cleaned up
  - Checks ^^ for language-specific values
- Implements whitespace trimming

### Next Steps

- [x] Tests pass
- [ ] New bugfix release
