### PR TITLE
Truncate subquery stacks to top 4 elements

### DIFF
--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -20,7 +20,18 @@ function spatialmatch(query, phrasematchResults, options, callback) {
     stacks = stacks.slice(0,30);
     // Rebalance weights, relevs of stacks here.
     for (var i = 0; i < stacks.length; i++) {
-        stacks[i] = rebalance(query, stacks[i]);
+        // Some stacks have many many elements leading to a performance
+        // problem @ coalesce. This limits a stack to the top 4 most specific
+        // subquery matches.
+        //
+        // Example/explanation:
+        //
+        // - 'Pizza Shop', '100 Main St', 'Springfield', 'Massachusetts', 'United States', 'North America', 'Planet Earth'
+        //
+        // Is more context than we need and we'll do just fine finding the place using:
+        //
+        // - 'Pizza Shop', '100 Main St', 'Springfield', 'Massachusetts'
+        stacks[i] = rebalance(query, stacks[i].slice(-4));
     }
 
     var waste = [];

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -1,6 +1,6 @@
+var Cache = require('@mapbox/carmen-cache').Cache;
 var proximity = require('./util/proximity.js');
 var queue = require('d3-queue').queue;
-var coalesce = require('@mapbox/carmen-cache').Cache.coalesce;
 var uniq = require('./util/uniq');
 var bbox = require('./util/bbox.js');
 var termops = require('./util/termops');
@@ -90,7 +90,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
             coalesceOpts.bboxzxy = bbox.insideTile(options.bbox, stack[0].zoom);
         }
 
-        coalesce(stack, coalesceOpts, function(err, cacheSpatialmatches) {
+        Cache.coalesce(stack, coalesceOpts, function(err, cacheSpatialmatches) {
             // Include text for debugging with each matched feature.
             var byIdx = stackByIdx(stack);
 

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -112,7 +112,7 @@ function toFeature(context, format, language, languageMode, debug) {
         text: featureText.text,
         place_name: place_name,
         place_type: feat.properties['carmen:types'],
-        relevance: context._relevance,
+        relevance: Math.min(1, Math.max(0, context._relevance)),
         properties: {}
     };
 

--- a/test/geocode-unit.spatialmatch-stack-truncate.test.js
+++ b/test/geocode-unit.spatialmatch-stack-truncate.test.js
@@ -7,6 +7,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
+var Cache = require('@mapbox/carmen-cache').Cache;
+var origCoalesce = Cache.coalesce;
 
 var conf = {
     a: new mem({maxzoom: 6}, function() {}),
@@ -17,6 +19,14 @@ var conf = {
     f: new mem({maxzoom: 6}, function() {}),
 };
 var c = new Carmen(conf);
+
+tape('mock/spy', function(assert) {
+    Cache.coalesce = function(stack, options, callback) {
+        assert.deepEqual(stack.length, 4, 'stack length == 4');
+        origCoalesce.call(Cache, stack, options, callback);
+    };
+    assert.end();
+});
 
 tape('index a', function(t) {
     addFeature(conf.a, {
@@ -97,6 +107,11 @@ tape('test spatialmatch stack truncate (desc)', function(t) {
         t.equals(res.features[0].id, 'f.1');
         t.end();
     });
+});
+
+tape('unmock/spy', function(assert) {
+    Cache.coalesce = origCoalesce;
+    assert.end();
 });
 
 tape('teardown', function(assert) {

--- a/test/geocode-unit.spatialmatch-stack-truncate.test.js
+++ b/test/geocode-unit.spatialmatch-stack-truncate.test.js
@@ -1,0 +1,106 @@
+// Suppose we are from an alien planet with 6 administrative levels, a-f.
+// Suppose we process a query for "a b c d e f"
+// Tests that stack gets truncated to 4 most specific elements.
+
+var tape = require('tape');
+var Carmen = require('..');
+var context = require('../lib/context');
+var mem = require('../lib/api-mem');
+var addFeature = require('../lib/util/addfeature');
+
+var conf = {
+    a: new mem({maxzoom: 6}, function() {}),
+    b: new mem({maxzoom: 6}, function() {}),
+    c: new mem({maxzoom: 6}, function() {}),
+    d: new mem({maxzoom: 6}, function() {}),
+    e: new mem({maxzoom: 6}, function() {}),
+    f: new mem({maxzoom: 6}, function() {}),
+};
+var c = new Carmen(conf);
+
+tape('index a', function(t) {
+    addFeature(conf.a, {
+        id:1,
+        properties: {
+            'carmen:text':'a',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+tape('index b', function(t) {
+    addFeature(conf.b, {
+        id:1,
+        properties: {
+            'carmen:text':'b',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+tape('index c', function(t) {
+    addFeature(conf.c, {
+        id:1,
+        properties: {
+            'carmen:text':'c',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+tape('index d', function(t) {
+    addFeature(conf.d, {
+        id:1,
+        properties: {
+            'carmen:text':'d',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+tape('index e', function(t) {
+    addFeature(conf.e, {
+        id:1,
+        properties: {
+            'carmen:text':'e',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+tape('index f', function(t) {
+    addFeature(conf.f, {
+        id:1,
+        properties: {
+            'carmen:text':'f',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    }, t.end);
+});
+
+tape('test spatialmatch stack truncate', function(t) {
+    c.geocode('a b c d e f', {}, function(err, res) {
+        t.ifError(err);
+        t.equals(res.features.length, 4);
+        t.equals(res.features[0].relevance, 1.00, 'Despite truncate, sets final relevance from context');
+        t.equals(res.features[0].id, 'f.1');
+        t.end();
+    });
+});
+
+tape('test spatialmatch stack truncate (desc)', function(t) {
+    c.geocode('f e d c b a', {}, function(err, res) {
+        t.ifError(err);
+        t.equals(res.features.length, 4);
+        t.equals(res.features[0].relevance, 1.00, 'Despite truncate, sets final relevance from context');
+        t.equals(res.features[0].id, 'f.1');
+        t.end();
+    });
+});
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -242,6 +242,38 @@ test('ops#toFeature + no formatter + languageMode=strict', function(assert) {
     context = [{
         properties: {
             'carmen:text': 'Chicago',
+            'carmen:types': ['place'],
+            'carmen:center': [0, 0],
+            'carmen:extid': 'place.1'
+        }
+    }];
+    context._relevance = -1;
+
+    feature = ops.toFeature(context, {}, 'en', null, true);
+    assert.deepEqual(feature.place_name, 'Chicago');
+    assert.deepEqual(feature.relevance, 0);
+
+    context._relevance = 1.5;
+
+    feature = ops.toFeature(context, {}, 'en', null, true);
+    assert.deepEqual(feature.place_name, 'Chicago');
+    assert.deepEqual(feature.relevance, 1);
+
+    context._relevance = 0.5;
+
+    feature = ops.toFeature(context, {}, 'en', null, true);
+    assert.deepEqual(feature.place_name, 'Chicago');
+    assert.deepEqual(feature.relevance, 0.5);
+
+    assert.end()
+});
+
+test('ops#toFeature + no formatter + languageMode=strict', function(assert) {
+    var context, feature;
+
+    context = [{
+        properties: {
+            'carmen:text': 'Chicago',
             'carmen:text_en': 'Chicago',
             'carmen:text_zh': '芝加哥',
             'carmen:types': ['place'],


### PR DESCRIPTION
### Context

Some queries from in IRL (whether intentional or from garbage mishaps like double copy + paste) can lead to very deep, legitimate subquery stacking combinations like:

```
['Pizza Shop', '100 Main St', 'Springfield', 'Massachusetts', 'United States', 'N Main St', 'Springfield', 'Massachusetts', 'United States']
```

These currently are a real performance killer and unnecessarily so. For now this PR implements truncation of long subquery stacking combinations, grabbing only the 4 most specific subquery features to match at the coalesce stage.

- Adds tests for this in both the ascending and descending specificity direction (e.g. to make sure we handle CJK general => specific ordered queries correctly)
- Interestingly even if we truncate subquery stacks **some final results end up with > 1.0 relevance** at the verifymatch stage. This is because we may check multiple stacks in a staggered fashion like this:

    ```
    [a b c d]
    [b c d e]
    ```

    And if the final context we evaluate is `a b c d e` carmen is aware of all 5 features and bonuses the relevance values appropriately (In theory this may already be happening in `master`). This PR also adds a final clip on relevance values in `ops.toFeature()` for now to keep our relevance values consistently in the 0-1 range externally.

cc @mapbox/geocoding-gang 
