### PR TITLE
Add geocoder_universal_text flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ geocoder_version        | Required. Should be set to **6** for carmen@v11.x. Ind
 geocoder_cachesize      | Optional + advanced. Maximum number of shards to allow in the `carmen-cache` message cache. Defaults uptream to 65536 (maximum number of possible shards).
 geocoder_address_order  | Optional + advanced. A string that can be set to `ascending` or `descending` to indicate the expected ordering of address components for an index. Defaults to `ascending`.
 geocoder_inherit_score  | Optional + advanced. Set to `true` if features from this index should appear above other identically (ish) named parent features that are part of its context (e.g. promote New York (city) promoted above New York (state)). Defaults to `false`.
+geocoder_universal_text | Optional + advanced. Set to `true` if features from this index should be considered language agnostic (e.g. postcodes). They will bypass the `languageMode=strict` flag and the `carmen:text` field will be treated as compatible with any language. Defaults to `false`.
 
 *Note: The sum of maxzoom + geocoder_resolution must be no greater than 14.*
 

--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ function Geocoder(indexes, options) {
             source.geocoder_layer = (info.geocoder_layer||'').split('.').shift();
             source.geocoder_tokens = info.geocoder_tokens||{};
             source.geocoder_inherit_score = info.geocoder_inherit_score || false;
+            source.geocoder_universal_text = info.geocoder_universal_text || false;
             source.token_replacer = token.createReplacer(info.geocoder_tokens||{});
 
             if (tokenValidator(source.token_replacer)) {

--- a/lib/util/closest-lang.js
+++ b/lib/util/closest-lang.js
@@ -151,6 +151,9 @@ var closestLangLabel = function(target, candidates, prefix) {
         if (candidates[prefix + fb[fb_i]])
             return fb[fb_i];
 
+    // final fallback to universal text if present
+    if (candidates[prefix + 'universal']) return 'universal';
+
     // now try heuristics to get something close
     var munTarget = getLanguageArray(target);
     var munCandidates = regexCandidates.map(function(item) { return getLanguageArray(item); });
@@ -216,8 +219,31 @@ var closestLang = function(target, candidates, prefix) {
  * @return {string}
  */
 function getLanguageCode(str) {
+    if (str === 'universal') return 'universal';
     if (!hasLanguage(str)) return false;
     return getLanguageComponent(getLanguageArray(str).subtags);
+}
+
+/**
+ * Takes a language string and feature properties object and returns a text
+ * object with `text` and optional `language` properties.
+ *
+ * @param {string} language A language string
+ * @param {object} properties A feature properties object
+ * @return {object}
+ */
+function getText(language, properties) {
+    if (!properties['carmen:text']) throw new Error('Feature has no carmen:text');
+    if (!language) return { text: properties['carmen:text'].split(',')[0].trim() };
+    var languageLabel = closestLang.closestLangLabel(language, properties, 'carmen:text_');
+    var languageText = languageLabel ? properties['carmen:text_' + languageLabel] : false;
+    var text = {
+        text: (languageText||properties['carmen:text']||'').split(',')[0].trim()
+    };
+    if (languageText && languageLabel !== 'universal') {
+        text.language = languageLabel.replace('_', '-');
+    }
+    return text;
 }
 
 module.exports = closestLang;
@@ -225,3 +251,5 @@ module.exports.getLanguage = getLanguage;
 module.exports.getLanguageCode = getLanguageCode;
 module.exports.hasLanguage = hasLanguage;
 module.exports.closestLangLabel = closestLangLabel;
+module.exports.getText = getText;
+

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -92,6 +92,13 @@ function addrTransform(doc) {
 function normalize(source, doc) {
     doc.properties['carmen:types'] = doc.properties['carmen:types'] || [source.type];
     doc.properties['carmen:index'] = source.id;
+
+    // Copy carmen:text to carmen:text_universal for sources that
+    // have universal/cross-language text (e.g. postcodes).
+    // This property is treated by the closest lang/and other text
+    // fallback selection as equivalent to a real language code match.
+    if (source.geocoder_universal_text) doc.properties['carmen:text_universal'] = doc.properties['carmen:text'];
+
     doc = addrTransform(doc);
     return doc;
 }

--- a/lib/util/filter.js
+++ b/lib/util/filter.js
@@ -118,6 +118,6 @@ function featureMatchesLanguage(feature, options) {
     if (options.languageMode !== 'strict') return true;
     var a = closestLang.getLanguageCode(closestLang.closestLangLabel(options.language, feature.properties, 'carmen:text_'));
     var b = closestLang.getLanguageCode(options.language);
-    return a && b && a === b;
+    return a && b && (a === 'universal' || a === b);
 }
 

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -14,7 +14,7 @@ var featureMatchesLanguage = require('./filter').featureMatchesLanguage;
  */
 function toFeature(context, format, language, languageMode, debug) {
     var feat = context[0];
-    if (!feat.properties['carmen:center']&& !feat.properties['carmen:legacy']) throw new Error('Feature has no carmen:center');
+    if (!feat.properties['carmen:center']) throw new Error('Feature has no carmen:center');
     if (!feat.properties['carmen:extid'])  throw new Error('Feature has no carmen:extid');
 
     // check for whether or not there are any parts of the response in the queried language.
@@ -32,27 +32,15 @@ function toFeature(context, format, language, languageMode, debug) {
     }
     if (typeof format === 'object') format = format['default'];
 
-    var _gettext = function(f) {
-        if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
-        if (!language)
-            return { text: f.properties['carmen:text'].split(',')[0].trim() };
-        var languageLabel = closestLang.closestLangLabel(language, f.properties, "carmen:text_");
-        var languageText = languageLabel ? f.properties["carmen:text_" + languageLabel] : false;
-        var text = { text: (languageText||f.properties['carmen:text']||'').split(',')[0].trim() };
-        if (languageText) text.language = languageLabel.replace('_', '-');
-        return text;
-    };
-    var gettext = function(f) {
-        return _gettext(f).text;
-    };
-
     var place_name;
     // Use geocoder_format to format output if applicable
     if (!format || format === true || format === 1) {
         place_name = ((feat.properties['carmen:address'] ? feat.properties['carmen:address'] + ' ' : '') +
             context
                 .filter(function(f) { return featureMatchesLanguage(f, { language: language, languageMode: languageMode }); })
-                .map(gettext).join(', ')).trim();
+                .map(function(f) { return closestLang.getText(language, f.properties).text; })
+                .join(', ')
+        ).trim();
     } else {
         // Create template object that lists what we want to know
         var template = format.replace(/ /g,'').replace(/,/g,'').trim().replace(/^{/,'').replace(/}$/,'').split('}{');
@@ -70,7 +58,7 @@ function toFeature(context, format, language, languageMode, debug) {
 
             for (var x = 0; x < context.length; x++) {
                 var f = context[x];
-                if (!f.properties['carmen:text'] && !f.properties['carmen:legacy']) throw new Error('Feature has no carmen:text');
+                if (!f.properties['carmen:text']) throw new Error('Feature has no carmen:text');
                 if (!featureMatchesLanguage(f, { language: language, languageMode: languageMode })) continue;
                 var carmenProp = f.properties['carmen:extid'].split('.')[0]; // ex. 'place', 'postcode', 'region'
 
@@ -78,7 +66,7 @@ function toFeature(context, format, language, languageMode, debug) {
                 if (templateProp == carmenProp) {
                     if (templateSubprop == '_name') {
                         // `name` is a hardcoded subproperty that maps to carmen:text
-                        val = gettext(f);
+                        val = closestLang.getText(language, f.properties).text;
                         format = format.replace('{' + templateProp + '._name}',val);
                     } else if (templateSubprop == '_number') {
                         // `address` is a hardcored subproperty that maps to carmen:address
@@ -105,7 +93,7 @@ function toFeature(context, format, language, languageMode, debug) {
         place_name = format;
     }
 
-    var featureText = _gettext(feat);
+    var featureText = closestLang.getText(language, feat.properties);
     var feature = {
         id: feat.properties['carmen:extid'],
         type: 'Feature',
@@ -144,7 +132,7 @@ function toFeature(context, format, language, languageMode, debug) {
             if (!context[c].properties['carmen:extid']) throw new Error('Feature has no carmen:extid');
             if (!featureMatchesLanguage(context[c], { language: language, languageMode: languageMode })) continue;
 
-            var contextFeat = _gettext(context[c]);
+            var contextFeat = closestLang.getText(language, context[c].properties);
             contextFeat.id = context[c].properties['carmen:extid'];
 
             // copy over all non-'carmen:*' properties

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -48,3 +48,33 @@ tape('handle nulls w/ prefix', function(assert) {
 
     assert.end();
 });
+
+tape('universal', function(assert) {
+    assert.equal(closestLangLabel('en', {
+        'universal': '10000'
+    }), '10000');
+    assert.equal(closestLangLabel('zh', {
+        'universal': '10000'
+    }), '10000');
+    assert.end();
+});
+
+tape('getText', function(assert) {
+    assert.deepEqual(closestLangLabel.getText(null, {
+        'carmen:text': 'Default',
+        'carmen:text_en': 'English',
+        'carmen:text_universal': 'Universal'
+    }), { text: 'Default' });
+    assert.deepEqual(closestLangLabel.getText('en', {
+        'carmen:text': 'Default',
+        'carmen:text_en': 'English',
+        'carmen:text_universal': 'Universal'
+    }), { text: 'English', language: 'en' });
+    assert.deepEqual(closestLangLabel.getText('zh', {
+        'carmen:text': 'Default',
+        'carmen:text_en': 'English',
+        'carmen:text_universal': 'Universal'
+    }), { text: 'Universal' });
+    assert.end();
+});
+

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -168,6 +168,16 @@ tape('filter.featureMatchesLanguage', function(assert) {
         languageMode: 'strict'
     }), 'disallowed: no matching text');
 
+    assert.ok(filter.featureMatchesLanguage({
+        properties: {
+            'carmen:text': 'New York',
+            'carmen:text_universal': 'New York'
+        }
+    }, {
+        language: 'en',
+        languageMode: 'strict'
+    }), 'allowed: text_universal');
+
     assert.end();
 });
 

--- a/test/geocode-unit.languageMode-universal.test.js
+++ b/test/geocode-unit.languageMode-universal.test.js
@@ -1,0 +1,98 @@
+var tape = require('tape');
+var Carmen = require('..');
+var mem = require('../lib/api-mem');
+var context = require('../lib/context');
+var addFeature = require('../lib/util/addfeature');
+
+(function() {
+    var conf = {
+        country: new mem({ maxzoom:6 }, function() {}),
+        postcode: new mem({ maxzoom:6, geocoder_universal_text: true }, function() {})
+    };
+    var c = new Carmen(conf);
+
+    tape('index country', function(assert) {
+        addFeature(conf.country, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_es': 'Estados Unidos',
+                'carmen:text': 'United States'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('index postcode', function(assert) {
+        addFeature(conf.postcode, {
+            id: 1,
+            type: 'Feature',
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text': '10000'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('query: 10000', function(assert) {
+        c.geocode('10000', {}, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, United States');
+            assert.end();
+        });
+    });
+
+    tape('query: 10000, language: es', function(assert) {
+        c.geocode('10000', { language: 'es' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, Estados Unidos');
+            assert.end();
+        });
+    });
+
+    tape('query: 10000, language: es, languageMode: strict', function(assert) {
+        c.geocode('10000', { language: 'es', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, Estados Unidos');
+            assert.end();
+        });
+    });
+
+    tape('query: 1,1', function(assert) {
+        c.geocode('1,1', {}, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, United States');
+            assert.end();
+        });
+    });
+
+    tape('query: 1,1, language: es', function(assert) {
+        c.geocode('1,1', { language: 'es' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, Estados Unidos');
+            assert.end();
+        });
+    });
+
+    tape('query: 1,1, language: es, languageMode: strict', function(assert) {
+        c.geocode('1,1', { language: 'es', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, '10000, Estados Unidos');
+            assert.end();
+        });
+    });
+
+    tape('teardown', function(assert) {
+        context.getTile.cache.reset();
+        assert.end();
+    });
+})();
+


### PR DESCRIPTION
### Context

Following on the heels of the `languageMode: strict` option (https://github.com/mapbox/carmen/pull/580), this PR provides a `geocoder_universal_text` option that allows an index's text to be treated as compatible with any/all languages. The most immediate use case is for postcodes (e.g. the zip code 10000 need not be translated into any other language) though there may be other uses in the future.

### How it's implemented

This index-specific flag was easiest to implement as a post-feature/context load modifier. If an index sets this flag to true, all features going through the `feature.normalize(source, properties)` function will have its `carmen:text` field copied to `carmen:text_universal`.

The remaining steps were to make sure the closest language/language filtering logic respected a `carmen:text_universal` value on a feature if set.

(The alternative approach would be to pass the index `source` object/configuration around through many parts of the stack. This seeemed :x: to me).

### Next Steps

- [x] Unit tests for altered functions
- [x] Integration testing

cc @mapbox/geocoding-gang @alianthes 