### PR TITLE
Fix stats output for scripts/carmen.js

### DIFF
--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -94,6 +94,7 @@ carmen.geocode(argv.query, {
     'indexes': true
 }, function(err, data) {
     if (err) throw err;
+    load = +new Date() - load;
     if (data.features.length && !argv.geojson) {
         console.log('Tokens');
         console.log('------');

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -124,6 +124,16 @@ tape('bin/carmen query', function(t) {
     });
 });
 
+tape('bin/carmen query w/ stats', function(t) {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --stats', function(err, stdout, stderr) {
+        t.ifError(err);
+        var re = new RegExp(/warmup\:\s+(\d+)ms/)
+        var match = re.exec(stdout);
+        t.ok(match[1] < 3600000, "ensure load stat is an elapsed delta of less than an hour");
+        t.end();
+    });
+});
+
 
 //Index was not indexed witht the brazil=canada token so this should produce Canada as a result
 tape('bin/carmen query w/ global tokens', function(t) {

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -127,9 +127,23 @@ tape('bin/carmen query', function(t) {
 tape('bin/carmen query w/ stats', function(t) {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --stats', function(err, stdout, stderr) {
         t.ifError(err);
-        var re = new RegExp(/warmup\:\s+(\d+)ms/)
-        var match = re.exec(stdout);
-        t.ok(match[1] < 3600000, "ensure load stat is an elapsed delta of less than an hour");
+        var warmup_re = new RegExp(/warmup\:\s+(\d+)ms/)
+        var phrasematch_re = new RegExp(/phrasematch\:\s+(\d+)ms/)
+        var spatialmatch_re = new RegExp(/spatialmatch\:\s+(\d+)ms/)
+        var verifymatch_re = new RegExp(/verifymatch\:\s+(\d+)ms/)
+        var totaltime_re = new RegExp(/totaltime\:\s+(\d+)ms/)
+
+        var warmup_match = warmup_re.exec(stdout);
+        var phrasematch_match = phrasematch_re.exec(stdout);
+        var spatialmatch_match = spatialmatch_re.exec(stdout);
+        var verifymatch_match = verifymatch_re.exec(stdout);
+        var totaltime_match = totaltime_re.exec(stdout);
+
+        t.ok(warmup_match[1] < 3600000, "ensure load stat is an elapsed delta of less than an hour");
+        t.ok(phrasematch_match[1] < 3600000, "ensure phrasematch stat is an elapsed delta of less than an hour");
+        t.ok(spatialmatch_match[1] < 3600000, "ensure spatialmatch stat is an elapsed delta of less than an hour");
+        t.ok(verifymatch_match[1] < 3600000, "ensure verifymatch stat is an elapsed delta of less than an hour");
+        t.ok(totaltime_match[1] < 3600000, "ensure totaltime stat is an elapsed delta of less than an hour");
         t.end();
     });
 });


### PR DESCRIPTION
### Context

The `--stats` flag reports the timing of each major operation: `warmup`, `phrasematch`, `spatialmatch`, and `verifymatch`.

### Fixes/Adds

The `warmup` value was broken: It was reporting a date rather than a delta. Looks like this went missing in https://github.com/mapbox/carmen/commit/9d78a3115d01be874bc6ed1b77c2976c12ae67b3

### Summary

This fixes the `warmup` value by ensuring it represents elapsed time.

### Next Steps

Do we need tests of the command line tools like `scripts/carmen.js`?