### PR TITLE
[WIP] CJK segmentation 

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -94,6 +94,15 @@ function feature(id) {
 };
 
 /**
+ * segmentWords - segment CJK strings using significant n-grams
+ *
+ * @param  {String} string  A string to tokenize
+ */
+function segmentWords(string) {
+    return string.split('')
+};
+
+/**
  * tokenize - Normalize input text into lowercase, asciified tokens.
  *
  * @param  {String} query  A string to tokenize
@@ -142,7 +151,7 @@ function tokenize(query, lonlat) {
         if (pretokens[i].length && unidecode(pretokens[i]).length) {
             var charCode = pretokens[i][0].charCodeAt();
             if (charCode >= 19968 && charCode <= 40959) {
-                tokens = tokens.concat(pretokens[i].split(''));
+                tokens = tokens.concat(segmentWords(pretokens[i]));
             } else {
                 tokens.push(pretokens[i]);
             }

--- a/test/termops.segmentWords.test.js
+++ b/test/termops.segmentWords.test.js
@@ -1,0 +1,21 @@
+var termops = require('../lib/util/termops');
+var test = require('tape');
+
+test('tokenizes Japanese strings containing CJK characters', function(assert) {
+    assert.deepEqual(termops.segmentWords('岐阜県中津川市馬籠'), ['岐阜県', '中津', '川市', '馬', '籠']);
+    assert.end();
+});
+
+test('edge cases - empty string', function(assert) {
+    assert.deepEqual(termops.segmentWords(''), []);
+    assert.end();
+});
+
+test('tokenize Japanese strings with numeric component', function(assert) {
+    assert.deepEqual(termops.segmentWords('岐阜県中津川市馬籠4571-1'),  ['岐阜県', '中津', '川市', '馬', '籠', '4571', '-', '1'], 'dashed number at end');
+    assert.deepEqual(termops.segmentWords('岐阜県中津川市4571-1馬籠'),  ['岐阜県', '中津', '川市', '4571','-','1','馬','籠'], 'dashed number in middle');
+    assert.deepEqual(termops.segmentWords('岐阜県中津川市4571馬籠'),    ['岐阜県', '中津', '川市', '4571', '馬','籠'], 'number in middle');
+    assert.deepEqual(termops.segmentWords('岐阜県中津川市4571馬籠123'), ['岐阜県', '中津', '川市', '4571', '馬','籠','123'], 'numbers in middle and at end');
+    assert.deepEqual(termops.segmentWords('岐阜県123中津川市4571馬籠'), ['123中津川市4571馬籠'], 'does not split strings that begin with numbers');
+    assert.end();
+});


### PR DESCRIPTION
### Context
This is meant to add smarter word-segmentation to CJK strings, avoiding the naive per-character tokenization. see more discussion on mapbox/api-geocoder#1351

### Fixes/Adds
<!-- with link to relevant ticket(s) or short description -->


### Summary
- [ ] brief list of changes


### Next Steps
 - [ ] add resources for significant ngrams
 - [ ] implement greedy LTR segmentation (with backoff)
