### PR TITLE
exclude loose language matches known to involve mixed scripts

### DIFF
--- a/lib/util/closest-lang.js
+++ b/lib/util/closest-lang.js
@@ -109,9 +109,17 @@ var scriptBonuses = {
     'Latn': 1  // in general, prefer Latin to other scripts where multiple options
                // are resent and no script is specified (most likely to come up with Serbian)
 }
-var closestLangLabel = function(target, candidates, prefix) {
+
+// sub-types of these languages use different scripts and should not be combined in strict languageMode
+var digraphic = [
+    'sr'
+]
+
+var closestLangLabel = function(target, candidates, prefix, languageMode) {
     prefix = prefix || "";
     target = target.replace("-", "_");
+    languageMode = languageMode || "";
+    var primary = target.split('_')[0].toLowerCase(); // e.g., the `en` part of `en_US`
 
     // first check if there's an exact match
     if (candidates[prefix + target]) return target;
@@ -142,11 +150,17 @@ var closestLangLabel = function(target, candidates, prefix) {
 
     // then check if there's a language-only match
     for (i = 0; i < regexCandidates.length; i++) {
-        if (regexCandidates[i].toLowerCase() == target.split('_')[0].toLowerCase()) return regexCandidates[i];
+        if (regexCandidates[i].toLowerCase() == primary) {
+            if (languageMode === 'strict' && digraphic.indexOf(primary) > -1) {
+                continue;
+            } else {
+                return regexCandidates[i];
+            }
+        }
     }
 
     // then check if there's a language-only fallback
-    fb = fallback[target.split('_')[0].toLowerCase()];
+    if (languageMode !== 'strict' && digraphic.indexOf(primary) === -1) fb = fallback[primary];
     if (fb) for (fb_i = 0; fb_i < fb.length; fb_i++)
         if (candidates[prefix + fb[fb_i]])
             return fb[fb_i];
@@ -202,12 +216,12 @@ var closestLangLabel = function(target, candidates, prefix) {
     var winner = munCandidates[0];
 
     // require at least a score of 50 (so, at a minimum either a language match or non-Latin script match) to win
-    if (winner.score < 50) return;
+    if (winner.score < 50 || (languageMode === 'strict' && digraphic.indexOf(winner.code) > -1)) return;
     return winner.code;
 }
 
-var closestLang = function(target, candidates, prefix) {
-    var label = closestLangLabel(target, candidates, prefix);
+var closestLang = function(target, candidates, prefix, languageMode) {
+    var label = closestLangLabel(target, candidates, prefix, languageMode);
     return label ? candidates[(prefix || "") + label] : label;
 }
 

--- a/lib/util/equivalent.json
+++ b/lib/util/equivalent.json
@@ -1,13 +1,13 @@
 {
     "hr": [
         "bs",
-        "sr"
+        "sr_Latn"
     ],
     "bs": [
         "hr",
-        "sr"
+        "sr_Latn"
     ],
-    "sr": [
+    "sr_Latn": [
         "bs",
         "hr"
     ]

--- a/lib/util/equivalent.json
+++ b/lib/util/equivalent.json
@@ -1,11 +1,11 @@
 {
     "hr": [
         "bs",
-        "sr_Latn"
+        "sr"
     ],
     "bs": [
         "hr",
-        "sr_Latn"
+        "sr"
     ],
     "sr_Latn": [
         "bs",

--- a/lib/util/filter.js
+++ b/lib/util/filter.js
@@ -118,9 +118,11 @@ function featureMatchesTypes(source, feature, options) {
 function featureMatchesLanguage(feature, options) {
     if (!options.language) return true;
     if (options.languageMode !== 'strict') return true;
-    var a = closestLang.getLanguageCode(closestLang.closestLangLabel(options.language, feature.properties, 'carmen:text_'));
+    var label = closestLang.closestLangLabel(options.language, feature.properties, 'carmen:text_', options.languageMode);
+
+    var a = closestLang.getLanguageCode(label);
     var b = closestLang.getLanguageCode(options.language);
-    return a && b && (a === 'universal' || a === b || equivalentLanguages(a, b));
+    return a && b && (a === 'universal' || a === b || equivalentLanguages(label, b));
 }
 
 /**

--- a/test/closest-lang.test.js
+++ b/test/closest-lang.test.js
@@ -86,15 +86,18 @@ tape('serbian fallbacks', function(assert) {
     var sr_Cyrl = 'sr_Cyrl';
     var hr = 'hr';
     var bs = 'bs';
+    var languageMode = 'strict';
 
-    assert.equal(closestLangLabel('sr-BA', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn, 'sr-BA falls back to sr_Latn');
-    assert.equal(closestLangLabel('sr-CS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn, 'sr-CS falls back to sr_Latn');
-    assert.equal(closestLangLabel('sr-ME', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn, 'sr-ME falls back to sr_Latn');
-    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr_Latn, 'sr-RS falls back to sr_Latn');
-    assert.equal(closestLangLabel('sr-XX', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }), sr, 'sr-XX falls back to sr');
-    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Cyrl: sr_Cyrl, hr: hr, bs: bs }), hr, 'use hr if sr_Latn not present');
-    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Cyrl: sr_Cyrl, bs: bs }), bs, 'use bs if sr_Latn and hr not present');
+    assert.equal(closestLangLabel('sr-BA', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }, null, languageMode), sr_Latn, 'sr-BA falls back to sr_Latn');
+    assert.equal(closestLangLabel('sr-CS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }, null, languageMode), sr_Latn, 'sr-CS falls back to sr_Latn');
+    assert.equal(closestLangLabel('sr-ME', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }, null, languageMode), sr_Latn, 'sr-ME falls back to sr_Latn');
+    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }, null, languageMode), sr_Latn, 'sr-RS falls back to sr_Latn');
+    assert.equal(closestLangLabel('sr-XX', { sr: sr, sr_Latn: sr_Latn, sr_Cyrl: sr_Cyrl }, null, languageMode), sr_Latn, 'sr-XX falls back to sr_Latn');
+    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Cyrl: sr_Cyrl, hr: hr, bs: bs }, null, languageMode), hr, 'use hr if sr_Latn not present');
+    assert.equal(closestLangLabel('sr-RS', { sr: sr, sr_Cyrl: sr_Cyrl, bs: bs }, null, languageMode), bs, 'use bs if sr_Latn and hr not present');
 
+    assert.equal(closestLangLabel('sr-XX', { sr: sr, sr_Cyrl: sr_Cyrl, hr: hr, bs: bs }, null, languageMode), undefined, 'no equivalent language matching unless explicitly set');
+    assert.equal(closestLangLabel('sr-Latn', { sr: sr }, null, languageMode), undefined, 'no mixed scripts in strict mode');
 
     assert.end();
 });

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -192,7 +192,7 @@ tape('filter.featureMatchesLanguage', function(assert) {
 });
 
 tape('filter.equivalentLanguages', function(assert) {
-    assert.ok(filter.equivalentLanguages("sr", "hr"));
+    assert.ok(filter.equivalentLanguages("sr_Latn", "hr"));
 
     assert.end();
 });

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -268,9 +268,10 @@ var addFeature = require('../lib/util/addfeature');
             id: 1,
             properties: {
                 'carmen:center': [1,1],
-                'carmen:text_sr_Latn': 'Sjedinjene Američke Države',
                 'carmen:text': 'United States',
-                'carmen:text_en': 'United States'
+                'carmen:text_en': 'United States',
+                'carmen:text_sr': 'Сједињене Америчке Државе',
+                'carmen:text_sr_Latn': 'Sjedinjene Američke Države'
             },
             geometry: {
                 type: 'Point',
@@ -311,11 +312,49 @@ var addFeature = require('../lib/util/addfeature');
         }, assert.end);
     });
 
+    tape('index place', function(assert) {
+        addFeature(conf.place, {
+            type: 'Feature',
+            id: 2,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_sr': 'Београд',
+                'carmen:text_hr': 'Beograd',
+                'carmen:text': 'Belgrade'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
 
     tape('query: paris, language: sr-Latn, languageMode: strict', function(assert) {
         c.geocode('paris', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
             assert.ifError(err);
             assert.equal(res.features.length, 0, 'filters out mixed-script results');
+            assert.end();
+        });
+    });
+
+    tape('query: belgrade, language: sr-Latn, languageMode: strict', function(assert) {
+        c.geocode('belgrade', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            console.log("Res", res)
+            assert.equal(res.features.length, 1, 'allows hr result');
+            assert.equal(res.features[0].language, 'hr', 'language code is hr');
+            assert.end();
+        });
+    });
+
+    tape('query: belgrade, language: hr, languageMode: strict', function(assert) {
+        c.geocode('belgrade', { language: 'hr', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            console.log("res", res)
+            assert.equal(res.features.length, 1, 'allows hr result');
+            assert.equal(res.features[0].language, 'hr', 'language code is hr');
+            assert.equal(res.features[0].place_name, 'Beograd, Teksas', 'language=hr excludes sr results');
             assert.end();
         });
     });

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -253,3 +253,75 @@ var addFeature = require('../lib/util/addfeature');
     });
 })();
 
+// digraphic exclusion test
+(function() {
+    var conf = {
+        country: new mem({ maxzoom:6, geocoder_name: 'country' }, function() {}),
+        region: new mem({ maxzoom:6, geocoder_name: 'region' }, function() {}),
+        place: new mem({ maxzoom:6, geocoder_name: 'place' }, function() {})
+    };
+    var c = new Carmen(conf);
+
+    tape('index country', function(assert) {
+        addFeature(conf.country, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_sr_Latn': 'Sjedinjene Američke Države',
+                'carmen:text': 'United States',
+                'carmen:text_en': 'United States'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('index region', function(assert) {
+        addFeature(conf.region, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_hr': 'Teksas',
+                'carmen:text': 'Texas'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+    tape('index place', function(assert) {
+        addFeature(conf.place, {
+            type: 'Feature',
+            id: 1,
+            properties: {
+                'carmen:center': [1,1],
+                'carmen:text_sr': 'Парис',
+                'carmen:text': 'Paris'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }, assert.end);
+    });
+
+
+    tape('query: paris, language: sr-Latn, languageMode: strict', function(assert) {
+        c.geocode('paris', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features.length, 0, 'filters out mixed-script results');
+            assert.end();
+        });
+    });
+
+    tape('teardown', function(assert) {
+        context.getTile.cache.reset();
+        assert.end();
+    });
+})();


### PR DESCRIPTION
### Context
Follow-up to #593 & #594. Excludes languages with subtypes that use varying scripts from falling back to a potentially mixed-script result.

### Summary
* Add a `digraphic` array of languages known to use multiple scripts
* For these languages, don't attempt a loose match in strict languageMode.
