### PR TITLE
Use carmen-cache@0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.14.0",
+    "carmen-cache": "0.14.1",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/test/fixtures/output.default.geojson
+++ b/test/fixtures/output.default.geojson
@@ -32,12 +32,12 @@
             },
             "context": [
                 {
-                    "id": "region.1",
-                    "text": "Ontario"
+                    "text": "Ontario",
+                    "id": "region.1"
                 },
                 {
-                    "id": "country.1",
-                    "text": "Canada"
+                    "text": "Canada",
+                    "id": "country.1"
                 }
             ]
         }

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -291,8 +291,8 @@
                     "relev": 1,
                     "covers": [
                         {
-                            "x": 24,
-                            "y": 24,
+                            "x": 25,
+                            "y": 25,
                             "relev": 1,
                             "id": 1,
                             "idx": 2,
@@ -328,12 +328,12 @@
             },
             "context": [
                 {
-                    "id": "region.1",
-                    "text": "Ontario"
+                    "text": "Ontario",
+                    "id": "region.1"
                 },
                 {
-                    "id": "country.1",
-                    "text": "Canada"
+                    "text": "Canada",
+                    "id": "country.1"
                 }
             ]
         }

--- a/test/fixtures/output.reverse-dev.geojson
+++ b/test/fixtures/output.reverse-dev.geojson
@@ -304,12 +304,12 @@
             },
             "context": [
                 {
-                    "id": "region.1",
-                    "text": "Ontario"
+                    "text": "Ontario",
+                    "id": "region.1"
                 },
                 {
-                    "id": "country.1",
-                    "text": "Canada"
+                    "text": "Canada",
+                    "id": "country.1"
                 }
             ]
         },
@@ -609,8 +609,8 @@
             },
             "context": [
                 {
-                    "id": "country.1",
-                    "text": "Canada"
+                    "text": "Canada",
+                    "id": "country.1"
                 }
             ]
         },


### PR DESCRIPTION
### Fixes/Adds

Updates to carmen-cache@0.14.1 which includes optimizations for the spatialmatch `coalesce()` step. Refs https://github.com/mapbox/carmen-cache/pull/65
