### PR TITLE
@mapbox/carmen-cache@0.16.2

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -13,6 +13,8 @@ module.exports = function analyze(source, callback) {
     for (var i = 0; i < 7; i++) stats.byScore[i] = 0;
     for (var j = 0.4; j <= 1; j = j + 0.2) stats.byRelev[j.toFixed(1)] = 0;
 
+    source._geocoder.unloadall('grid');
+
     getStats(Math.pow(16,4), callback);
 
     function getStats(i, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,16 +215,6 @@ function store(source, callback) {
     });
     q.awaitAll(function(err) {
         if (err) return callback(err);
-
-        // @TODO: robustify this behavior in carmen-cache.
-        // Currently unloadall + loadall after storing does not result in the
-        // same state prior to storing (though it should).
-        // Only affects geocoding unit tests which index, store, and then attempt
-        // to use the index live immediately atm.
-
-        // source._geocoder.unloadall('freq');
-        // source._geocoder.unloadall('grid');
-        // source._geocoder.unloadall('stat');
         callback();
     });
 }

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -1,6 +1,6 @@
 var proximity = require('./util/proximity.js');
 var queue = require('d3-queue').queue;
-var coalesce = require('carmen-cache').Cache.coalesce;
+var coalesce = require('@mapbox/carmen-cache').Cache.coalesce;
 var uniq = require('./util/uniq');
 var bbox = require('./util/bbox.js');
 

--- a/lib/util/cxxcache.js
+++ b/lib/util/cxxcache.js
@@ -1,4 +1,4 @@
-var Cache = require('carmen-cache').Cache;
+var Cache = require('@mapbox/carmen-cache').Cache;
 var queue = require('d3-queue').queue;
 var uniq = require('./uniq');
 var types = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/archive/cd20c47ed2bd1ecc8081b22e14ac85e8ea22c47a.tar.gz",
+    "@mapbox/carmen-cache": "0.16.2",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "carmen-cache": "0.15.0",
+    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/archive/cd20c47ed2bd1ecc8081b22e14ac85e8ea22c47a.tar.gz",
     "d3-queue": "2.0.x",
     "dawg-cache": "0.3.1",
     "err-code": "1.1.1",


### PR DESCRIPTION
### Context

A slew of fixes + performance improvements from @springmeyer upstream in `carmen-cache`.

### Next Steps

Since this changes our indexer (makes sense given the perf improvements that shards must be unloaded before being loaded again to be fresh) I'd like to do some IRL indexing testing to make sure all of this is :ok_hand:.

- [x] Tests pass
- [x] IRL indexing test
- [x] IRL runtime tests review
- [x] carmen-cache release + carmen release
