### PR TITLE
Serbian script preference

### DIFF
--- a/lib/util/fallback.json
+++ b/lib/util/fallback.json
@@ -214,6 +214,9 @@
   "sr_Latn": [
     "sr_Cyrl"
   ],
+  "sr_RS": [
+    "sr_Latn"
+  ],
   "sv": [
     "en"
   ],

--- a/lib/util/fallback.json
+++ b/lib/util/fallback.json
@@ -214,6 +214,15 @@
   "sr_Latn": [
     "sr_Cyrl"
   ],
+  "sr_BA": [
+    "sr_Latn"
+  ],
+  "sr_CS": [
+    "sr_Latn"
+  ],
+  "sr_ME": [
+    "sr_Latn"
+  ],
   "sr_RS": [
     "sr_Latn"
   ],

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -78,13 +78,18 @@ tape('getText', function(assert) {
     assert.end();
 });
 
+// sr_BA, sr_CS, sr_ME, and sr_RS (regions where serbian is spoken) fall back to `sr_Latn`. Other (non-serbian-speaking) regions fall back to `sr`
 tape('sr_RS', function(assert) {
 
     var sr = 'sr';
     var sr_Latn = 'sr_Latn';
     var sr_Cyrl = 'sr_Cyrl';
 
+    assert.equal(closestLangLabel('sr-BA', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn);
+    assert.equal(closestLangLabel('sr-CS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn);
+    assert.equal(closestLangLabel('sr-ME', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn);
     assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn);
+    assert.equal(closestLangLabel('sr-XX', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr);
 
     assert.end();
 });

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -78,3 +78,13 @@ tape('getText', function(assert) {
     assert.end();
 });
 
+tape('sr_RS', function(assert) {
+
+    var sr = 'sr';
+    var sr_Latn = 'sr_Latn';
+    var sr_Cyrl = 'sr_Cyrl';
+
+    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn);
+
+    assert.end();
+});


### PR DESCRIPTION
### Context
The Serbian language can be written with either Latin or Cyrillic script. This sets to fallback for region-specific Serbian language codes to prefer Latin script.

### Summary
* Add `sr_Latn` fallback for `sr_BA`, `sr_CS`, `sr_ME`, and `sr_RS` codes