### PR TITLE
Use carmen-cache@0.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.16.3",
+    "@mapbox/carmen-cache": "0.16.4",
     "@mapbox/geojsonhint": "^1.2.0",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/sphericalmercator": "~1.0.1",


### PR DESCRIPTION
Update to carmen-cache@0.16.4 with a key bugfix (https://github.com/mapbox/carmen-cache/pull/82) that affects longer queries.
