### PR TITLE
Fix indexer behavior for indexes where the max score is specified as 0

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -46,7 +46,7 @@ function indexdocs(docs, source, options, callback) {
     if (TIMER) console.time('update:freq');
     var freq;
     try {
-        freq = generateFrequency(docs, source.token_replacer, options.tokens, source.maxscore);
+        freq = generateFrequency(docs, source.token_replacer, options.tokens, parseInt(source.maxscore));
     } catch (err) {
         return callback(err);
     }

--- a/test/geocode-unit.zeroscore.js
+++ b/test/geocode-unit.zeroscore.js
@@ -1,0 +1,41 @@
+// Tests Windsor CT (city) vs Windsor Ct (street name)
+// Windsor CT should win via stacky bonus.
+
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    // make maxscore a string to simulate how carmen will encounter it after pulling it from the meta table in an mbtiles file
+    place: new mem({geocoder_name: 'place', maxzoom: 6, minscore: '0', maxscore: '0', geocoder_stack: 'us'}, function() {}),
+};
+
+var c = new Carmen(conf);
+
+tape('index place', function(t) {
+    addFeature(conf.place, {
+        id:1,
+        properties: {
+            'carmen:score':0,
+            'carmen:text':'Chicago',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0]
+        }
+    }, t.end);
+});
+
+// this should have been indexed properly despite having a zero score in an index with zero maxscore
+tape('geocode against an all-zero-score index', function(t) {
+    c.geocode('chicago', { limit_verify: 1 }, function(err, res) {
+        t.ifError(err);
+        t.deepEqual(res.features.length, 1, '1 result');
+        t.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
When using carmen backed by mbtiles, with a configured `maxscore` property with a value of 0, a subtle indexing bug can occur whereby the `maxscore` property is read out of the `.mbtiles` file as a string instead of a number, and is consequently interpreted as truthy rather than falsy, causing some intended protections against divide-by-zero to fail.


### Fixes/Adds
This PR ensures that source.maxscore is cast to an integer before using it in calculations, and adds a test to make sure this behavior continues to work.
