### PR TITLE
Scriptsniff

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -390,6 +390,7 @@ function forwardGeocode(geocoder, query, options, callback) {
 function toFeatures(geocoder, contexts, options) {
     var features = [];
     var indexes = {};
+    var feature;
 
     for (var i = 0; i < contexts.length; i++) {
         var context = contexts[i];
@@ -397,7 +398,9 @@ function toFeatures(geocoder, contexts, options) {
         if (!filter.featureAllowed(index, context[0], options)) continue;
 
         // Convert this context array to a feature
-        features.push(ops.toFeature(context, index.geocoder_format, options.language, options.languageMode, options.debug));
+        feature = ops.toFeature(context, index.geocoder_format, options.language, options.languageMode, options.debug)
+        if(!filter.noMixedScripts(feature, options)) continue;
+        features.push(feature);
 
         // Record index usage for this feature
         if (options.indexes) for (var k = 0; k < context.length; k++) {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -399,7 +399,7 @@ function toFeatures(geocoder, contexts, options) {
 
         // Convert this context array to a feature
         feature = ops.toFeature(context, index.geocoder_format, options.language, options.languageMode, options.debug)
-        if(!filter.noMixedScripts(feature, options)) continue;
+        if (!filter.noMixedScripts(feature, options)) continue;
         features.push(feature);
 
         // Record index usage for this feature

--- a/lib/util/filter.js
+++ b/lib/util/filter.js
@@ -1,5 +1,6 @@
 var closestLang = require('./closest-lang');
 var equivalent = require('./equivalent.json');
+var scriptsniff = require('@mapbox/scriptsniff');
 
 module.exports = {};
 module.exports.sourceAllowed = sourceAllowed;
@@ -10,6 +11,7 @@ module.exports.featureMatchesTypes = featureMatchesTypes;
 module.exports.featureMatchesStacks = featureMatchesStacks;
 module.exports.featureMatchesLanguage = featureMatchesLanguage;
 module.exports.equivalentLanguages = equivalentLanguages;
+module.exports.noMixedScripts = noMixedScripts;
 
 /**
  * For a given source, determine if it is allowed to participate in forward
@@ -124,7 +126,8 @@ function featureMatchesLanguage(feature, options) {
 }
 
 /**
- * Determine whether two different languages are equivalent enough to pass the `languageMode: strict` filter
+ * Filter function for determining whether two different languages are equivalent enough to pass
+ * the `languageMode: strict` filter.
  *
  * @param {string} a The language label from a feature
  * @param {string} b The language label from the `options.language` setting
@@ -134,3 +137,16 @@ function equivalentLanguages(a, b) {
     return equivalent[a] && equivalent[a].indexOf(b) > -1;
 }
 
+/**
+ * Filter function for determining whether feature contexts use multiple scripts, for use with the
+ * `languageMode: strict` filter.
+ *
+ * @param {object} feature a Carmen Geojson feature
+ * @param {options} options A geocoder query options object
+ * @return {boolean}
+ */
+function noMixedScripts(feature, options) {
+    if (!options.language) return true;
+    if (options.languageMode !== 'strict') return true;
+    return feature && feature.place_name && scriptsniff(feature.place_name).length < 2;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@mapbox/carmen-cache": "0.16.5",
     "@mapbox/geojsonhint": "^1.2.0",
     "@mapbox/locking": "^3.0.0",
+    "@mapbox/scriptsniff": "0.0.1",
     "@mapbox/sphericalmercator": "~1.0.1",
     "@mapbox/tilebelt": "1.0.x",
     "@turf/bbox": "^3.7.3",

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -197,3 +197,46 @@ tape('filter.equivalentLanguages', function(assert) {
     assert.end();
 });
 
+tape('filter.noMixedScripts', function(assert) {
+    assert.ok(filter.noMixedScripts({
+        place_name: 'Парис, Teksas, Sjedinjene Američke Države'
+    }, {
+        languageMode: 'strict'
+    }), 'allowed: language is not defined');
+
+    assert.ok(filter.noMixedScripts({
+        place_name: 'Парис, Teksas, Sjedinjene Američke Države'
+    }, {
+        language: 'sr'
+    }), 'allowed: languageMode is not defined');
+
+    assert.ok(filter.noMixedScripts({
+        place_name: 'Парис, Teksas, Sjedinjene Američke Države'
+    }, {
+        language: 'sr',
+        languageMode: 'stirct'
+    }), 'allowed: languageMode !== "strict"');
+
+    assert.ok(filter.noMixedScripts({
+        place_name: '20001'
+    }, {
+        language: 'sr',
+        languageMode: 'strict'
+    }), 'allowed: numeric result');
+
+    assert.ok(filter.noMixedScripts({
+        place_name: '20001 Washington DC'
+    }, {
+        language: 'sr',
+        languageMode: 'strict'
+    }), 'allowed: mixed numeric & text result');
+
+    assert.notOk(filter.noMixedScripts({
+        place_name: 'Парис, Teksas, Sjedinjene Američke Države'
+    }, {
+        language: 'sr',
+        languageMode: 'strict'
+    }), 'disallowed: mixed Cyrillic and Latin text');
+
+    assert.end();
+});

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -253,3 +253,76 @@ var addFeature = require('../lib/util/addfeature');
     });
 })();
 
+// script sniffer tests
+(function() {
+    var conf = {
+        country: new mem({ maxzoom:6, geocoder_name: 'country' }, function() {}),
+        region: new mem({ maxzoom:6, geocoder_name: 'region' }, function() {}),
+        place: new mem({ maxzoom:6, geocoder_name: 'place' }, function() {})
+    };
+    var c = new Carmen(conf);
+
+    tape('index country', function(assert) {
+        addFeature(conf.country, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_sr_Latn': 'Sjedinjene Američke Države',
+                'carmen:text': 'United States',
+                'carmen:text_en': 'United States'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('index region', function(assert) {
+        addFeature(conf.region, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_hr': 'Teksas',
+                'carmen:text': 'Texas'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('index place', function(assert) {
+        addFeature(conf.place, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_sr': 'Парис',
+                'carmen:text': 'Paris'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+
+    tape('query: paris, language: sr-Latn, languageMode: strict', function(assert) {
+        c.geocode('paris', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features.length, 0, 'filters out mixed-script results');
+            assert.end();
+        });
+    });
+
+    tape('teardown', function(assert) {
+        context.getTile.cache.reset();
+        assert.end();
+    });
+})();
+


### PR DESCRIPTION
### Context
Follow-up to #593 & 594.

Even after ensuring language consistency with `languageMode: strict`, mixed-script results can still sneak through in cases where a single language has variants written with differing scripts. This adds a final script consistency check.

### Summary
* add [scriptsniff](https://github.com/mapbox/scriptsniff)
* use scriptsniff to test each feature's `place_name` for mixed script results
* don't include these results when using `languageMode: strict`

### Next Steps
This is a little blunt, and removes any mixed-script results entirely as a final fail-safe. A more sophisticated approach would be to detect the desired script based on the language parameter, and filter out individual features from the context array that don't match the intended script.
