### PR TITLE
Optimize phrasematch

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -1,6 +1,7 @@
 var termops = require('./util/termops');
 var token = require('./util/token');
 var bb = require('./util/bbox');
+var dawgcache = require('./util/dawg');
 
 /**
 * phrasematch
@@ -35,6 +36,16 @@ module.exports = function phrasematch(source, query, options, callback) {
     }
 
     subqueries = termops.uniqPermutations(subqueries);
+    var dawg;
+    // if writeCache, dump data once here to avoid
+    // repeated penalty of dump per subquery
+    if (source._dictcache.dump) {
+        // create a ReadCache once
+        dawg = new dawgcache(source._dictcache.dump());
+    } else {
+        // Already is a ReadCache
+        dawg = source._dictcache;
+    }
 
     loadall(getter, 'freq', [1], function(err) {
         if (err) return callback(err);
@@ -51,10 +62,10 @@ module.exports = function phrasematch(source, query, options, callback) {
             var subquery = subqueries[l];
             var text = termops.encodableText(subquery);
             if (text) {
-                if (!source._dictcache.hasPhrase(text, subquery.ender)) continue;
+                if (!dawg.hasPhrase(text, subquery.ender)) continue;
                 // Augment permutations with matched grids,
                 // index position and weight relative to input query.
-                var phrase = termops.encodePhrase(subquery, options.autocomplete ? subquery.ender : false);
+                var phrase = termops.encodePhraseText(text, options.autocomplete ? subquery.ender : false);
                 var weight = subquery.length / tokenized.length;
                 phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder, source.zoom));
             }

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -16,6 +16,7 @@ module.exports.getHousenumRangeV3 = getHousenumRangeV3;
 module.exports.encodeTerm = encodeTerm;
 module.exports.encodableText = encodableText;
 module.exports.encodePhrase = encodePhrase;
+module.exports.encodePhraseText = encodePhraseText;
 module.exports.tokenize = tokenize;
 module.exports.feature = feature;
 
@@ -79,6 +80,12 @@ function encodePhrase(tokens, degen) {
     var encoded = parseInt(murmur.hash128(text).hex().substr(-13), 16);
     return encoded - (encoded % 2) + (degen ? 0 : 1);
 };
+
+function encodePhraseText(text, degen) {
+    var encoded = parseInt(murmur.hash128(text).hex().substr(-13), 16);
+    return encoded - (encoded % 2) + (degen ? 0 : 1);
+};
+
 
 // Generate a hash id from a feature ID. Fits within a 20-bit integer space
 // to be encoded cleanly into zxy values (see lib/util/grid).
@@ -442,17 +449,19 @@ function getIndexablePhrases(tokens, freq) {
 
     for (var i = 0; i < perms.length; i++) {
         // Indexing optimization.
-        if (perms[i].relev < 0.8) break;
+        var relev = perms[i].relev;
+        if (relev < 0.8) break;
 
         var text = perms[i].join(' ');
 
         // Encode canonical phrase.
         var toEncode = [];
+        var etext = encodableText(text);
         toEncode.push({
             degen: false,
-            relev: perms[i].relev,
-            text: encodableText(perms[i].join(' ')),
-            phrase: encodePhrase(perms[i].join(' '), false)
+            relev: relev,
+            text: etext,
+            phrase: encodePhraseText(etext, false)
         });
 
         // Encode degens of phrase.
@@ -460,19 +469,22 @@ function getIndexablePhrases(tokens, freq) {
         if (tokens.indexDegens) {
             var degens = getPhraseDegens(text);
             l = degens.length;
-            while (l--) toEncode.push({
-                degen: true,
-                relev: perms[i].relev,
-                text: encodableText(degens[l]),
-                phrase: encodePhrase(degens[l], true)
-            });
+            while (l--) {
+                var egtext = encodableText(degens[l]);
+                toEncode.push({
+                    degen: true,
+                    relev: relev,
+                    text: egtext,
+                    phrase: encodePhraseText(egtext, true)
+                });
+            }
         // Enclude degen=true version of the canonical phrase.
         } else {
             toEncode.push({
                 degen: true,
-                relev: perms[i].relev,
-                text: encodableText(perms[i].join(' ')),
-                phrase: encodePhrase(perms[i].join(' '), true)
+                relev: relev,
+                text: etext,
+                phrase: encodePhraseText(etext, true)
             });
         }
 


### PR DESCRIPTION
### Context

I profiled the [setup routine](https://github.com/mapbox/carmen/blob/master/bench/geocode.js#L13-L50) and [geocode routine](https://github.com/mapbox/carmen/blob/master/bench/geocode.js#L64-L69) of `bench/geocode.js`.

With the `setup` routine I noticed:

  - The main event loop was quite busy (98% of time sampled it was busy in sync code)
  - The threadpool was idle
  - The primary bottlenecks in the main event loop were: 1) garbage collection, 2) `unidecode`, and 3) v8 string and array manipulation
  - The main bottleneck within `unidecode` was string allocation, deallocation, and `std::string::append`. 

With the `geocode` routine I noticed:

  - The main event loop was fairly busy (77% busy, 23% idle)
  - The threadpool was idle (with the exception of < 1 % in `carmen::cache::coalesce`)
  - The majority of the 77% of the main event loop was bottlenecked in JSDawg usage:
      - 4 % in deallocating `shared_ptr`
      - the remainder in `JSDawg::Insert` (which itself is slow due to the `std::to_string` usage)

Next I worked to optimize both jsdawg (https://github.com/mapbox/dawg-cache/pull/10) and unidecode (https://github.com/mapbox/node-unidecode-cxx/pull/4). These PRs noticeably speed up the benchmarks in those two repos by reducing memory allocations.

However I noticed they did not make a big impact on the overall performance of carmen's `bench/geocode.js`. So next I took a look at how jsdawg and unidecode were being used in carmen. 

I noticed that `unidecode` and `JSDawg::insert` were being called more times than needed. In many places strings are parsed twice with `unidecode` and the results are not shared. And in several cases `WriteCache.hasPhrase` is called (which is noted to be slow: https://github.com/mapbox/carmen/blob/33e8aa008c3140f7a171eea9c1baa32e154d5afb/lib/util/dawg.js#L58-L59). This `WriteCache.hasPhrase` usage explains why `JSDawg::Insert` was blocking the main event loop in the `geocode` case because it internally [dumps and reloads the entire cache](https://github.com/mapbox/carmen/blob/33e8aa008c3140f7a171eea9c1baa32e154d5afb/lib/util/dawg.js#L19-L30).

### Fixes/Adds

  - Avoids calling `unidecode` twice per subquery
  - Avoids dumping and recreating a dawg `ReadCache` per subquery
  - Speeds up `getIndexablePhrases` by avoided extra `unidecode` calls
  - Speeds up `bench/geocode.js` by `~ 6x`

### Next Steps

 - [ ]  Should we remove [this slow WriteCache functions](https://github.com/mapbox/carmen/blob/33e8aa008c3140f7a171eea9c1baa32e154d5afb/lib/util/dawg.js#L57-L66) to avoid them being called in performance critical code?
 - [ ] Code review of my other PRs: https://github.com/mapbox/node-unidecode-cxx/pull/4 and https://github.com/mapbox/dawg-cache/pull/10
