### PR TITLE
Iterate through options.stacks array - lowercasing & add tests

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -55,8 +55,12 @@ module.exports = function(geocoder, query, options, callback) {
         if (!Array.isArray(options.stacks) || options.stacks.length < 1)
             return callback(errcode('options.stacks must be an array with at least 1 stack', 'EINVALID'));
         var k = options.stacks.length;
-        while (k--) if (!geocoder.bystack[options.stacks[k]])
-            return callback(errcode('Stack "' + options.stacks[k] + '" is not a known stack. Must be one of: ' + Object.keys(geocoder.bystack).join(', '), 'EINVALID'));
+        while (k--) {
+            options.stacks[k] = options.stacks[k].toLowerCase();
+
+            if (!geocoder.bystack[options.stacks[k]])
+                return callback(errcode('Stack "' + options.stacks[k] + '" is not a known stack. Must be one of: ' + Object.keys(geocoder.bystack).join(', '), 'EINVALID'));
+        }
     }
 
     //Proximity is currently not enabled

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -66,6 +66,14 @@ var addFeature = require('../lib/util/addfeature');
         });
     });
 
+    tape('query filter - will be lowercased', function(t) {
+        c.geocode('0,0', { stacks: ['CA'] }, function(err, res) {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Canada');
+            t.end();
+        });
+    });
+
     tape('query filter', function(t) {
         c.geocode('United States', { stacks: ['ca'] }, function(err, res) {
             t.ifError(err);


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
Folks were using capital letters in the `options.stacks` array. Since the stacks filtering is typically used for country level filtering, these do not need to be base sensitive.

### Summary
- Add `toLowerCase` to all elements of `options.stacks` array.
- Add associated tests