### PR TITLE
Multitype backfill + place_type

### DIFF
--- a/carmen-geojson.md
+++ b/carmen-geojson.md
@@ -11,6 +11,7 @@ Carmen returns results as a [GeoJSON](http://geojson.org/) `FeatureCollection`:
                 "id": "place.4201",
                 "text": "Austin",
                 "place_name": "Austin, Texas, United States",
+                "place_type": [ "place" ],
                 "bbox": [-97.9383829999999, 30.098659, -97.5614889999999, 30.516863],
                 "center": [-97.7559964, 30.3071816],
                 "geometry": {
@@ -51,6 +52,7 @@ key | description
 id | Id of the feature of the form `{index}.{id}` where index is the id/handle of the datasource that contributed the result.
 text | Text representing the feature (e.g. "Austin").
 place_name | Human-readable text representing the full result hierarchy (e.g. "Austin, Texas, United States").
+place_type | An array of index types that this feature may be returned as. Most features have only one type matching its id.
 bbox | Optional. Array bounding box of the form [minx,miny,maxx,maxy].
 address | Where applicable. Contains the housenumber for the returned feature
 center | Array of the form [lon,lat].

--- a/lib/context.js
+++ b/lib/context.js
@@ -96,12 +96,6 @@ function getSubtypeLookup(types) {
 function stackFeatures(geocoder, loaded, options) {
     if (!loaded.length) return [];
 
-    var typeOrder = Object.keys(geocoder.indexes).reduce(function(memo, id) {
-        var index = geocoder.indexes[id];
-        if (!memo[index.type]) memo[index.type] = memo._counter++;
-        return memo;
-    }, { _counter:0 });
-
     var context = [];
     var memo = {};
     var firstType = false;
@@ -118,11 +112,7 @@ function stackFeatures(geocoder, loaded, options) {
 
         for (var l = feature.properties['carmen:types'].length - 1; l >= 0; l--) {
             var type = feature.properties['carmen:types'][l];
-            var promoted = l > 0 && options.full;
             var conflict = feature.properties['carmen:conflict'] || type;
-
-            // Reconstruct extid based on selected type
-            feature.properties['carmen:extid'] = type + '.' + feature.properties['carmen:extid'].split('.').pop();
 
             // Disallow shifting a feature's type to occupy the maxtype
             // The maxtype is set on forward geocodes by the matched feature
@@ -147,28 +137,8 @@ function stackFeatures(geocoder, loaded, options) {
                 memo[type] = feature;
                 memo[conflict] = feature;
                 if (!firstType) firstType = type;
-                break;
-            } else if (memo[type] && promoted && typeOrder[firstType] <= typeOrder[type]) {
-                // Remove references to previously stacked features between
-                // the promoted feature's base type and promoted type. Example:
-                //
-                // Let type order be: region, district, place
-                //
-                // feature1: district
-                // feature2: region,place (multitype)
-                //
-                // Clear out any previously stacked features in region, district, place
-                // and block placement of any other features at those levels.
-                var baseType = feature.properties['carmen:types'][0];
-                for (var t in typeOrder) {
-                    if (typeOrder[t] >= typeOrder[baseType] &&
-                        typeOrder[t] <= typeOrder[type]) {
-                        memo[t] = false;
-                    }
-                }
-                // Stack new feature
-                memo[type] = feature;
-                memo[conflict] = feature;
+                // Reconstruct extid based on selected type
+                feature.properties['carmen:extid'] = type + '.' + feature.properties['carmen:extid'].split('.').pop();
                 break;
             } else if (memo[type] && loaded[i].properties['carmen:geomtype'] !== 3) {
                 // Don't replace a stacked feature that is closer to the queried point
@@ -182,6 +152,8 @@ function stackFeatures(geocoder, loaded, options) {
                 // Stack new feature
                 memo[type] = feature;
                 memo[conflict] = feature;
+                // Reconstruct extid based on selected type
+                feature.properties['carmen:extid'] = type + '.' + feature.properties['carmen:extid'].split('.').pop();
                 break;
             }
         }
@@ -194,7 +166,6 @@ function stackFeatures(geocoder, loaded, options) {
         if (context.indexOf(toAdd) !== -1) continue;
 
         // Strip out context-logic properties for now
-        delete toAdd.properties['carmen:types'];
         delete toAdd.properties['carmen:stack'];
         delete toAdd.properties['carmen:conflict'];
 

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -264,12 +264,11 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
         try {
             while (context.length) {
                 // filter context results by types if specified.
-                if (options.parentTypes) {
-                    var type = context[0].properties['carmen:extid'].split('.')[0];
-                    if (options.parentTypes.indexOf(type) === -1) {
-                        context.shift();
-                        continue;
-                    }
+                if (options.parentTypes && !context[0].properties['carmen:types'].filter(function(type) {
+                    return options.parentTypes.indexOf(type) > -1;
+                }).length) {
+                    context.shift();
+                    continue;
                 }
                 // use the display template appropriate to the language, if available
                 var index = geocoder.indexes[context[0].properties['carmen:index']];

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -105,6 +105,7 @@ function toFeature(context, format, language, debug) {
         type: 'Feature',
         text: featureText.text,
         place_name: place_name,
+        place_type: feat.properties['carmen:types'],
         relevance: context._relevance,
         properties: {}
     };

--- a/test/context.stackFeatures.test.js
+++ b/test/context.stackFeatures.test.js
@@ -177,13 +177,15 @@ tape('context.stackFeatures multitype, nogap', function(assert) {
         type: 'Feature',
         properties: {
             'carmen:types': ['region','place'],
-            'carmen:extid': 'region.1'
+            'carmen:extid': 'region.1',
+            'carmen:geomtype': 3
         }
     }, {
         type: 'Feature',
         properties: {
             'carmen:types': ['place'],
-            'carmen:extid': 'place.1'
+            'carmen:extid': 'place.1',
+            'carmen:geomtype': 3
         }
     }, {
         type: 'Feature',
@@ -193,9 +195,10 @@ tape('context.stackFeatures multitype, nogap', function(assert) {
         }
     }];
     var stacked = context.stackFeatures(geocoderStub, loaded.slice(0), {});
-    assert.deepEqual(stacked, [loaded[2],loaded[0]], '2 features stacked, 1 promoted');
+    assert.deepEqual(stacked, [loaded[2],loaded[1],loaded[0]], '3 features stacked');
     assert.deepEqual(stacked[0].properties['carmen:extid'], 'poi.1');
     assert.deepEqual(stacked[1].properties['carmen:extid'], 'place.1');
+    assert.deepEqual(stacked[2].properties['carmen:extid'], 'region.1');
     assert.end();
 });
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -625,9 +625,9 @@ test('Context eliminates correct properties', function(assert) {
             context(c, [0, 0], { full: false }, function(err, contexts) {
                 assert.ifError(err);
                 var contextObj = contexts.pop();
-                assert.deepEqual(Object.keys(contextObj.properties), ['carmen:extid', 'carmen:tmpid', 'carmen:index', 'carmen:vtquerydist', 'carmen:geomtype', 'carmen:center', 'carmen:text', 'idaho_potatoes', 'short_code'], 'found expected keys on country object');
+                assert.deepEqual(Object.keys(contextObj.properties), ['carmen:extid', 'carmen:tmpid', 'carmen:index', 'carmen:vtquerydist', 'carmen:geomtype', 'carmen:types', 'carmen:center', 'carmen:text', 'idaho_potatoes', 'short_code'], 'found expected keys on country object');
                 contextObj = contexts.pop();
-                assert.deepEqual(Object.keys(contextObj.properties), ['carmen:extid', 'carmen:tmpid', 'carmen:index', 'carmen:vtquerydist', 'carmen:geomtype', 'carmen:center', 'carmen:text'], 'found expected keys on region object');
+                assert.deepEqual(Object.keys(contextObj.properties), ['carmen:extid', 'carmen:tmpid', 'carmen:index', 'carmen:vtquerydist', 'carmen:geomtype', 'carmen:types', 'carmen:center', 'carmen:text'], 'found expected keys on region object');
                 assert.end();
             });
         });

--- a/test/fixtures/output.default.geojson
+++ b/test/fixtures/output.default.geojson
@@ -9,6 +9,9 @@
             "type": "Feature",
             "text": "Toronto",
             "place_name": "Toronto, Ontario, Canada",
+            "place_type": [
+                "place"
+            ],
             "relevance": 0.99,
             "properties": {
                 "wikidata": "Q172"

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -9,6 +9,9 @@
             "type": "Feature",
             "text": "Toronto",
             "place_name": "Toronto, Ontario, Canada",
+            "place_type": [
+                "place"
+            ],
             "relevance": 0.99,
             "properties": {
                 "wikidata": "Q172",

--- a/test/fixtures/output.reverse-dev.geojson
+++ b/test/fixtures/output.reverse-dev.geojson
@@ -10,6 +10,9 @@
             "type": "Feature",
             "text": "Toronto",
             "place_name": "Toronto, Ontario, Canada",
+            "place_type": [
+                "place"
+            ],
             "relevance": 1,
             "properties": {
                 "wikidata": "Q172",
@@ -279,6 +282,9 @@
                     "6/38/39",
                     "6/39/39"
                 ],
+                "carmen:types": [
+                    "place"
+                ],
                 "carmen:index": "place",
                 "carmen:extid": "place.1",
                 "carmen:tmpid": 67108865,
@@ -318,6 +324,9 @@
             "type": "Feature",
             "text": "Ontario",
             "place_name": "Ontario, Canada",
+            "place_type": [
+                "region"
+            ],
             "relevance": 1,
             "properties": {
                 "carmen:text": "Ontario",
@@ -584,6 +593,9 @@
                     "6/38/39",
                     "6/39/39"
                 ],
+                "carmen:types": [
+                    "region"
+                ],
                 "carmen:index": "region",
                 "carmen:extid": "region.1",
                 "carmen:tmpid": 33554433,
@@ -619,6 +631,9 @@
             "type": "Feature",
             "text": "Canada",
             "place_name": "Canada",
+            "place_type": [
+                "country"
+            ],
             "relevance": 1,
             "properties": {
                 "carmen:text": "Canada",
@@ -884,6 +899,9 @@
                     "6/37/39",
                     "6/38/39",
                     "6/39/39"
+                ],
+                "carmen:types": [
+                    "country"
                 ],
                 "carmen:index": "country",
                 "carmen:extid": "country.1",

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -220,7 +220,7 @@ var addFeature = require('../lib/util/addfeature');
     tape('Search for an address without a number (multiple layers)', function(t) {
         c.geocode('fake street', { limit_verify: 1 }, function(err, res) {
             t.ifError(err);
-            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":0.79,"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
+            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":0.79,"place_type": ['address'],"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
             t.end();
         });
     });

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -100,9 +100,12 @@ tape('multitype reverse', function(assert) {
     assert.comment('note:   shifted reverse');
     c.geocode('0,0', {}, function(err, res) {
         assert.ifError(err);
-        assert.deepEqual(res.features[0].place_name, 'capital');
-        assert.deepEqual(res.features[0].id, 'place.1');
-        assert.deepEqual(res.features[0].context, undefined);
+        assert.deepEqual(res.features[0].place_name, 'smallplace, district 1, capital');
+        assert.deepEqual(res.features[0].id, 'place.2');
+        assert.deepEqual(res.features[0].context, [
+            { id: 'district.1', text: 'district 1' },
+            { id: 'region.1', text: 'capital' }
+        ]);
         assert.end();
     });
 });

--- a/test/geocode-unit.multitype-reverse.test.js
+++ b/test/geocode-unit.multitype-reverse.test.js
@@ -1,0 +1,123 @@
+// Test multitype behavior
+
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),
+    place: new mem({maxzoom:6}, function() {}),
+    poi: new mem({maxzoom:6}, function() {})
+};
+var c = new Carmen(conf);
+
+tape('index region', function(t) {
+    addFeature(conf.region, {
+        id:1,
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-40,-40],
+                [-40,40],
+                [40,40],
+                [40,-40],
+                [-40,-40]
+            ]]
+        },
+        properties: {
+            'carmen:types': ['region', 'place'],
+            'carmen:text': 'caracas',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('index poi', function(t) {
+    addFeature(conf.poi, {
+        id:1,
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        },
+        properties: {
+            'carmen:text': 'cafe',
+            'carmen:center': [0,0]
+        }
+    }, t.end);
+});
+
+tape('multitype reverse', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: cafe, caracas');
+    assert.comment('note:   returns full context, no shifts');
+    c.geocode('0,0', {}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'cafe, caracas');
+        assert.deepEqual(res.features[0].id, 'poi.1');
+        assert.deepEqual(res.features[0].context, [{
+            id: 'place.1',
+            text: 'caracas'
+        }]);
+        assert.end();
+    });
+});
+
+tape('multitype reverse, types=poi', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: cafe, caracas');
+    assert.comment('note:   returns full context, no shifts');
+    c.geocode('0,0', {types:['poi']}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'cafe, caracas');
+        assert.deepEqual(res.features[0].id, 'poi.1');
+        assert.deepEqual(res.features[0].context, [{
+            id: 'place.1',
+            text: 'caracas'
+        }]);
+        assert.end();
+    });
+});
+
+tape('multitype reverse, types=place', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: caracas');
+    assert.comment('note:   returns caracas, shift');
+    c.geocode('0,0', {types:['place']}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].id, 'place.1');
+        assert.end();
+    });
+});
+
+tape('multitype reverse, types=region', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: caracas');
+    assert.comment('note:   returns caracas, shift');
+    c.geocode('0,0', {types:['region']}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].id, 'region.1');
+        assert.end();
+    });
+});
+
+tape('multitype reverse, types=place,region', function(assert) {
+    assert.comment('query:  0,0');
+    assert.comment('result: caracas');
+    assert.comment('note:   returns caracas, shift');
+    c.geocode('0,0', {types:['place','region']}, function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].id, 'place.1');
+        assert.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/geocode-unit.multitype.test.js
+++ b/test/geocode-unit.multitype.test.js
@@ -108,11 +108,11 @@ tape('multitype reverse, types=poi', function(assert) {
 
 tape('multitype reverse, types=place', function(assert) {
     assert.comment('query:  0,0');
-    assert.comment('result: caracas');
-    assert.comment('note:   returns caracas with shift');
+    assert.comment('result: liberatador, caracas');
+    assert.comment('note:   returns libertador, caracas, no shift');
     c.geocode('0,0', {types:['place']}, function(err, res) {
         assert.ifError(err);
-        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].place_name, 'libertador, caracas');
         assert.deepEqual(res.features[0].id, 'place.1');
         assert.end();
     });
@@ -132,11 +132,11 @@ tape('multitype reverse, types=region', function(assert) {
 
 tape('multitype reverse, types=place,region', function(assert) {
     assert.comment('query:  0,0');
-    assert.comment('result: caracas');
-    assert.comment('note:   returns caracas with');
+    assert.comment('result: libertador, caracas');
+    assert.comment('note:   returns libertador, caracas, no shift');
     c.geocode('0,0', {types:['place','region']}, function(err, res) {
         assert.ifError(err);
-        assert.deepEqual(res.features[0].place_name, 'caracas');
+        assert.deepEqual(res.features[0].place_name, 'libertador, caracas');
         assert.deepEqual(res.features[0].id, 'place.1');
         assert.end();
     });

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -6,6 +6,7 @@ test('ops#toFeature', function(t) {
         properties: {
             "carmen:center": [-99.392855, 63.004759],
             "carmen:text": "Canada, CA",
+            "carmen:types": ["country"],
             "carmen:extid": "country.1833980151",
             "short_code": "ca"
         }
@@ -16,6 +17,7 @@ test('ops#toFeature', function(t) {
         type: 'Feature',
         text: 'Canada',
         place_name: 'Canada',
+        place_type: ['country'],
         relevance: 1,
         center: [ -99.392855, 63.004759 ],
         properties: { short_code: "ca" },
@@ -28,11 +30,12 @@ test('ops#toFeature', function(t) {
             "carmen:center": [-99.392855,63.004759],
             "carmen:address": 9,
             "carmen:text": "Fake Street",
+            "carmen:types": ["address"],
             "carmen:extid": "address.1833980151"
         }
     }];
     feat._relevance = 1;
-    t.deepEqual(ops.toFeature(feat, "{address._name} {address._number}"), { address: 9, center: [ -99.392855, 63.004759 ], geometry: { coordinates: [ -99.392855, 63.004759 ], type: 'Point' }, id: 'address.1833980151', place_name: 'Fake Street 9', properties: {}, relevance: 1, text: 'Fake Street', type: 'Feature' });
+    t.deepEqual(ops.toFeature(feat, "{address._name} {address._number}"), { address: 9, center: [ -99.392855, 63.004759 ], geometry: { coordinates: [ -99.392855, 63.004759 ], type: 'Point' }, id: 'address.1833980151', place_name: 'Fake Street 9', place_type: ['address'], properties: {}, relevance: 1, text: 'Fake Street', type: 'Feature' });
 
     t.deepEqual(ops.toFeature([{
         properties: {
@@ -172,6 +175,7 @@ test('ops#toFeature', function(t) {
             // Internal score property
             'carmen:score': 1,
             // Public carmen properties
+            'carmen:types': ["place"],
             "carmen:center": [0, 0],
             "carmen:extid": "place.1"
         }
@@ -182,6 +186,7 @@ test('ops#toFeature', function(t) {
         type: 'Feature',
         text: 'Торонто',
         place_name: 'Торонто',
+        place_type: ['place'],
         relevance: 1,
         language: 'ru',
         center: [ 0, 0 ],
@@ -206,6 +211,7 @@ test('ops#toFeature', function(t) {
             // Internal score property
             'carmen:score': 1,
             // Public carmen properties
+            "carmen:types": ["place"],
             "carmen:center": [0, 0],
             "carmen:extid": "place.1"
         }
@@ -216,6 +222,7 @@ test('ops#toFeature', function(t) {
         type: 'Feature',
         text: 'Торонто',
         place_name: 'Торонто',
+        place_type: ['place'],
         relevance: 0.5,
         language: 'ru',
         center: [ 0, 0 ],


### PR DESCRIPTION
This softens the behavior of the previous PR adding multitype behavior (https://github.com/mapbox/carmen/pull/529) and adds the `place_type` key to provide better visibility into multitype features in response data.

- If a multitype feature and other normal features may be returned for the same type level for a given reverse geocode, the normal features will take precedence. This changes the previous behavior where a multitype feature would override other features at the promoted level.
- Include new `place_type` property for enumerating all the possible types of a returned feature. Usually this is an array of just one element -- the type of the feature.