### PR TITLE
Handle null language values

### DIFF
--- a/lib/util/closest-lang.js
+++ b/lib/util/closest-lang.js
@@ -121,10 +121,12 @@ var closestLangLabel = function(target, candidates, prefix) {
     if (prefix) {
         var regexPrefix = new RegExp("^" + escapeRegExp(prefix));
         regexCandidates = Object.keys(candidates)
+            .filter(function(item) { return !!candidates[item]; })
             .filter(function(item) { return regexPrefix.exec(item); })
             .map(function(item) { return item.replace(regexPrefix, ""); });
     } else {
-        regexCandidates = Object.keys(candidates);
+        regexCandidates = Object.keys(candidates)
+            .filter(function(item) { return !!candidates[item]; });
     }
 
     // then check if there's a case-insensitive, but otherwise exact match

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -39,3 +39,12 @@ tape('handle nulls', function(assert) {
     assert.end();
 });
 
+tape('handle nulls w/ prefix', function(assert) {
+
+    var zh = '帝力縣';
+    var zhtw = null;
+
+    assert.equal(closestLangLabel('zh_TW', { 'carmen:text_zh': zh, 'carmen:text_zh_TW': zhtw }, 'carmen:text_'), zh);
+
+    assert.end();
+});

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -29,3 +29,13 @@ tape('closestLangLabel', function(assert) {
     assert.end();
 });
 
+tape('handle nulls', function(assert) {
+
+    var zh = '帝力縣';
+    var zhtw = null;
+
+    assert.equal(closestLangLabel('zh-TW', { zh: zh, zh_TW: zhtw }), zh);
+
+    assert.end();
+});
+


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
The langauge fallback code didn't work if the language existed as a feature property with a null value.

### Fixes/Adds
<!-- with link to relevant ticket(s) or short description -->
Fixes #565 

### Summary
- [ ] Filter out null language values from possible language matches
- [ ] Test both code paths, with and without a `carmen:text_` prefix

