### PR TITLE
carmen-cache@0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/45206571406ea4e392ce5c5762c41a26f483e5f9.tar.gz",
+    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/9308bf44cdcfa509de1535dbd0d0241a9336ba9b.tar.gz",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/9308bf44cdcfa509de1535dbd0d0241a9336ba9b.tar.gz",
+    "carmen-cache": "0.15.0",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.14.1",
+    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/motorin.tar.gz",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/motorin.tar.gz",
+    "carmen-cache": "https://github.com/mapbox/carmen-cache/archive/45206571406ea4e392ce5c5762c41a26f483e5f9.tar.gz",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -124,9 +124,9 @@ tape('west st, tonawanda, ny', function(t) {
         t.deepEqual(res.debug.spatialmatch.covers[0].id, 5);
         t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
         t.deepEqual(res.debug.spatialmatch.covers[0].relev, 0.3333333333333333);
-        t.deepEqual(res.debug.spatialmatch.covers[1].text, 'tonawanda');
+        t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
         t.deepEqual(res.debug.spatialmatch.covers[1].relev, 0.3333333333333333);
-        t.deepEqual(res.debug.spatialmatch.covers[2].text, 'ny');
+        t.deepEqual(res.debug.spatialmatch.covers[2].text, 'tonawanda');
         t.deepEqual(res.debug.spatialmatch.covers[2].relev, 0.3333333333333333);
         t.deepEqual(res.debug.spatialmatch_position, 0);
 


### PR DESCRIPTION
### Summary

Updates to carmen-cache@0.15.0 with a more robust `coalesce()`. See https://github.com/mapbox/carmen-cache/pull/66 for full details.

This will start carmen @ 17.8.x