### PR TITLE
Use Number for hard error on non-numeric input

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -97,8 +97,8 @@ function tokenize(query, lonlat) {
     if (lonlat) {
         var numeric = query.split(',');
         if (numeric.length === 2) {
-            numeric[0] = parseFloat(numeric[0].trim());
-            numeric[1] = parseFloat(numeric[1].trim());
+            numeric[0] = Number(numeric[0].trim());
+            numeric[1] = Number(numeric[1].trim());
             if (!isNaN(numeric[0]) && !isNaN(numeric[1])) return numeric;
         }
     }

--- a/test/termops.tokenize.test.js
+++ b/test/termops.tokenize.test.js
@@ -35,6 +35,13 @@ test('tokenizes lonlat', function(assert) {
     // Housenumber like pairs are left alone
     assert.deepEqual(termops.tokenize('1400 15', true), ['1400','15']);
     assert.deepEqual(termops.tokenize('14th 15th', true), ['14th','15th']);
+
+    // ParseFloat can think a string is a reverse query as `9 Street` is a valid Float - enforce numeric input
+    assert.deepEqual(termops.tokenize('9 rue Alphonse Penaud Paris, 75020 France', true), [ '9', 'rue', 'alphonse', 'penaud', 'paris', '75020', 'france' ]);
+    assert.deepEqual(termops.tokenize('9 a, 10 b', true), [ '9', 'a', '10', 'b' ]);
+    assert.deepEqual(termops.tokenize('9 a, 10', true), [ '9', 'a', '10' ]);
+    assert.deepEqual(termops.tokenize('9,10 b', true), [ '9', '10', 'b']);
+
     assert.end();
 });
 test('edge cases - empty string', function(assert) {


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->

If a string loosely fit the format of a reverse query `Number , Number` it could be interpreted as such even when actually being a forward query.

This was due to `parseFloat` ignore non-numeric characters and just grabbing any number it sees.

Ref: https://github.com/DenisCarriere/geocoder-geojson/issues/8#issue-201756354
