### PR TITLE
Move eslint to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",
-    "eslint": "^1.5.0",
     "@mapbox/geojsonhint": "^1.2.0",
     "@mapbox/locking": "^3.0.0",
     "mapnik": "~3.5.12",
@@ -37,6 +36,7 @@
     "xregexp": "3.0.0"
   },
   "devDependencies": {
+    "eslint": "^1.5.0",
     "retire": "0.4.x",
     "bytes": "^1.0.0",
     "tape": "4.6.0",


### PR DESCRIPTION
The `eslint` module is 26 MB once installed. It should be installed as a devDep to avoid increasing the size of  `npm --production` installs unnecessarily.
