### PR TITLE
Rocksdb massive refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ function Geocoder(indexes, options) {
                         new cxxcache.RocksDBCache(name + ".grid", data.grid) :
                         new cxxcache.MemoryCache(name + ".grid")
                 }
-                if (data.freq && fs.existsSync(data.freq))
             } else {
                 source._geocoder = source._original._geocoder;
             }

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -11,11 +11,11 @@ module.exports = function analyze(source, callback) {
     for (var i = 0; i < 7; i++) stats.byScore[i] = 0;
     for (var j = 0.4; j <= 1; j = j + 0.2) stats.byRelev[j.toFixed(1)] = 0;
 
-    var ids = s._geocoder.list('grid');
+    var ids = s._geocoder.grid.list();
     ids.sort();
     while (ids.length) {
         var id = ids.shift();
-        var grids = s._geocoder.get('grid', id);
+        var grids = s._geocoder.grid.get(id);
         var rels = grids.length;
 
         // Verify that relations are unique.

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -18,7 +18,7 @@ module.exports = function index(from, to, callback) {
                     // call pack on the from cache into the to filename
                     var toRdb = to.getBaseFilename() + '.' + type + '.rocksdb';
 
-                    from._geocoder.pack(toRdb, type);
+                    from._geocoder[type].pack(toRdb);
 
                     rocksDirs[type] = toRdb;
                     cb();
@@ -37,8 +37,8 @@ module.exports = function index(from, to, callback) {
                     }
                 });
                 copyQ.await(function() {
-                    to._geocoder.loadSync(rocksDirs.grid, "grid");
-                    to._geocoder.loadSync(rocksDirs.freq, "freq");
+                    to._geocoder.grid = new RocksDBCache(to._geocoder.grid.id, rocksDirs.grid);
+                    to._geocoder.freq = new RocksDBCache(to._geocoder.freq.id, rocksDirs.freq);
                     callback();
                 })
             });

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,4 +1,5 @@
 var queue = require('d3-queue').queue;
+var cxxcache = require('./util/cxxcache');
 var stream = require('stream');
 var fs = require('fs-extra');
 
@@ -37,8 +38,8 @@ module.exports = function index(from, to, callback) {
                     }
                 });
                 copyQ.await(function() {
-                    to._geocoder.grid = new RocksDBCache(to._geocoder.grid.id, rocksDirs.grid);
-                    to._geocoder.freq = new RocksDBCache(to._geocoder.freq.id, rocksDirs.freq);
+                    to._geocoder.grid = new cxxcache.RocksDBCache(to._geocoder.grid.id, rocksDirs.grid);
+                    to._geocoder.freq = new cxxcache.RocksDBCache(to._geocoder.freq.id, rocksDirs.freq);
                     callback();
                 })
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var feature = require('./util/feature'),
     indexdocs = require('./indexer/indexdocs'),
     split = require('split'),
     fs = require('fs-extra'),
+    cxxcache = require('./util/cxxcache'),
     TIMER = process.env.TIMER;
 
 module.exports = index;
@@ -189,17 +190,19 @@ function store(source, callback) {
             var rocksdb = source.getBaseFilename() + '.' + type + '.rocksdb';
 
             // steps:
-            //   - pack to a temp directory (which may pack from lazy or from rocks)
-            //   - disconnect current rocks
+            //   - pack to a temp directory
+            //   - delete current rocks cache
             //   - move temp rocks overtop current rocks position
-            //   - reload new rocks
+            //   - create new rocks cache
 
             var tmpdir = require('os').tmpdir() + "/temp." + Math.random().toString(36).substr(2, 5);
-            cache.pack(tmpdir, type);
+            cache[type].pack(tmpdir);
 
-            cache.unload(type, 'lazy');
+            var id = cache[type].id;
+            delete cache[type];
+
             fs.move(tmpdir, rocksdb, {clobber: true}, function(err) {
-                if (!err) cache.loadSync(rocksdb, type);
+                if (!err) cache[type] = new cxxcache.RocksDBCache(id, rocksdb);
                 callback(err);
             });
         })
@@ -209,19 +212,7 @@ function store(source, callback) {
         var dawgFile = source.getBaseFilename() + '.dawg';
         fs.writeFile(dawgFile, source._dictcache.dump(), callback);
     });
-    q.awaitAll(function(err) {
-        if (err) return callback(err);
-
-        // @TODO: robustify this behavior in carmen-cache.
-        // Currently unload + load after storing does not result in the
-        // same state prior to storing (though it should).
-        // Only affects geocoding unit tests which index, store, and then attempt
-        // to use the index live immediately atm.
-
-        source._geocoder.unload('freq', 'mem');
-        source._geocoder.unload('grid', 'mem');
-        callback();
-    });
+    q.awaitAll(callback);
 }
 
 // Cleans a doc for storage based on source properties.

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,13 +149,13 @@ function update(source, docs, options, callback) {
                     for (var i = 0; i < ids.length; i++) {
                         id = ids[i];
                         // This merges new entries on top of old ones.
-                        cache.set('grid', id, data[id], true);
+                        cache.grid.set(id, data[id], true);
                     }
                 } else {
                     for (var k = 0; k < ids.length; k++) {
                         id = ids[k];
                         // This merges new entries on top of old ones.
-                        cache.set('grid', id, data[id], true);
+                        cache.grid.set(id, data[id], true);
                         dictcache.setId(id);
                     }
                 }

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -57,12 +57,12 @@ function indexdocs(docs, source, options, callback) {
 
     for (var i = 0; i < ids.length; i++) {
         var id = ids[i];
-        freq[id][0] = (source._geocoder.get('freq', id) || [0])[0] + freq[id][0];
+        freq[id][0] = (source._geocoder.freq.get(id) || [0])[0] + freq[id][0];
         // maxscore should not be cumulative.
         if (id === "__MAX__") {
-            freq[id][0] = (source._geocoder.get('freq', id) || [0,0])[0] || freq[id][0];
+            freq[id][0] = (source._geocoder.freq.get(id) || [0,0])[0] || freq[id][0];
         }
-        source._geocoder.set('freq', id, freq[id]);
+        source._geocoder.freq.set(id, freq[id]);
     }
     if (TIMER) console.time('update:indexdocs');
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -151,7 +151,7 @@ function merge(geocoder, from1, from2, to, options, callback) {
 
             if (!fs.existsSync(rocks.from1)) from1._geocoder[type].pack(rocks.from1);
             if (!fs.existsSync(rocks.from2)) from2._geocoder[type].pack(rocks.from2);
-            from1._geocoder.merge(
+            cxxcache.RocksDBCache.merge(
                 rocks.from1,
                 rocks.from2,
                 rocks.to,

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -3,7 +3,7 @@ var queue = require('d3-queue').queue,
     extend = require('util')._extend,
     dawgCache = require('dawg-cache'),
     carmenDawg = require('./util/dawg'),
-    cxxcache = require('./lib/cxxcache'),
+    cxxcache = require('./util/cxxcache'),
     fork = require('child_process').fork,
     fs = require('fs-extra');
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -3,6 +3,7 @@ var queue = require('d3-queue').queue,
     extend = require('util')._extend,
     dawgCache = require('dawg-cache'),
     carmenDawg = require('./util/dawg'),
+    cxxcache = require('./lib/cxxcache'),
     fork = require('child_process').fork,
     fs = require('fs-extra');
 
@@ -148,15 +149,15 @@ function merge(geocoder, from1, from2, to, options, callback) {
                 to: toBase + '.' + type + '.rocksdb'
             }
 
-            if (!fs.existsSync(rocks.from1)) from1._geocoder.pack(rocks.from1, type);
-            if (!fs.existsSync(rocks.from2)) from2._geocoder.pack(rocks.from2, type);
+            if (!fs.existsSync(rocks.from1)) from1._geocoder[type].pack(rocks.from1);
+            if (!fs.existsSync(rocks.from2)) from2._geocoder[type].pack(rocks.from2);
             from1._geocoder.merge(
                 rocks.from1,
                 rocks.from2,
                 rocks.to,
                 type,
                 function() {
-                    to._geocoder.loadSync(rocks.to, type);
+                    to._geocoder[type] = new cxxcache.RocksDBCache(to._geocoder[type].id, rocks.to);
                     stats[type] = +(new Date()) - start;
                     cb();
                 }

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -48,7 +48,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     // load up scorefactor used at indexing time.
     // it will be used to scale scores for approximated
     // cross-index comparisons.
-    var scorefactor = (source._geocoder.get('freq', '__MAX__')||[0])[0] || 1;
+    var scorefactor = (source._geocoder.freq.get('__MAX__')||[0])[0] || 1;
 
     var phrasematches = [];
 

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -65,7 +65,7 @@ module.exports = function phrasematch(source, query, options, callback) {
 
             var prefix = (options.autocomplete && subquery.ender);
 
-            phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder, source.zoom, prefix));
+            phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix));
         }
     }
 

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -1,6 +1,6 @@
 var proximity = require('./util/proximity.js');
 var queue = require('d3-queue').queue;
-var coalesce = require('@mapbox/carmen-cache').Cache.coalesce;
+var coalesce = require('@mapbox/carmen-cache').coalesce;
 var bbox = require('./util/bbox.js');
 var termops = require('./util/termops');
 

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -9,9 +9,11 @@ var split = require('split');
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'ogr.input'));
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
 
-module.exports = addFeature;
+module.exports = {};
+module.exports.queueFeature = queueFeature;
+module.exports.queueVT = queueVT;
+module.exports.buildQueued = buildQueued;
 module.exports.setOptions = setOptions;
-module.exports.vt = addVT;
 module.exports.resetLogs = resetLogs;
 
 var options = {};
@@ -20,14 +22,36 @@ function setOptions(opts) {
     options = opts;
 }
 
-function addFeature(source, doc, callback) {
+function queueFeature(source, doc, callback) {
     if (!Array.isArray(doc)) doc = [doc];
-    return _addFeature(source, doc, false, callback);
+    source.__pending = source.__pending || {};
+    source.__pending[vtile_only] = source.__pending[false] || [];
+    source.__pending[vtile_only] = source.__pending[false].concat(doc);
+    callback(null);
 }
 
-function addVT(source, doc, callback) {
+function queueVT(source, doc, callback) {
     if (!Array.isArray(doc)) doc = [doc];
-    return _addFeature(source, doc, true, callback);
+    source.__pending = source.__pending || {};
+    source.__pending[vtile_only] = source.__pending[true] || [];
+    source.__pending[vtile_only] = source.__pending[true].concat(doc);
+    callback(null);
+}
+
+function buildQueued(source, callback) {
+    var q = queue(1);
+    [false, true].forEach(function(vtile_only) {
+        q.defer(function(cb) {
+            source.__pending = source.__pending || {};
+            if (source.__pending[vtile_only].length) {
+                _addFeature(source, source.__pending[vtile_only], vtile_only, cb);
+            }
+        });
+    });
+    q.awaitAll(function(err) {
+        delete source.__pending;
+        return callback(err);
+    });
 }
 
 function zxyArray(input) {

--- a/lib/util/addfeature.js
+++ b/lib/util/addfeature.js
@@ -25,28 +25,28 @@ function setOptions(opts) {
 function queueFeature(source, doc, callback) {
     if (!Array.isArray(doc)) doc = [doc];
     source.__pending = source.__pending || {};
-    source.__pending[vtile_only] = source.__pending[false] || [];
-    source.__pending[vtile_only] = source.__pending[false].concat(doc);
+    source.__pending[false] = source.__pending[false] || [];
+    source.__pending[false] = source.__pending[false].concat(doc);
     callback(null);
 }
 
 function queueVT(source, doc, callback) {
     if (!Array.isArray(doc)) doc = [doc];
     source.__pending = source.__pending || {};
-    source.__pending[vtile_only] = source.__pending[true] || [];
-    source.__pending[vtile_only] = source.__pending[true].concat(doc);
+    source.__pending[true] = source.__pending[true] || [];
+    source.__pending[true] = source.__pending[true].concat(doc);
     callback(null);
 }
 
 function buildQueued(source, callback) {
     var q = queue(1);
     [false, true].forEach(function(vtile_only) {
-        q.defer(function(cb) {
-            source.__pending = source.__pending || {};
-            if (source.__pending[vtile_only].length) {
+        source.__pending = source.__pending || {};
+        if (source.__pending[vtile_only] && source.__pending[vtile_only].length) {
+            q.defer(function(cb) {
                 _addFeature(source, source.__pending[vtile_only], vtile_only, cb);
-            }
-        });
+            });
+        }
     });
     q.awaitAll(function(err) {
         delete source.__pending;

--- a/lib/util/cxxcache.js
+++ b/lib/util/cxxcache.js
@@ -1,76 +1,63 @@
-var Cache = require('@mapbox/carmen-cache').Cache;
+var cache = require('@mapbox/carmen-cache');
 var uniq = require('./uniq');
 
-// This file wraps the Cache object coming from C++
+// This file wraps the MemoryCache and RocksDBCache objects coming from C++
 //
-// This object internally uses two caches: one to
-// store fully materialized data (called 'memory' cache)
+// This object exposes two caches: one to
+// store fully materialized data (MemoryCache)
 // and another that stores a raw protobuf representation
-// of the data (called 'lazy' cache) which needs extra
+// of the data (RocksDBCache) which needs extra
 // work to decode before being usable.
 //
 // This object offers to JS these functions:
 //
-// Returns whether the Cache has data loaded for a given
-// index type by looking in both the memory cache
-// and the lazy cache.
-// - has(type)
-//
-// Load data into memory synchronously (recommend)
-// This connects a rocksdb directory to carmen-cache
-// to use as the lazy cache for a given type
-// - loadSync(filename, type)
-//
-// Gets data for a given type, and id
+// Gets data for a given id
 // Copied to the JS land function 'get'
-// - _get(type, id)
+// - _get(id)
 //
-// Adds a JS array to the cache for given type
+// Adds a JS array to the cache for given
 // and id. This adds data directly to the fully materialized
 // cache and leaves the lazy protobuf cache untouched
 // which is in contrast to the load method.
 // Copied to the JS land function 'set'
-// - _set(type, id, data)
+// - _set(id, data)
 //
 // Writes a rocksdb database to the given filename
-// containing the lazy representation of all data for a given
-// type.
-// - pack(filename, type)
+// containing the lazy representation of all data in the cache.
+// - pack(filename)
 //
-// Returns the ids for all arrays for the matching type.
+// Returns the ids for all arrays in the cache.
 // Looks in both the memory cache and the lazy cache for
 // matches.
-// - list(type)
-//
-// Removes cached data for given type from
-// both the memory and lazy caches.
-// - unload(type)
+// - list()
 
-exports = module.exports = Cache;
+exports = module.exports = cache;
 
-// Store a id->data pair into this cache
-Cache.prototype.set = Cache.prototype._set;
+[cache.MemoryCache, cache.RocksDBCache].forEach(function(Cache) {
+    // Store a id->data pair into this cache
+    Cache.prototype.set = Cache.prototype._set;
 
-// Get the data that belongs to a specific `data` member.
-Cache.prototype.get = Cache.prototype._get;
+    // Get the data that belongs to a specific `data` member.
+    Cache.prototype.get = Cache.prototype._get;
 
-// # getall
-//
-// @param {String} type
-// @param {Array} ids an array of ids as numbers
-// @param {Function} callback a function invoked with `(error, unique results)`
-Cache.prototype.getall = function(type, ids, callback) {
-    var cache = this;
-    var result = [];
+    // # getall
+    //
+    // @param {String} type
+    // @param {Array} ids an array of ids as numbers
+    // @param {Function} callback a function invoked with `(error, unique results)`
+    Cache.prototype.getall = function(type, ids, callback) {
+        var cache = this;
+        var result = [];
 
-    for (var i = 0; i < ids.length; i++) {
-        var match = cache._get(type, ids[i]);
-        if (match) {
-            var j = match.length;
-            while (j--) result.push(match[i]);
+        for (var i = 0; i < ids.length; i++) {
+            var match = cache._get(ids[i]);
+            if (match) {
+                var j = match.length;
+                while (j--) result.push(match[i]);
+            }
         }
-    }
 
-    result = type === 'grid' ? result : uniq(result);
-    callback(null, result);
-};
+        result = type === 'grid' ? result : uniq(result);
+        callback(null, result);
+    };
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/7f17692327387ef1ad7bc9302512492c807ee1ec",
+    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/323519dcefe5049dbf4bc68e3fc807e331e99b39",
     "@mapbox/geojsonhint": "^1.2.0",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/sphericalmercator": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/523ec85709eaf6fb698e38075a5d05c99c07e470",
+    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/7f17692327387ef1ad7bc9302512492c807ee1ec",
     "@mapbox/geojsonhint": "^1.2.0",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/sphericalmercator": "~1.0.1",

--- a/test/addfeature.test.js
+++ b/test/addfeature.test.js
@@ -5,8 +5,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 6}, function() {}),

--- a/test/addfeature.test.js
+++ b/test/addfeature.test.js
@@ -3,6 +3,7 @@ var tape = function() {};
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -162,6 +163,15 @@ tape('index place', function(t) {
     }
     queueFeature(conf.place, docs, t.end);
     
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('query batched features', function(t) {

--- a/test/addfeature.test.js
+++ b/test/addfeature.test.js
@@ -3,7 +3,9 @@ var tape = function() {};
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 6}, function() {}),
@@ -82,7 +84,7 @@ tape('index country (batch)', function(t) {
     };
     docs.push(country);
 
-    addFeature(conf.country, docs, t.end);
+    queueFeature(conf.country, docs, t.end);
 });
 
 tape('index region', function(t) {
@@ -118,7 +120,7 @@ tape('index region', function(t) {
         }
     };
     docs.push(usvi)
-    addFeature(conf.region, docs, t.end);
+    queueFeature(conf.region, docs, t.end);
 });
 
 tape('index place', function(t) {
@@ -158,7 +160,7 @@ tape('index place', function(t) {
         }
         docs.push(place);
     }
-    addFeature(conf.place, docs, t.end);
+    queueFeature(conf.place, docs, t.end);
     
 });
 

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -11,8 +11,8 @@ var rand = Math.random().toString(36).substr(2, 5);
 var tmpindex = path.join(tmpdir, 'test-carmen-index-' + rand + '.mbtiles');
 var tmpindex2 = path.join(tmpdir, 'test-carmen-index2-' + rand + '.mbtiles');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 tape('clean tmp index', function(assert) {
     try {

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -10,7 +10,9 @@ var MBTiles = require('mbtiles');
 var rand = Math.random().toString(36).substr(2, 5);
 var tmpindex = path.join(tmpdir, 'test-carmen-index-' + rand + '.mbtiles');
 var tmpindex2 = path.join(tmpdir, 'test-carmen-index2-' + rand + '.mbtiles');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 tape('clean tmp index', function(assert) {
     try {
@@ -45,7 +47,7 @@ tape('index', function(assert) {
     }
     function write1(err) {
         assert.ifError(err);
-        addFeature(conf.index, {
+        queueFeature(conf.index, {
             id:38,
             properties: {
                 'carmen:text':'Canada',
@@ -56,7 +58,7 @@ tape('index', function(assert) {
     }
     function write2(err) {
         assert.ifError(err);
-        addFeature(conf.index, {
+        queueFeature(conf.index, {
             id:39,
             properties: {
                 'carmen:text':'Brazil',

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -69,7 +69,7 @@ tape('index', function(assert) {
     }
     function store(err) {
         assert.ifError(err);
-        require('../lib/index.js').store(conf.index, stop);
+        buildQueued(conf.index, stop);
     }
     function stop(err) {
         assert.ifError(err);

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,4 +1,5 @@
-var Cache = require('../lib/util/cxxcache');
+var Cache = require('../lib/util/cxxcache').MemoryCache;
+var RocksDBCache = require('../lib/util/cxxcache').RocksDBCache;
 var test = require('tape');
 var fs = require('fs');
 
@@ -9,41 +10,34 @@ var tmpfile = function() { return tmpdir + "/" + (tmpidx++) + ".dat"; };
 
 test('#get', function(r) {
     var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    r.deepEqual([0, 1, 2], cache.get('grid', '5'));
-    r.throws(function() { cache.get('grid'); }, Error, 'throws on misuse');
+    cache.set('5', [0,1,2]);
+    r.deepEqual([0, 1, 2], cache.get('5'));
+    r.throws(function() { cache.get(); }, Error, 'throws on misuse');
     r.end();
 });
 
 test('#list', function(s) {
     var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    s.deepEqual(['5'], cache.list('grid'));
-    s.end();
-});
-
-test('#has', function(s) {
-    var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    s.deepEqual(true, cache.has('grid', 34566));
+    cache.set('5', [0,1,2]);
+    s.deepEqual(['5'], cache.list());
     s.end();
 });
 
 test('#get', function(s) {
     var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    s.deepEqual([0, 1, 2], cache.get('grid', '5'));
-    s.equal(undefined, cache._get('grid', '9'));
+    cache.set('5', [0,1,2]);
+    s.deepEqual([0, 1, 2], cache.get('5'));
+    s.equal(undefined, cache._get('9'));
     s.end();
 });
 
 test('#pack', function(s) {
     var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    //s.deepEqual(2065, cache.pack('grid', 34566).length);
+    cache.set('5', [0,1,2]);
+    //s.deepEqual(2065, cache.pack(34566).length);
     // set should replace data
-    cache.set('grid', '5', [0,1,2,4]);
-    //s.deepEqual(2066, cache.pack('grid', 34566).length);
+    cache.set('5', [0,1,2,4]);
+    //s.deepEqual(2066, cache.pack(34566).length);
     // throw on invalid grid
     s.throws(cache.set.bind(null, 'grid', '5', []), 'cache.set throws on empty grid value');
     // now test packing data created via load
@@ -52,15 +46,10 @@ test('#pack', function(s) {
     for (var i=0;i<10000;++i) {
         array.push(0);
     }
-    packer.set('grid', '5', array);
-    var loader = new Cache('a');
+    packer.set('5', array);
     var packed = tmpfile();
-    packer.pack(packed, 'grid');
-    loader.loadSync(packed, 'grid');
-    // grab data right back out
-    //s.deepEqual(12063, loader.pack('grid', 34566).length);
-    // try to grab data that does not exist
-    s.throws(function() { loader.pack('grid', 99999999999999) });
+    packer.pack(packed);
+    var loader = new RocksDBCache('a', packed);
     s.end();
 });
 
@@ -68,80 +57,23 @@ test('#load', function(s) {
     var cache = new Cache('a');
     s.equal('a', cache.id);
 
-    s.equal(undefined, cache.get('grid', '5'));
-    s.deepEqual([], cache.list('grid'));
+    s.equal(undefined, cache.get('5'));
+    s.deepEqual([], cache.list());
 
-    cache.set('grid', '5', [0,1,2]);
-    s.deepEqual([0,1,2], cache.get('grid', '5'));
-    s.deepEqual([ '5' ], cache.list('grid'));
+    cache.set('5', [0,1,2]);
+    s.deepEqual([0,1,2], cache.get('5'));
+    s.deepEqual([ '5' ], cache.list());
 
-    cache.set('grid', '21', [5,6]);
-    s.deepEqual([5,6], cache.get('grid', '21'));
-    s.deepEqual([ '21', '5' ], cache.list('grid'), 'keys in cache');
+    cache.set('21', [5,6]);
+    s.deepEqual([5,6], cache.get('21'));
+    s.deepEqual([ '21', '5' ], cache.list(), 'keys in cache');
 
     // cache A serializes data, cache B loads serialized data.
     var pack = tmpfile();
-    cache.pack(pack, 'grid');
-    var loader = new Cache('b');
-    loader.loadSync(pack, 'grid');
-    s.deepEqual([6,5], loader.get('grid', '21'));
-    s.deepEqual([ '21', '5'], loader.list('grid'), 'keys in cache');
-    s.end();
-});
-
-test('#unload on empty data', function(s) {
-    var cache = new Cache('a');
-    s.equal(false,cache.unload('grid'));
-    s.deepEqual(false, cache.has('grid'));
-    s.end();
-});
-
-test('#unload after set', function(s) {
-    var cache = new Cache('a');
-    cache.set('grid', '5', [0,1,2]);
-    s.deepEqual(true, cache.has('grid'));
-    s.equal(true,cache.unload('grid'));
-    s.deepEqual(false, cache.has('grid'));
-    s.end();
-});
-
-test('#unload after load', function(s) {
-    var cache = new Cache('a');
-    var array = [];
-    for (var i=0;i<10000;++i) {
-        array.push(0);
-    }
-    cache.set('grid', '5', array);
-    var pack = tmpfile();
-    cache.pack(pack, 'grid');
-    var loader = new Cache('b');
-    loader.loadSync(pack, 'grid');
-    s.deepEqual(array, loader.get('grid', '5'));
-    s.deepEqual(['5'], loader.list('grid'), 'single key');
-    s.deepEqual(true, loader.has('grid'));
-    s.equal(true,loader.unload('grid'));
-    s.deepEqual(false, loader.has('grid'));
-    s.end();
-});
-
-test('#unload', function(s) {
-    var cache = new Cache('a');
-    var array = [];
-    for (var i=0;i<10000;++i) {
-        array.push(0);
-    }
-    cache.set('grid', '5', array);
-    var pack = tmpfile();
-    cache.pack(pack, 'grid');
-
-    var loader = new Cache('b');
-    loader.loadSync(pack, 'grid');
-    s.deepEqual(array, loader.get('grid', '5'));
-    s.deepEqual(['5'], loader.list('grid'), 'many shards');
-    s.deepEqual(true, loader.has('grid'));
-    s.equal(true,loader.unload('grid'));
-    s.deepEqual(false, loader.has('grid'));
-    s.deepEqual([], loader.list('grid'), 'no keys');
+    cache.pack(pack);
+    var loader = new RocksDBCache('b', pack);
+    s.deepEqual([6,5], loader.get('21'));
+    s.deepEqual([ '21', '5'], loader.list(), 'keys in cache');
     s.end();
 });
 

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -49,7 +49,7 @@ test('#pack', function(s) {
     packer.set('5', array);
     var packed = tmpfile();
     packer.pack(packed);
-    var loader = new RocksDBCache('a', packed);
+    s.ok(new RocksDBCache('a', packed));
     s.end();
 });
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -4,7 +4,9 @@ var test = require('tape');
 var zlib = require('zlib');
 var path = require('path');
 var mapnik = require('mapnik');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 var mem = require('../lib/api-mem');
 
@@ -659,8 +661,8 @@ test('Context eliminates correct properties', function(assert) {
     };
 
     var q = queue(1);
-    q.defer(function(cb) { addFeature(conf.country, country, cb); });
-    q.defer(function(cb) { addFeature(conf.region, region, cb); });
+    q.defer(function(cb) { queueFeature(conf.country, country, cb); });
+    q.defer(function(cb) { queueFeature(conf.region, region, cb); });
     q.awaitAll(function() {
         c._open(function() {
             context(c, [0, 0], { full: false }, function(err, contexts) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -663,6 +663,8 @@ test('Context eliminates correct properties', function(assert) {
     var q = queue(1);
     q.defer(function(cb) { queueFeature(conf.country, country, cb); });
     q.defer(function(cb) { queueFeature(conf.region, region, cb); });
+    q.defer(function(cb) { buildQueued(conf.country, cb); });
+	q.defer(function(cb) { buildQueued(conf.region, cb); });
     q.awaitAll(function() {
         c._open(function() {
             context(c, [0, 0], { full: false }, function(err, contexts) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -5,8 +5,8 @@ var zlib = require('zlib');
 var path = require('path');
 var mapnik = require('mapnik');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 var mem = require('../lib/api-mem');
 
@@ -664,7 +664,7 @@ test('Context eliminates correct properties', function(assert) {
     q.defer(function(cb) { queueFeature(conf.country, country, cb); });
     q.defer(function(cb) { queueFeature(conf.region, region, cb); });
     q.defer(function(cb) { buildQueued(conf.country, cb); });
-	q.defer(function(cb) { buildQueued(conf.region, cb); });
+    q.defer(function(cb) { buildQueued(conf.region, cb); });
     q.awaitAll(function() {
         c._open(function() {
             context(c, [0, 0], { full: false }, function(err, contexts) {

--- a/test/fixtures/mem-dawg.json
+++ b/test/fixtures/mem-dawg.json
@@ -258,6 +258,11 @@
         }
     },
     "geocoder": {
-        "id": "to"
+        "freq": {
+            "id": "to.freq"
+        },
+        "grid": {
+            "id": "to.grid"
+        }
     }
 }

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 //Make sure that capital letters are lowercased on indexing to match input token
 (function() {
@@ -25,7 +27,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test address index for alphanumerics', function(t) {
         c.geocode('9B FAKE STREET', { limit_verify: 1 }, function(err, res) {
@@ -55,7 +57,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test address index for alphanumerics', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -85,7 +87,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test address query with alphanumeric', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -117,7 +119,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates:[[0,0],[0,100]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test alphanumeric address query with address range', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -160,7 +162,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates:[[0,0],[0,100]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test alphanumeric address query with address range', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -204,7 +206,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates:[[0,0],[0,100]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('index fake UK postcode', function(t) {
         var postcode = {
@@ -215,7 +217,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center': [0,0]
             }
         };
-        addFeature(conf.postcode, postcode, t.end);
+        queueFeature(conf.postcode, postcode, t.end);
     });
     tape('test UK postcode not getting confused w/ address range', function(t) {
         c.geocode('B77 1AB', { limit_verify: 10 }, function(err, res) {
@@ -249,7 +251,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates:[[0,0],[0,100]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test hyphenated address query with address range', function(t) {
         c.geocode('23-414 beach street', { limit_verify: 1 }, function(err, res) {

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 //Make sure that capital letters are lowercased on indexing to match input token
 (function() {
@@ -220,15 +220,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.postcode, postcode, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('test UK postcode not getting confused w/ address range', function(t) {
         c.geocode('B77 1AB', { limit_verify: 10 }, function(err, res) {
             t.equals(res.features[0].place_name, 'B77 1AB', 'found feature \'B77 1AB\'');

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -27,7 +28,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address index for alphanumerics', function(t) {
         c.geocode('9B FAKE STREET', { limit_verify: 1 }, function(err, res) {
@@ -57,7 +58,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address index for alphanumerics', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -87,7 +88,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address query with alphanumeric', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -119,7 +120,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates:[[0,0],[0,100]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test alphanumeric address query with address range', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -162,7 +163,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates:[[0,0],[0,100]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test alphanumeric address query with address range', function(t) {
         c.geocode('9b fake street', { limit_verify: 1 }, function(err, res) {
@@ -219,6 +220,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.postcode, postcode, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('test UK postcode not getting confused w/ address range', function(t) {
         c.geocode('B77 1AB', { limit_verify: 10 }, function(err, res) {
             t.equals(res.features[0].place_name, 'B77 1AB', 'found feature \'B77 1AB\'');
@@ -251,7 +261,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates:[[0,0],[0,100]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test hyphenated address query with address range', function(t) {
         c.geocode('23-414 beach street', { limit_verify: 1 }, function(err, res) {

--- a/test/geocode-unit.address-bitmask.test.js
+++ b/test/geocode-unit.address-bitmask.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})

--- a/test/geocode-unit.address-bitmask.test.js
+++ b/test/geocode-unit.address-bitmask.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})
@@ -23,7 +25,7 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 tape('index address', function(t) {
     var address = {
@@ -38,7 +40,7 @@ tape('index address', function(t) {
             coordinates: [[0,0], [0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 tape('index address', function(t) {
     var address = {
@@ -53,7 +55,7 @@ tape('index address', function(t) {
             coordinates: [[0,0],[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('full address', function(t) {

--- a/test/geocode-unit.address-bitmask.test.js
+++ b/test/geocode-unit.address-bitmask.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -57,6 +58,15 @@ tape('index address', function(t) {
     };
     queueFeature(conf.address, address, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('full address', function(t) {
     c.geocode('500 baker street', { limit_verify: 2 }, function(err, res) {
@@ -107,6 +117,13 @@ tape('numbered street address', function(t) {
         t.end();
     });
 });
+tape('numbered street address', function(t) {
+    c.geocode('15th street 500b', { limit_verify: 2 }, function(err, res) {
+        t.ifError(err);
+        t.equals(res.features[0].address, '500b');
+        t.end();
+    });
+});
 
 // @TODO maskAddress needs to select multiple candidate addresses now...
 tape.skip('test de - number street with address', function(t) {
@@ -131,4 +148,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Test geocoder_address formatting + return place_name as germany style address (address number follows name)
 (function() {
@@ -26,7 +28,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('Search for germany style address', function(t) {
@@ -68,7 +70,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('Search for germany style address - with language tag but no german vaue', function(t) {
@@ -128,7 +130,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
 
     tape('index region', function(t) {
@@ -144,7 +146,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.region, region, t.end);
+        queueFeature(conf.region, region, t.end);
     });
 
     tape('index place', function(t) {
@@ -160,7 +162,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
 
     tape('index postcode', function(t) {
@@ -176,7 +178,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.postcode, postcode, t.end);
+        queueFeature(conf.postcode, postcode, t.end);
     });
 
     tape('index address', function(t) {
@@ -192,7 +194,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('index poi', function(t) {
@@ -208,7 +210,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.poi, poi, t.end);
+        queueFeature(conf.poi, poi, t.end);
     });
     tape('Search for an address (multiple layers)', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
@@ -258,7 +260,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('test address index for US relev', function(t) {
@@ -308,7 +310,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test address index for relev', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
@@ -339,7 +341,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index kitten', function(t) {
         var kitten = {
@@ -355,7 +357,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.kitten, kitten, t.end);
+        queueFeature(conf.kitten, kitten, t.end);
     });
 
     tape('Search for an address using a template that has nonstandard properites', function(t) {

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Test geocoder_address formatting + return place_name as germany style address (address number follows name)
 (function() {

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -28,7 +29,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
 
     tape('Search for germany style address', function(t) {
@@ -70,7 +71,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
 
     tape('Search for germany style address - with language tag but no german vaue', function(t) {
@@ -212,6 +213,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('Search for an address (multiple layers)', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
             t.ifError(err);
@@ -260,7 +270,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
 
     tape('test address index for US relev', function(t) {
@@ -310,7 +320,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [0,0]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address index for relev', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
@@ -358,6 +368,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         };
         queueFeature(conf.kitten, kitten, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('Search for an address using a template that has nonstandard properites', function(t) {

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -28,7 +28,7 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates:[[0,0],[0,100]]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address query with address range', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
@@ -63,7 +63,7 @@ var addFeature = require('../lib/util/addfeature'),
                 ]
             }
         };
-        queueFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
 
     tape('test tiger interpolation house number', function(t) {

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -26,7 +28,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates:[[0,0],[0,100]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('test address query with address range', function(t) {
         c.geocode('9 fake street', { limit_verify: 1 }, function(err, res) {
@@ -61,7 +63,7 @@ var addFeature = require('../lib/util/addfeature');
                 ]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('test tiger interpolation house number', function(t) {

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {

--- a/test/geocode-unit.backy.test.js
+++ b/test/geocode-unit.backy.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -58,6 +59,15 @@ tape('index street 2', function(t) {
     };
     queueFeature(conf.street, street, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('lessingstrasse koln 50825', function(t) {
     c.geocode('lessingstrasse koln 50825', { limit_verify:1 }, function(err, res) {
         t.ifError(err);
@@ -81,4 +91,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.backy.test.js
+++ b/test/geocode-unit.backy.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     postcode: new mem(null, function() {}),

--- a/test/geocode-unit.backy.test.js
+++ b/test/geocode-unit.backy.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     postcode: new mem(null, function() {}),
@@ -21,7 +23,7 @@ tape('index postcode', function(t) {
             'carmen:center': [0,0]
         }
     };
-    addFeature(conf.postcode, doc, t.end);
+    queueFeature(conf.postcode, doc, t.end);
 });
 tape('index city', function(t) {
     var city = {
@@ -32,7 +34,7 @@ tape('index city', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index street 1', function(t) {
     var street = {
@@ -43,7 +45,7 @@ tape('index street 1', function(t) {
             'carmen:center': [0,0]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('index street 2', function(t) {
     var street = {
@@ -54,7 +56,7 @@ tape('index street 2', function(t) {
             'carmen:center': [360/64+0.001,0]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('lessingstrasse koln 50825', function(t) {
     c.geocode('lessingstrasse koln 50825', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.bbox.test.js
+++ b/test/geocode-unit.bbox.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -57,6 +58,15 @@ tape('index feature', function(t) {
         }
     };
     queueFeature(conf.street, feature, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 // run query with invalid bbox, expect error

--- a/test/geocode-unit.bbox.test.js
+++ b/test/geocode-unit.bbox.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     street: new mem(null, function() {})
@@ -15,7 +17,7 @@ tape('index feature', function(t) {
     for (var i = 1; i < 100; i++) range.push(i);
     range.forEach(function(i) {
         t.test('addFeature', function(tt) {
-            addFeature(conf.street, {
+            queueFeature(conf.street, {
                 id:i,
                 properties: {
                     'carmen:text':'Main Street',
@@ -41,7 +43,7 @@ tape('index feature', function(t) {
             'carmen:score': 1,
         }
     };
-    addFeature(conf.street, feature, t.end);
+    queueFeature(conf.street, feature, t.end);
 });
 
 tape('index feature', function(t) {
@@ -54,7 +56,7 @@ tape('index feature', function(t) {
             'carmen:score': 1,
         }
     };
-    addFeature(conf.street, feature, t.end);
+    queueFeature(conf.street, feature, t.end);
 });
 
 // run query with invalid bbox, expect error

--- a/test/geocode-unit.bbox.test.js
+++ b/test/geocode-unit.bbox.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     street: new mem(null, function() {})

--- a/test/geocode-unit.byid.test.js
+++ b/test/geocode-unit.byid.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.byid.test.js
+++ b/test/geocode-unit.byid.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -35,6 +36,15 @@ tape('index place', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('query byid', function(t) {
     c.geocode('country.1', {}, function(err, res) {
@@ -60,4 +70,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.byid.test.js
+++ b/test/geocode-unit.byid.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -13,7 +15,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:text': 'china',
@@ -24,7 +26,7 @@ tape('index country', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         properties: {
             'carmen:text':'chicago',

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     addressitp: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {}),
@@ -25,7 +27,7 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 tape('index addressitp', function(t) {
     var addressitp = {
@@ -47,7 +49,7 @@ tape('index addressitp', function(t) {
             coordinates:[[0,0],[0,1]]
         }
     };
-    addFeature(conf.addressitp, addressitp, t.end);
+    queueFeature(conf.addressitp, addressitp, t.end);
 });
 tape('test address query with address range', function(t) {
     c.geocode('100 fake street', { limit_verify: 2 }, function(err, res) {

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -51,6 +52,15 @@ tape('index addressitp', function(t) {
     };
     queueFeature(conf.addressitp, addressitp, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('test address query with address range', function(t) {
     c.geocode('100 fake street', { limit_verify: 2 }, function(err, res) {
         t.ifError(err);
@@ -74,4 +84,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     addressitp: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {}),

--- a/test/geocode-unit.context-overlap.test.js
+++ b/test/geocode-unit.context-overlap.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     place_a: new mem({maxzoom:6, geocoder_name:'place'}, function() {}),

--- a/test/geocode-unit.context-overlap.test.js
+++ b/test/geocode-unit.context-overlap.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -55,6 +56,15 @@ tape('index street_b', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('geocoder_name dedupe', function(t) {
     c.geocode('main street', { limit_verify:1 }, function(err, res) {
         t.ifError(err);
@@ -70,4 +80,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.context-overlap.test.js
+++ b/test/geocode-unit.context-overlap.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     place_a: new mem({maxzoom:6, geocoder_name:'place'}, function() {}),
@@ -14,7 +16,7 @@ var conf = {
 };
 var c = new Carmen(conf);
 tape('index place_a', function(t) {
-    addFeature(conf.place_a, {
+    queueFeature(conf.place_a, {
         id:1,
         properties: {
             'carmen:text': 'sadtown',
@@ -24,7 +26,7 @@ tape('index place_a', function(t) {
     }, t.end);
 });
 tape('index place_b', function(t) {
-    addFeature(conf.place_b, {
+    queueFeature(conf.place_b, {
         id:2,
         properties: {
             'carmen:text':'funtown',
@@ -34,7 +36,7 @@ tape('index place_b', function(t) {
     }, t.end);
 });
 tape('index street_a', function(t) {
-    addFeature(conf.street_a, {
+    queueFeature(conf.street_a, {
         id:2,
         properties: {
             'carmen:text':'wall street',
@@ -44,7 +46,7 @@ tape('index street_a', function(t) {
     }, t.end);
 });
 tape('index street_b', function(t) {
-    addFeature(conf.street_b, {
+    queueFeature(conf.street_b, {
         id:1,
         properties: {
             'carmen:text':'main street',

--- a/test/geocode-unit.dataterm-only.test.js
+++ b/test/geocode-unit.dataterm-only.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -26,6 +27,15 @@ tape('index address (dataterm only)', function(t) {
     };
     queueFeature(conf.address, address, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('test address', function(t) {
     c.geocode('100', { limit_verify: 1 }, function(err, res) {
@@ -39,4 +49,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.dataterm-only.test.js
+++ b/test/geocode-unit.dataterm-only.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})
@@ -22,7 +24,7 @@ tape('index address (dataterm only)', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('test address', function(t) {

--- a/test/geocode-unit.dataterm-only.test.js
+++ b/test/geocode-unit.dataterm-only.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})

--- a/test/geocode-unit.dataterm-vs-postcode.test.js
+++ b/test/geocode-unit.dataterm-vs-postcode.test.js
@@ -57,6 +57,15 @@ tape('index postcode', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('test address', function(t) {
     c.geocode('2000 Austria', { limit_verify: 5 }, function(err, res) {
@@ -70,4 +79,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.dataterm-vs-postcode.test.js
+++ b/test/geocode-unit.dataterm-vs-postcode.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 6, geocoder_name:'country'}, function() {}),

--- a/test/geocode-unit.dataterm-vs-postcode.test.js
+++ b/test/geocode-unit.dataterm-vs-postcode.test.js
@@ -3,7 +3,9 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 6, geocoder_name:'country'}, function() {}),
@@ -29,13 +31,13 @@ tape('index address (noise)', function(t) {
                 coordinates: [[i,0]]
             }
         };
-        addFeature(conf.address, address, done);
+        queueFeature(conf.address, address, done);
     }, i);
     q.awaitAll(t.end);
 });
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:text':'Austria',
@@ -46,7 +48,7 @@ tape('index country', function(t) {
 });
 
 tape('index postcode', function(t) {
-    addFeature(conf.postcode, {
+    queueFeature(conf.postcode, {
         id:1,
         properties: {
             'carmen:text':'2000',

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -47,6 +47,15 @@ tape('index address (signal)', function(t) {
     };
     queueFeature(conf.address, address, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('test address', function(t) {
     c.geocode('1500 fake street', { limit_verify: 1 }, function(err, res) {
@@ -61,4 +70,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -3,7 +3,9 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})
@@ -25,7 +27,7 @@ tape('index address (noise)', function(t) {
                 coordinates: [[0,0]]
             }
         };
-        addFeature(conf.address, address, done);
+        queueFeature(conf.address, address, done);
     }, i);
     q.awaitAll(t.end);
 });
@@ -43,7 +45,7 @@ tape('index address (signal)', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('test address', function(t) {

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     province: new mem(null, function() {}),
@@ -19,7 +21,7 @@ tape('index province', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
 });
 tape('index city 1', function(t) {
     var city = {
@@ -30,7 +32,7 @@ tape('index city 1', function(t) {
             'carmen:center':[0,0]
         }
     }
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index city 2', function(t) {
     var city = {
@@ -41,7 +43,7 @@ tape('index city 2', function(t) {
             'carmen:center':[14.0625, -2.8079929095776683]
         }
     };
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index street 1', function(t) {
     var street = {
@@ -52,7 +54,7 @@ tape('index street 1', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('index street 2', function(t) {
     var street = {
@@ -63,7 +65,7 @@ tape('index street 2', function(t) {
             'carmen:center':[14.0625, -2.8079929095776683]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('west st, tonawanda, ny', function(t) {
     c.geocode('west st tonawanda ny', { limit_verify:1, debug:4 }, function(err, res) {

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     province: new mem(null, function() {}),

--- a/test/geocode-unit.debug.test.js
+++ b/test/geocode-unit.debug.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -66,6 +67,15 @@ tape('index street 2', function(t) {
         }
     };
     queueFeature(conf.street, street, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 tape('west st, tonawanda, ny', function(t) {
     c.geocode('west st tonawanda ny', { limit_verify:1, debug:4 }, function(err, res) {
@@ -144,5 +154,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-
-

--- a/test/geocode-unit.dict-collision.test.js
+++ b/test/geocode-unit.dict-collision.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem(null, function() {}),
@@ -18,7 +20,7 @@ tape('index unicode place', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('valid match', function(t) {

--- a/test/geocode-unit.dict-collision.test.js
+++ b/test/geocode-unit.dict-collision.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -22,6 +23,15 @@ tape('index unicode place', function(t) {
     };
     queueFeature(conf.place, place, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('valid match', function(t) {
     c.geocode('京都市', { limit_verify:1 }, function(err, res) {
@@ -35,5 +45,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-
-

--- a/test/geocode-unit.dict-collision.test.js
+++ b/test/geocode-unit.dict-collision.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem(null, function() {}),

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -26,7 +27,23 @@ tape('index address', function(t) {
     };
     queueFeature(conf.address, address, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
+tape('test address', function(t) {
+    c.geocode('56 Brehmestr.', { limit_verify: 1 }, function(err, res) {
+        t.ifError(err);
+        t.equals(res.features[0] && res.features[0].place_name, 'Brehmestraße 56');
+        t.end();
+    });
+});
 tape('test address', function(t) {
     c.geocode('56 Brehmestr.', { limit_verify: 1 }, function(err, res) {
         t.ifError(err);

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_format: '{address._name} {address._number}', geocoder_name:'address'}, function() {})

--- a/test/geocode-unit.early-degen.test.js
+++ b/test/geocode-unit.early-degen.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_format: '{address._name} {address._number}', geocoder_name:'address'}, function() {})
@@ -22,7 +24,7 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('test address', function(t) {

--- a/test/geocode-unit.emoji.test.js
+++ b/test/geocode-unit.emoji.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {})

--- a/test/geocode-unit.emoji.test.js
+++ b/test/geocode-unit.emoji.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -40,6 +41,15 @@ tape('index non-emoji country', function(assert) {
         }
     }, assert.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('should not find emoji feaure', function(assert) {
     // Line smiley
@@ -73,4 +83,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.emoji.test.js
+++ b/test/geocode-unit.emoji.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {})
@@ -10,7 +12,7 @@ var conf = {
 
 var c = new Carmen(conf);
 tape('index emoji country', function(assert) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id: 1,
         geometry: {
             type: 'Point',
@@ -25,7 +27,7 @@ tape('index emoji country', function(assert) {
 });
 
 tape('index non-emoji country', function(assert) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id: 2,
         geometry: {
             type: 'Point',

--- a/test/geocode-unit.fallback.js
+++ b/test/geocode-unit.fallback.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom: 6}, function() {}),

--- a/test/geocode-unit.fallback.js
+++ b/test/geocode-unit.fallback.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -115,6 +116,15 @@ tape('index region "Washington" lines up with Seattle', function(t) {
         }
     };
     queueFeature(conf.region, region, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 //Make a mismatched query with a street(100 Main St - containing 3 tokens) in Cold City and postcode, place and region layers lining up with Seattle, Washington

--- a/test/geocode-unit.fallback.js
+++ b/test/geocode-unit.fallback.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom: 6}, function() {}),
@@ -28,7 +30,7 @@ tape('index place "Cold City"', function(t) {
             coordinates: coldCityCenter
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 //Address 1 in Cold City
@@ -46,7 +48,7 @@ tape('index address "Main St" in "Cold City"', function(t) {
             coordinates: [coldCityCenter]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 //Address 2 in Cold City
@@ -63,7 +65,7 @@ tape('index address "Market" in "Cold City"', function(t) {
             coordinates: [coldCityCenter]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 //Place 2: Seattle
@@ -80,7 +82,7 @@ tape('index place Seattle', function(t) {
             coordinates: seattleCenter
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 //Postcode 1: Centered to line up with Seattle
@@ -96,7 +98,7 @@ tape('index postcode "12345" in Seattle', function(t) {
             coordinates: seattleCenter
         }
     };
-    addFeature(conf.postcode, postcode, t.end);
+    queueFeature(conf.postcode, postcode, t.end);
 });
 
 //Region 1: Centered to line up with Seattle 
@@ -112,7 +114,7 @@ tape('index region "Washington" lines up with Seattle', function(t) {
             coordinates: seattleCenter
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 //Make a mismatched query with a street(100 Main St - containing 3 tokens) in Cold City and postcode, place and region layers lining up with Seattle, Washington

--- a/test/geocode-unit.featurenoop.test.js
+++ b/test/geocode-unit.featurenoop.test.js
@@ -7,8 +7,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueVT = addFeature.queueVT,
-	buildQueued = addFeature.buildQueued;
+    queueVT = addFeature.queueVT,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     a: new mem(null, function() {}),

--- a/test/geocode-unit.featurenoop.test.js
+++ b/test/geocode-unit.featurenoop.test.js
@@ -6,7 +6,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     a: new mem(null, function() {}),

--- a/test/geocode-unit.featurenoop.test.js
+++ b/test/geocode-unit.featurenoop.test.js
@@ -7,7 +7,7 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
+	queueVT = addFeature.queueVT,
 	buildQueued = addFeature.buildQueued;
 
 var conf = {
@@ -15,14 +15,14 @@ var conf = {
 };
 var c = new Carmen(conf);
 tape('index', function(t) {
-    addFeature.vt(conf.a, {
+    queueVT(conf.a, {
         id:1,
         properties: {
             'carmen:text':'\n',
             'carmen:zxy':['6/32/32'],
             'carmen:center':[0,0]
         }
-    }, t.end);
+    }, function() { buildQueued(conf.a, t.end) });
 });
 tape('reverse geocode', function(t) {
     c.geocode('0,0', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -2,14 +2,16 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({ maxzoom:6, geocoder_address: 1 }, function() {})
 };
 var c = new Carmen(conf);
 tape('index "av francisco de aguirre #"', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:1,
         properties: {
             'carmen:text':'av francisco de aguirre',
@@ -23,7 +25,7 @@ tape('index "av francisco de aguirre #"', function(t) {
     }, t.end);
 });
 tape('index "# r ademar da silva neiva"', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:2,
         properties: {
             'carmen:text':'r ademar da silva neiva',

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -38,6 +39,15 @@ tape('index "# r ademar da silva neiva"', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 // partial unidecoded terms do not match
 tape('search: "av francisco de aguirre 2 la serena"', function(t) {
     c.geocode('av francisco de aguirre 2 la serena', { limit_verify:2 }, function(err, res) {
@@ -51,4 +61,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.fnv1a-collision.test.js
+++ b/test/geocode-unit.fnv1a-collision.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({ maxzoom:6, geocoder_address: 1 }, function() {})

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // limit_verify 1 implies that the correct result must be the very top
 // result prior to context verification. It means even with a long list
@@ -29,7 +31,7 @@ tape('index province', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
 });
 tape('index city 1', function(t) {
     var city = {
@@ -40,7 +42,7 @@ tape('index city 1', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index city 2', function(t) {
     var city = {
@@ -51,7 +53,7 @@ tape('index city 2', function(t) {
             'carmen:center':[14.0625, -2.8079929095776683]
         }
     };
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index street 1', function(t) {
     var street = {
@@ -62,7 +64,7 @@ tape('index street 1', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('index street 2', function(t) {
     var street = {
@@ -73,7 +75,7 @@ tape('index street 2', function(t) {
             'carmen:center':[14.0625, -2.8079929095776683]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
 });
 tape('west st, tonawanda, ny', function(t) {
     c.geocode('west st tonawanda ny', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -77,6 +78,15 @@ tape('index street 2', function(t) {
     };
     queueFeature(conf.street, street, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('west st, tonawanda, ny', function(t) {
     c.geocode('west st tonawanda ny', { limit_verify:1 }, function(err, res) {
         t.ifError(err);
@@ -128,4 +138,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.gappy.test.js
+++ b/test/geocode-unit.gappy.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // limit_verify 1 implies that the correct result must be the very top
 // result prior to context verification. It means even with a long list

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -45,6 +46,16 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
+
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('Invalid stack - not a stack name', function(t) {
         c.geocode('0,0', { stacks: ['zz'] }, function(err, res) {
@@ -160,6 +171,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     //Features are first filtered by the index level geocoder_stack
     //At the end each feature is then filtered by the feature level geocoder_stack
@@ -228,6 +248,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('Canada', function(t) {
         c.geocode('Canada', { stacks: ['ca'] }, function(err, res) {
@@ -293,6 +322,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('check stack/idx agreement', function(t) {
         c.geocode('XXX', { stacks: ['ca'] }, function(err, res) {
@@ -347,6 +385,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('Canada', function(t) {
         c.geocode('Canada', { stacks: ['ca'] }, function(err, res) {

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 //Tests string value for index level geocoder_stack
 (function() {
@@ -23,7 +25,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country ca', function(t) {
-        addFeature(conf.ca, {
+        queueFeature(conf.ca, {
             id:1,
             properties: {
                 'carmen:text':'Canada',
@@ -34,7 +36,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index country us', function(t) {
-        addFeature(conf.us, {
+        queueFeature(conf.us, {
             id:1,
             properties: {
                 'carmen:text': 'United States',
@@ -115,7 +117,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country ca', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:text':'Canada',
@@ -126,7 +128,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index country us', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:2,
             properties: {
                 'carmen:text':'United States',
@@ -137,7 +139,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index place us', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:1,
             properties: {
                 'carmen:text':'Place',
@@ -148,7 +150,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index place ca', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:2,
             properties: {
                 'carmen:text':'Place',
@@ -196,7 +198,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country ca', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:text':'Canada',
@@ -206,7 +208,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index country us', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:2,
             properties: {
                 'carmen:text':'United States',
@@ -216,7 +218,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index place ca', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:1,
             properties: {
                 'carmen:text':'Tess',
@@ -268,7 +270,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country high score (us)', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:text': 'XXX',
@@ -280,7 +282,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index place low score (ca)', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:2,
             properties: {
                 'carmen:text':'XXX',
@@ -316,7 +318,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country ca', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:text':'Canada',
@@ -326,7 +328,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index country us', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:2,
             properties: {
                 'carmen:text':'United States',
@@ -336,7 +338,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index place ca', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:1,
             properties: {
                 'carmen:text':'Tess',

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 //Tests string value for index level geocoder_stack
 (function() {
@@ -47,15 +47,15 @@ var addFeature = require('../lib/util/addfeature'),
         }, t.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('Invalid stack - not a stack name', function(t) {
         c.geocode('0,0', { stacks: ['zz'] }, function(err, res) {
@@ -171,15 +171,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     //Features are first filtered by the index level geocoder_stack
     //At the end each feature is then filtered by the feature level geocoder_stack
@@ -248,15 +248,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('Canada', function(t) {
         c.geocode('Canada', { stacks: ['ca'] }, function(err, res) {
@@ -322,15 +322,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('check stack/idx agreement', function(t) {
         c.geocode('XXX', { stacks: ['ca'] }, function(err, res) {
@@ -385,15 +385,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('Canada', function(t) {
         c.geocode('Canada', { stacks: ['ca'] }, function(err, res) {

--- a/test/geocode-unit.geocoder_type.test.js
+++ b/test/geocode-unit.geocoder_type.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -24,7 +26,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[-77.04312264919281,38.91041215085371]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('index poi', function(t) {
         var poi = {
@@ -39,7 +41,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [-77.04441547393799,38.909427030614665]
             }
         };
-        addFeature(conf.poi, poi, t.end);
+        queueFeature(conf.poi, poi, t.end);
     });
 
     tape('query on address but still returns poi due to index order', function(t) {
@@ -89,7 +91,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[-77.04312264919281,38.91041215085371]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('index poi', function(t) {
         var poi = {
@@ -104,7 +106,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [-77.04441547393799,38.909427030614665]
             }
         };
-        addFeature(conf.poi, poi, t.end);
+        queueFeature(conf.poi, poi, t.end);
     });
     tape('address query returns address', function(t) {
         c.geocode('-77.04312264919281,38.91041215085371', {}, function(err, res) {
@@ -160,7 +162,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[-77.04312264919281,38.91041215085371]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('index poi', function(t) {
         var poi = {
@@ -175,7 +177,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [-77.04320579767227,38.910435109001334]
             }
         };
-        addFeature(conf.poi, poi, t.end);
+        queueFeature(conf.poi, poi, t.end);
     });
     tape('return poi if type filtering removes address', function(t) {
         c.geocode('-77.04320579767227,38.910435109001334', { types: ['poi'] }, function(err, res) {
@@ -223,7 +225,7 @@ var addFeature = require('../lib/util/addfeature');
                 ]]]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index place', function(t) {
         var place = {
@@ -248,7 +250,7 @@ var addFeature = require('../lib/util/addfeature');
                 ]]]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('Overlapping places return closest centroid', function(t) {
         c.geocode('-77.0378065109253,38.909836107628074', {}, function(err, res) {

--- a/test/geocode-unit.geocoder_type.test.js
+++ b/test/geocode-unit.geocoder_type.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require("d3-queue").queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -44,15 +44,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('query on address but still returns poi due to index order', function(t) {
         c.geocode('-77.04312264919281,38.91041215085371', {}, function(err, res) {
@@ -118,15 +118,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('address query returns address', function(t) {
         c.geocode('-77.04312264919281,38.91041215085371', {}, function(err, res) {
             t.ifError(err);
@@ -198,15 +198,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('return poi if type filtering removes address', function(t) {
         c.geocode('-77.04320579767227,38.910435109001334', { types: ['poi'] }, function(err, res) {
             t.ifError(err);
@@ -280,15 +280,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.place, place, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('Overlapping places return closest centroid', function(t) {
         c.geocode('-77.0378065109253,38.909836107628074', {}, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.geocoder_type.test.js
+++ b/test/geocode-unit.geocoder_type.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require("d3-queue").queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -43,6 +44,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('query on address but still returns poi due to index order', function(t) {
         c.geocode('-77.04312264919281,38.91041215085371', {}, function(err, res) {
@@ -108,6 +118,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('address query returns address', function(t) {
         c.geocode('-77.04312264919281,38.91041215085371', {}, function(err, res) {
             t.ifError(err);
@@ -179,6 +198,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.poi, poi, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('return poi if type filtering removes address', function(t) {
         c.geocode('-77.04320579767227,38.910435109001334', { types: ['poi'] }, function(err, res) {
             t.ifError(err);
@@ -252,6 +280,15 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.place, place, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('Overlapping places return closest centroid', function(t) {
         c.geocode('-77.0378065109253,38.909836107628074', {}, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.index-context.test.js
+++ b/test/geocode-unit.index-context.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Test that geocoder returns index names for context
 (function() {

--- a/test/geocode-unit.index-context.test.js
+++ b/test/geocode-unit.index-context.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -94,6 +95,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         };
         queueFeature(conf.address, address, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('Search for an address & check indexes', function(t) {

--- a/test/geocode-unit.index-context.test.js
+++ b/test/geocode-unit.index-context.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Test that geocoder returns index names for context
 (function() {
@@ -27,7 +29,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
 
     tape('index region', function(t) {
@@ -43,7 +45,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.region, region, t.end);
+        queueFeature(conf.region, region, t.end);
     });
 
     tape('index place', function(t) {
@@ -59,7 +61,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
 
     tape('index postcode', function(t) {
@@ -75,7 +77,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.postcode, postcode, t.end);
+        queueFeature(conf.postcode, postcode, t.end);
     });
 
     tape('index address', function(t) {
@@ -91,7 +93,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [[0,0],[0,0],[0,0]]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
 
     tape('Search for an address & check indexes', function(t) {

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -26,6 +27,15 @@ tape('index place', function(assert) {
         }
     }, assert.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('query place', function(t) {
     c.geocode('Chicago', { limit_verify: 1 }, function(err, res) {
         t.ifError(err);
@@ -47,4 +57,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {};
 for (var i = 0; i < 127; i++) {
@@ -15,7 +17,7 @@ conf['place'] = new mem({maxzoom: 6, geocoder_name:'place'}, function() {});
 var c = new Carmen(conf);
 tape('index place', function(assert) {
     assert.deepEqual(Object.keys(conf).length, 128, '128 indexes configured');
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         properties: {
             'carmen:text':'Chicago',

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {};
 for (var i = 0; i < 127; i++) {

--- a/test/geocode-unit.io-autocomplete.test.js
+++ b/test/geocode-unit.io-autocomplete.test.js
@@ -5,10 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {
@@ -33,7 +32,7 @@ tape('index place', function(assert) {
             }
         });
     }
-	queueFeature(conf.place, docs, function() { buildQueued(conf.place, assert.end) })
+    queueFeature(conf.place, docs, function() { buildQueued(conf.place, assert.end) })
 });
 
 function reset() {

--- a/test/geocode-unit.io-autocomplete.test.js
+++ b/test/geocode-unit.io-autocomplete.test.js
@@ -6,7 +6,9 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {

--- a/test/geocode-unit.io-autocomplete.test.js
+++ b/test/geocode-unit.io-autocomplete.test.js
@@ -21,10 +21,10 @@ tape('ready', function(assert) {
 });
 
 tape('index place', function(assert) {
-    var q = queue(1);
+    var docs = [];
     for (var i = 1; i < 100; i++) {
         var text = Math.random().toString().split('.').pop().toString(36);
-        q.defer(addFeature, conf.place, {
+        docs.push({
             id:i,
             properties: {
                 'carmen:text': 'aa' + text,
@@ -33,7 +33,7 @@ tape('index place', function(assert) {
             }
         });
     }
-    q.awaitAll(assert.end);
+	queueFeature(conf.place, docs, function() { buildQueued(conf.place, assert.end) })
 });
 
 function reset() {

--- a/test/geocode-unit.io-reverse.test.js
+++ b/test/geocode-unit.io-reverse.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {

--- a/test/geocode-unit.io-reverse.test.js
+++ b/test/geocode-unit.io-reverse.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -62,6 +63,15 @@ tape('index street', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 function resetLogs() {
     context.getTile.cache.reset();
@@ -113,4 +123,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.io-reverse.test.js
+++ b/test/geocode-unit.io-reverse.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {
@@ -21,7 +23,7 @@ tape('ready', function(assert) {
 });
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:text':'us',
@@ -31,7 +33,7 @@ tape('index country', function(t) {
     }, t.end);
 });
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id:1,
         properties: {
             'carmen:text':'ohio',
@@ -41,7 +43,7 @@ tape('index region', function(t) {
     }, t.end);
 });
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         properties: {
             'carmen:text':'springfield',
@@ -51,7 +53,7 @@ tape('index place', function(t) {
     }, t.end);
 });
 tape('index street', function(t) {
-    addFeature(conf.street, {
+    queueFeature(conf.street, {
         id:1,
         properties: {
             'carmen:text':'river rd',

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -64,6 +65,15 @@ tape('ready', function(assert) {
                 'carmen:center':[0,0]
             }
         }, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 });
 
@@ -133,4 +143,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {

--- a/test/geocode-unit.io-stack.test.js
+++ b/test/geocode-unit.io-stack.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Setup includes the api-mem `timeout` option to simulate asynchronous I/O.
 var conf = {
@@ -24,7 +26,7 @@ tape('ready', function(assert) {
 
 [1,2,3].forEach(function(i) {
     tape('index place ' + i, function(t) {
-        addFeature(conf['place'+i], {
+        queueFeature(conf['place'+i], {
             id:1,
             properties: {
                 'carmen:text':'springfield',
@@ -34,7 +36,7 @@ tape('ready', function(assert) {
         }, t.end);
     });
     tape('index street ' + i, function(t) {
-        addFeature(conf['street'+i], {
+        queueFeature(conf['street'+i], {
             id:1,
             properties: {
                 'carmen:text':'winding river rd',
@@ -44,7 +46,7 @@ tape('ready', function(assert) {
         }, t.end);
     });
     tape('index street ' + i, function(t) {
-        addFeature(conf['street'+i], {
+        queueFeature(conf['street'+i], {
             id:2,
             properties: {
                 'carmen:text':'river rd',
@@ -54,7 +56,7 @@ tape('ready', function(assert) {
         }, t.end);
     });
     tape('index street ' + i, function(t) {
-        addFeature(conf['street'+i], {
+        queueFeature(conf['street'+i], {
             id:3,
             properties: {
                 'carmen:text':'springfield st',

--- a/test/geocode-unit.jp-numeric.test.js
+++ b/test/geocode-unit.jp-numeric.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -25,7 +27,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region', function(t) {
@@ -37,7 +39,7 @@ tape('index region', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index place 1', function(t) {
@@ -49,7 +51,7 @@ tape('index place 1', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index address 1', function(t) {
@@ -66,7 +68,7 @@ tape('index address 1', function(t) {
             coordinates: [[0,0],[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('Check numeric text', function(t) {

--- a/test/geocode-unit.jp-numeric.test.js
+++ b/test/geocode-unit.jp-numeric.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.jp-numeric.test.js
+++ b/test/geocode-unit.jp-numeric.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -69,6 +70,15 @@ tape('index address 1', function(t) {
         }
     };
     queueFeature(conf.address, address, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('Check numeric text', function(t) {

--- a/test/geocode-unit.jp-order.test.js
+++ b/test/geocode-unit.jp-order.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -21,7 +23,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region', function(t) {
@@ -33,7 +35,7 @@ tape('index region', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index place 1', function(t) {
@@ -45,7 +47,7 @@ tape('index place 1', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index address 1', function(t) {
@@ -62,7 +64,7 @@ tape('index address 1', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('Check order, 岩出市中黒632', function(t) {

--- a/test/geocode-unit.jp-order.test.js
+++ b/test/geocode-unit.jp-order.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.jp-order.test.js
+++ b/test/geocode-unit.jp-order.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -66,6 +67,15 @@ tape('index address 1', function(t) {
     };
     queueFeature(conf.address, address, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('Check order, 岩出市中黒632', function(t) {
     c.geocode('岩出市中黒632', { limit_verify: 1}, function(err, res) {
@@ -97,4 +107,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.language-flag-bogus.test.js
+++ b/test/geocode-unit.language-flag-bogus.test.js
@@ -7,8 +7,8 @@ var mem = require('../lib/api-mem');
 var context = require('../lib/context');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {

--- a/test/geocode-unit.language-flag-bogus.test.js
+++ b/test/geocode-unit.language-flag-bogus.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -32,7 +34,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
 
     tape('0,0 ?language=en', function(t) {

--- a/test/geocode-unit.language-flag-bogus.test.js
+++ b/test/geocode-unit.language-flag-bogus.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -35,6 +36,15 @@ var addFeature = require('../lib/util/addfeature'),
             bbox: [0,-5.615985819155337,5.625,0]
         };
         queueFeature(conf.country, country, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('0,0 ?language=en', function(t) {

--- a/test/geocode-unit.language-flag-reverse.test.js
+++ b/test/geocode-unit.language-flag-reverse.test.js
@@ -7,8 +7,8 @@ var mem = require('../lib/api-mem');
 var context = require('../lib/context');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {

--- a/test/geocode-unit.language-flag-reverse.test.js
+++ b/test/geocode-unit.language-flag-reverse.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -32,7 +34,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
 
     tape('index city', function(t) {
@@ -53,7 +55,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
 
     tape('中国 => China', function(t) {

--- a/test/geocode-unit.language-flag-reverse.test.js
+++ b/test/geocode-unit.language-flag-reverse.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -56,6 +57,15 @@ var addFeature = require('../lib/util/addfeature'),
             bbox: [0,-5.615985819155337,5.625,0]
         };
         queueFeature(conf.place, place, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('中国 => China', function(t) {

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -64,6 +65,61 @@ var addFeature = require('../lib/util/addfeature'),
         };
         queueFeature(conf.place, place, t.end);
     });
+
+	tape('index region', function(t) {
+		var region = {
+			type: 'Feature',
+			properties: {
+				'carmen:center': [0,0],
+				'carmen:zxy': ['6/32/32'],
+				'carmen:text_zh': '西北部联邦管区',
+				'carmen:text_zh_Hant': '西北部聯邦管區',
+				'carmen:text_ru': 'Северо-Западный федеральный округ',
+				'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug',
+				'carmen:text_eo': '!!!!'
+			},
+			id: 1,
+			geometry: {
+				type: 'MultiPolygon',
+				coordinates: [
+					[[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+				]
+			},
+			bbox: [0,-5.615985819155337,5.625,0]
+		};
+		queueFeature(conf.region, region, t.end);
+	});
+
+	tape('index place2', function(t) {
+		var place = {
+			type: 'Feature',
+			properties: {
+				'carmen:center': [0,0],
+				'carmen:zxy': ['6/31/31'],
+				'carmen:text': 'Shenzhen',
+				'carmen:text_zh': '深圳市'
+			},
+			id: 2,
+			geometry: {
+				type: 'MultiPolygon',
+				coordinates: [
+					[[[-5.625,0],[-5.625,5.615985819155337],[0,5.615985819155337],[0,0],[-5.625,0]]]
+				]
+			},
+			bbox: [-5.625,0,0,5.615985819155337]
+		};
+		queueFeature(conf.place2, place, t.end);
+	});
+
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('russia => Russian Federation', function(t) {
         c.geocode('russia', { limit_verify:1 }, function(err, res) {
@@ -169,13 +225,15 @@ var addFeature = require('../lib/util/addfeature'),
     });
 
     // also 'translate' the context when available
-    tape('St Petersburg => Санкт-Петербу́рг, Российская Федерация - {language: "ru"}', function(t) {
+    tape('St Petersburg => Санкт-Петербу́рг, Северо-Западный федеральный округ, Российская Федерация - {language: "ru"}', function(t) {
         c.geocode('St Petersburg', { language: 'ru'}, function(err, res) {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'Санкт-Петербу́рг, Российская Федерация');
+            t.equal(res.features[0].place_name, 'Санкт-Петербу́рг, Северо-Западный федеральный округ, Российская Федерация');
             t.equal(res.features[0].id, 'place.1');
-            t.equal(res.features[0].context[0].text, 'Российская Федерация');
+            t.equal(res.features[0].context[0].text, 'Северо-Западный федеральный округ');
+            t.equal(res.features[0].context[1].text, 'Российская Федерация');
             t.equal(res.features[0].context[0].language, 'ru');
+            t.equal(res.features[0].context[1].language, 'ru');
             t.end();
         });
     });
@@ -184,36 +242,14 @@ var addFeature = require('../lib/util/addfeature'),
     tape('St Petersberg => Saint Petersburg - {language: "fr"}', function(t) {
         c.geocode('St Petersburg', { limit_verify:1, language: 'fr' }, function(err, res) {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'Saint Petersburg, Russian Federation');
+            t.equal(res.features[0].place_name, 'Saint Petersburg, Northwestern Federal District, Russian Federation');
             t.equal(res.features[0].id, 'place.1');
-            t.equal(res.features[0].context[0].text, 'Russian Federation');
+            t.equal(res.features[0].context[0].text, 'Northwestern Federal District');
+            t.equal(res.features[0].context[1].text, 'Russian Federation');
             t.equal(res.features[0].context[0].language, undefined);
+            t.equal(res.features[0].context[1].language, undefined);
             t.end();
         });
-    });
-
-    tape('index region', function(t) {
-        var region = {
-            type: 'Feature',
-            properties: {
-                'carmen:center': [0,0],
-                'carmen:zxy': ['6/32/32'],
-                'carmen:text_zh': '西北部联邦管区',
-                'carmen:text_zh_Hant': '西北部聯邦管區',
-                'carmen:text_ru': 'Северо-Западный федеральный округ',
-                'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug',
-                'carmen:text_eo': '!!!!'
-            },
-            id: 1,
-            geometry: {
-                type: 'MultiPolygon',
-                coordinates: [
-                    [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
-                ]
-            },
-            bbox: [0,-5.615985819155337,5.625,0]
-        };
-        queueFeature(conf.region, region, t.end);
     });
 
     // custom response format template
@@ -261,27 +297,6 @@ var addFeature = require('../lib/util/addfeature'),
             t.deepEqual(res.features[0].context[0].text, '!!!!');
             t.end();
         });
-    });
-
-    tape('index place2', function(t) {
-        var place = {
-            type: 'Feature',
-            properties: {
-                'carmen:center': [0,0],
-                'carmen:zxy': ['6/31/31'],
-                'carmen:text': 'Shenzhen',
-                'carmen:text_zh': '深圳市'
-            },
-            id: 2,
-            geometry: {
-                type: 'MultiPolygon',
-                coordinates: [
-                    [[[-5.625,0],[-5.625,5.615985819155337],[0,5.615985819155337],[0,0],[-5.625,0]]]
-                ]
-            },
-            bbox: [-5.625,0,0,5.615985819155337]
-        };
-        queueFeature(conf.place2, place, t.end);
     });
 
     tape('西北部联邦管区 => Russian Federation西北部联邦管区', function(t) {

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -39,7 +41,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
 
     tape('index city', function(t) {
@@ -60,7 +62,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
 
     tape('russia => Russian Federation', function(t) {
@@ -211,7 +213,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [0,-5.615985819155337,5.625,0]
         };
-        addFeature(conf.region, region, t.end);
+        queueFeature(conf.region, region, t.end);
     });
 
     // custom response format template
@@ -279,7 +281,7 @@ var addFeature = require('../lib/util/addfeature');
             },
             bbox: [-5.625,0,0,5.615985819155337]
         };
-        addFeature(conf.place2, place, t.end);
+        queueFeature(conf.place2, place, t.end);
     });
 
     tape('西北部联邦管区 => Russian Federation西北部联邦管区', function(t) {

--- a/test/geocode-unit.language-flag.test.js
+++ b/test/geocode-unit.language-flag.test.js
@@ -7,8 +7,8 @@ var mem = require('../lib/api-mem');
 var context = require('../lib/context');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -66,60 +66,60 @@ var addFeature = require('../lib/util/addfeature'),
         queueFeature(conf.place, place, t.end);
     });
 
-	tape('index region', function(t) {
-		var region = {
-			type: 'Feature',
-			properties: {
-				'carmen:center': [0,0],
-				'carmen:zxy': ['6/32/32'],
-				'carmen:text_zh': '西北部联邦管区',
-				'carmen:text_zh_Hant': '西北部聯邦管區',
-				'carmen:text_ru': 'Северо-Западный федеральный округ',
-				'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug',
-				'carmen:text_eo': '!!!!'
-			},
-			id: 1,
-			geometry: {
-				type: 'MultiPolygon',
-				coordinates: [
-					[[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
-				]
-			},
-			bbox: [0,-5.615985819155337,5.625,0]
-		};
-		queueFeature(conf.region, region, t.end);
-	});
+    tape('index region', function(t) {
+        var region = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:text_zh': '西北部联邦管区',
+                'carmen:text_zh_Hant': '西北部聯邦管區',
+                'carmen:text_ru': 'Северо-Западный федеральный округ',
+                'carmen:text': 'Northwestern Federal District,  Severo-Zapadny federalny okrug',
+                'carmen:text_eo': '!!!!'
+            },
+            id: 1,
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+                ]
+            },
+            bbox: [0,-5.615985819155337,5.625,0]
+        };
+        queueFeature(conf.region, region, t.end);
+    });
 
-	tape('index place2', function(t) {
-		var place = {
-			type: 'Feature',
-			properties: {
-				'carmen:center': [0,0],
-				'carmen:zxy': ['6/31/31'],
-				'carmen:text': 'Shenzhen',
-				'carmen:text_zh': '深圳市'
-			},
-			id: 2,
-			geometry: {
-				type: 'MultiPolygon',
-				coordinates: [
-					[[[-5.625,0],[-5.625,5.615985819155337],[0,5.615985819155337],[0,0],[-5.625,0]]]
-				]
-			},
-			bbox: [-5.625,0,0,5.615985819155337]
-		};
-		queueFeature(conf.place2, place, t.end);
-	});
+    tape('index place2', function(t) {
+        var place = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/31/31'],
+                'carmen:text': 'Shenzhen',
+                'carmen:text_zh': '深圳市'
+            },
+            id: 2,
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[-5.625,0],[-5.625,5.615985819155337],[0,5.615985819155337],[0,0],[-5.625,0]]]
+                ]
+            },
+            bbox: [-5.625,0,0,5.615985819155337]
+        };
+        queueFeature(conf.place2, place, t.end);
+    });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('russia => Russian Federation', function(t) {
         c.geocode('russia', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.languageMode-universal.test.js
+++ b/test/geocode-unit.languageMode-universal.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -12,7 +14,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -28,7 +30,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index postcode', function(assert) {
-        addFeature(conf.postcode, {
+        queueFeature(conf.postcode, {
             id: 1,
             type: 'Feature',
             properties: {

--- a/test/geocode-unit.languageMode-universal.test.js
+++ b/test/geocode-unit.languageMode-universal.test.js
@@ -4,8 +4,8 @@ var mem = require('../lib/api-mem');
 var context = require('../lib/context');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {

--- a/test/geocode-unit.languageMode-universal.test.js
+++ b/test/geocode-unit.languageMode-universal.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -42,6 +43,15 @@ var addFeature = require('../lib/util/addfeature'),
                 coordinates: [1,1]
             }
         }, assert.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('query: 10000', function(assert) {
@@ -97,4 +107,3 @@ var addFeature = require('../lib/util/addfeature'),
         assert.end();
     });
 })();
-

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -4,8 +4,8 @@ var mem = require('../lib/api-mem');
 var context = require('../lib/context');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -61,15 +61,15 @@ var addFeature = require('../lib/util/addfeature'),
         }, assert.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('query: c, language: zh, languageMode: strict', function(assert) {
         c.geocode('c', { language: 'zh', languageMode: 'strict' }, function(err, res) {
@@ -210,15 +210,15 @@ var addFeature = require('../lib/util/addfeature'),
         }, assert.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
 
     tape('query: c, language: zh, languageMode: strict', function(assert) {
@@ -352,15 +352,15 @@ var addFeature = require('../lib/util/addfeature'),
         }, assert.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
 
     tape('query: paris, language: sr-Latn, languageMode: strict', function(assert) {

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -59,6 +60,16 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, assert.end);
     });
+
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     tape('query: c, language: zh, languageMode: strict', function(assert) {
         c.geocode('c', { language: 'zh', languageMode: 'strict' }, function(err, res) {
@@ -199,6 +210,16 @@ var addFeature = require('../lib/util/addfeature'),
         }, assert.end);
     });
 
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
+
 
     tape('query: c, language: zh, languageMode: strict', function(assert) {
         c.geocode('c', { language: 'zh', languageMode: 'strict' }, function(err, res) {
@@ -331,6 +352,16 @@ var addFeature = require('../lib/util/addfeature'),
         }, assert.end);
     });
 
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
+
 
     tape('query: paris, language: sr-Latn, languageMode: strict', function(assert) {
         c.geocode('paris', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
@@ -343,7 +374,6 @@ var addFeature = require('../lib/util/addfeature'),
     tape('query: belgrade, language: sr-Latn, languageMode: strict', function(assert) {
         c.geocode('belgrade', { language: 'sr-Latn', languageMode: 'strict' }, function(err, res) {
             assert.ifError(err);
-            console.log("Res", res)
             assert.equal(res.features.length, 1, 'allows hr result');
             assert.equal(res.features[0].language, 'hr', 'language code is hr');
             assert.end();
@@ -353,7 +383,6 @@ var addFeature = require('../lib/util/addfeature'),
     tape('query: belgrade, language: hr, languageMode: strict', function(assert) {
         c.geocode('belgrade', { language: 'hr', languageMode: 'strict' }, function(err, res) {
             assert.ifError(err);
-            console.log("res", res)
             assert.equal(res.features.length, 1, 'allows hr result');
             assert.equal(res.features[0].language, 'hr', 'language code is hr');
             assert.equal(res.features[0].place_name, 'Beograd, Teksas', 'language=hr excludes sr results');

--- a/test/geocode-unit.languageMode.test.js
+++ b/test/geocode-unit.languageMode.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var context = require('../lib/context');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -11,7 +13,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -28,7 +30,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id: 2,
             type: 'Feature',
             properties: {
@@ -44,7 +46,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id: 3,
             type: 'Feature',
             properties: {
@@ -148,7 +150,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -165,7 +167,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index region', function(assert) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -181,7 +183,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index place', function(assert) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -263,7 +265,7 @@ var addFeature = require('../lib/util/addfeature');
     var c = new Carmen(conf);
 
     tape('index country', function(assert) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -281,7 +283,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index region', function(assert) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -297,7 +299,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index place', function(assert) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             type: 'Feature',
             id: 1,
             properties: {
@@ -313,7 +315,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index place', function(assert) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             type: 'Feature',
             id: 2,
             properties: {

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -5,7 +5,9 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -18,7 +20,7 @@ var addFeature = require('../lib/util/addfeature');
     };
     var c = new Carmen(conf);
     tape('index country', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id: 1,
             properties: {
                 'carmen:text':'United States',
@@ -30,7 +32,7 @@ var addFeature = require('../lib/util/addfeature');
     tape('index place', function(t) {
         var q = queue(1);
         for (var i = 1; i < 21; i++) q.defer(function(i, done) {
-            addFeature(conf.place, {
+            queueFeature(conf.place, {
                 id:i,
                 properties: {
                     'carmen:text':'place ' + i,
@@ -120,7 +122,7 @@ var addFeature = require('../lib/util/addfeature');
     };
     var c = new Carmen(conf);
     tape('index place', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id: 1,
             properties: {
                 'carmen:text':'west virginia',
@@ -146,7 +148,7 @@ var addFeature = require('../lib/util/addfeature');
     tape('index poi', function(t) {
         var q = queue(1);
         for (var i = 1; i < 6; i++) q.defer(function(i, done) {
-            addFeature(conf.poi, {
+            queueFeature(conf.poi, {
                 id:i,
                 properties: {
                     'carmen:text':'seneca rocks ' + i,
@@ -162,7 +164,7 @@ var addFeature = require('../lib/util/addfeature');
     });
 
     tape('index address', function(t) {
-        addFeature(conf.address, {
+        queueFeature(conf.address, {
             id: 1,
             properties: {
                 'carmen:addressnumber': [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
@@ -255,7 +257,7 @@ tape('teardown', function(assert) {
     };
     var c = new Carmen(conf);
     tape('index place', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id: 1,
             properties: {
                 'carmen:text':'west virginia',
@@ -266,7 +268,7 @@ tape('teardown', function(assert) {
     });
 
     tape('index address', function(t) {
-        addFeature(conf.address, {
+        queueFeature(conf.address, {
             id:1,
             properties: {
                 'carmen:text':'main street',
@@ -325,7 +327,7 @@ tape('teardown', function(assert) {
     };
     var c = new Carmen(conf);
     tape('index place', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id: 1,
             properties: {
                 'carmen:text':'west virginia',
@@ -336,7 +338,7 @@ tape('teardown', function(assert) {
     });
 
     tape('index address', function(t) {
-        addFeature(conf.address, {
+        queueFeature(conf.address, {
             id:1,
             properties: {
                 'carmen:text':'main street',

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -47,6 +47,16 @@ var addFeature = require('../lib/util/addfeature'),
         q.awaitAll(t.end);
     });
 
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
+
     tape('default response is 5 features (forward)', function(t) {
         c.geocode('place', {  }, function(err, res) {
             t.ifError(err);
@@ -178,6 +188,16 @@ var addFeature = require('../lib/util/addfeature'),
         }, t.end);
     });
 
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
     tape('default response is 1 features (reverse)', function(t) {
         c.geocode('-79.37745451927184,38.83420867393712', { }, function(err, res) {
             t.ifError(err);
@@ -295,6 +315,16 @@ tape('teardown', function(assert) {
         }, t.end);
     });
 
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
     tape('Reverse Cluster', function(t) {
         c.geocode('-79.37745451927184,38.83420867393712', { limit: 5, types: ['address'] }, function(err, res) {
             t.equal(res.features[0].place_name, '5 main street, west virginia');
@@ -361,6 +391,16 @@ tape('teardown', function(assert) {
                 ]
             }
         }, t.end);
+    });
+
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
 
     tape('Reverse ITP', function(t) {

--- a/test/geocode-unit.limit.test.js
+++ b/test/geocode-unit.limit.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -47,15 +47,15 @@ var addFeature = require('../lib/util/addfeature'),
         q.awaitAll(t.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     tape('default response is 5 features (forward)', function(t) {
         c.geocode('place', {  }, function(err, res) {

--- a/test/geocode-unit.localtext.test.js
+++ b/test/geocode-unit.localtext.test.js
@@ -4,7 +4,9 @@
 var tape = require('tape');
 var Carmen = require('..');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom:6 }, function() {}),
@@ -27,7 +29,7 @@ tape('index country', function(t) {
         geometry: { type: 'MultiPolygon', coordinates: [] },
         bbox: [ -11.25, 5.615, -5.625, 11.1784 ]
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region with bad language code', function(t) {
@@ -43,7 +45,7 @@ tape('index region with bad language code', function(t) {
         geometry: { type: 'MultiPolygon', coordinates: [] },
         bbox: [ -11.25, 5.615, -5.625, 11.1784 ]
     };
-    addFeature(conf.region, region, function(err) {
+    queueFeature(conf.region, region, function(err) {
         t.equal(err.message, 'fake is an invalid language code');
         t.end();
     });

--- a/test/geocode-unit.localtext.test.js
+++ b/test/geocode-unit.localtext.test.js
@@ -6,8 +6,8 @@ var Carmen = require('..');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom:6 }, function() {}),
@@ -21,6 +21,7 @@ tape('index region with bad language code', function(t) {
         region: new mem({ maxzoom:6 }, function() {})
     };
     var c2 = new Carmen(conf2);
+    t.ok(c2);
     var region = {
         type: 'Feature',
         properties: {
@@ -34,9 +35,9 @@ tape('index region with bad language code', function(t) {
         bbox: [ -11.25, 5.615, -5.625, 11.1784 ]
     };
     queueFeature(conf2.region, region, function() { buildQueued(conf2.region, function(err) {
-		t.equal(err.message, 'fake is an invalid language code');
-		t.end();
-	})});
+        t.equal(err.message, 'fake is an invalid language code');
+        t.end();
+    })});
 });
 
 tape('index country', function(t) {

--- a/test/geocode-unit.lowrelev.test.js
+++ b/test/geocode-unit.lowrelev.test.js
@@ -5,6 +5,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -35,6 +36,15 @@ tape('index country2', function(t) {
     };
     queueFeature(conf.country, country, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('czech => czech republic', function(t) {
     c.geocode('czech', { limit_verify:1 }, function(err, res) {
         t.ifError(err);
@@ -57,4 +67,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.lowrelev.test.js
+++ b/test/geocode-unit.lowrelev.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom:6 }, function() {})
@@ -20,7 +22,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 tape('index country2', function(t) {
     var country = {
@@ -31,7 +33,7 @@ tape('index country2', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 tape('czech => czech republic', function(t) {
     c.geocode('czech', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.lowrelev.test.js
+++ b/test/geocode-unit.lowrelev.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom:6 }, function() {})

--- a/test/geocode-unit.multiconfig.test.js
+++ b/test/geocode-unit.multiconfig.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -41,6 +42,20 @@ tape('index place', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(confA).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(confA[c], cb);
+        });
+    });
+	Object.keys(confB).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(confB[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('chicago (conf a)', function(t) {
     var a = new Carmen(confA);
     a.geocode('chicago', {}, function(err, res) {
@@ -64,4 +79,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.multiconfig.test.js
+++ b/test/geocode-unit.multiconfig.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var country =new mem(null, function() {});
 var region = new mem(null, function() {});
@@ -20,7 +22,7 @@ var pre = new Carmen(confA);
 
 tape('index province', function(t) {
     t.ok(pre);
-    addFeature(confA.country, {
+    queueFeature(confA.country, {
         id:1,
         properties: {
             'carmen:text':'america',
@@ -30,7 +32,7 @@ tape('index province', function(t) {
     }, t.end);
 });
 tape('index place', function(t) {
-    addFeature(confA.place, {
+    queueFeature(confA.place, {
         id:1,
         properties: {
             'carmen:text':'chicago',

--- a/test/geocode-unit.multiconfig.test.js
+++ b/test/geocode-unit.multiconfig.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var country =new mem(null, function() {});
 var region = new mem(null, function() {});
@@ -49,7 +49,7 @@ tape('build queued features', function(t) {
             buildQueued(confA[c], cb);
         });
     });
-	Object.keys(confB).forEach(function(c) {
+    Object.keys(confB).forEach(function(c) {
         q.defer(function(cb) {
             buildQueued(confB[c], cb);
         });

--- a/test/geocode-unit.multiload.test.js
+++ b/test/geocode-unit.multiload.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var country = new mem(null, function() {});
 var conf = { country: country };

--- a/test/geocode-unit.multiload.test.js
+++ b/test/geocode-unit.multiload.test.js
@@ -2,14 +2,16 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var country = new mem(null, function() {});
 var conf = { country: country };
 var a = new Carmen(conf);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:text':'america',

--- a/test/geocode-unit.multiload.test.js
+++ b/test/geocode-unit.multiload.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -19,6 +20,15 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     }, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 tape('geocodes', function(t) {
     a.geocode('america', {}, function(err, res) {
@@ -42,4 +52,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),
@@ -14,7 +16,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id:1,
         geometry: {
             type: 'Polygon',
@@ -35,7 +37,7 @@ tape('index region', function(t) {
 });
 
 tape('index district', function(t) {
-    addFeature(conf.district, {
+    queueFeature(conf.district, {
         id:1,
         geometry: {
             type: 'Polygon',
@@ -55,7 +57,7 @@ tape('index district', function(t) {
 });
 
 tape('index district', function(t) {
-    addFeature(conf.district, {
+    queueFeature(conf.district, {
         id:2,
         geometry: {
             type: 'Polygon',
@@ -75,7 +77,7 @@ tape('index district', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:2,
         geometry: {
             type: 'Polygon',

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),

--- a/test/geocode-unit.multitype-leapfrog.test.js
+++ b/test/geocode-unit.multitype-leapfrog.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -95,6 +96,15 @@ tape('index place', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('multitype reverse', function(assert) {
     assert.comment('query:  0,0');
@@ -128,4 +138,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.multitype-reverse.test.js
+++ b/test/geocode-unit.multitype-reverse.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),
@@ -14,7 +16,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id:1,
         geometry: {
             type: 'Polygon',
@@ -35,7 +37,7 @@ tape('index region', function(t) {
 });
 
 tape('index poi', function(t) {
-    addFeature(conf.poi, {
+    queueFeature(conf.poi, {
         id:1,
         geometry: {
             type: 'Point',

--- a/test/geocode-unit.multitype-reverse.test.js
+++ b/test/geocode-unit.multitype-reverse.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),

--- a/test/geocode-unit.multitype-reverse.test.js
+++ b/test/geocode-unit.multitype-reverse.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -48,6 +49,15 @@ tape('index poi', function(t) {
             'carmen:center': [0,0]
         }
     }, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('multitype reverse', function(assert) {
@@ -122,4 +132,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.multitype.test.js
+++ b/test/geocode-unit.multitype.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),

--- a/test/geocode-unit.multitype.test.js
+++ b/test/geocode-unit.multitype.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -68,6 +69,15 @@ tape('index poi', function(t) {
             'carmen:center': [0,0]
         }
     }, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('multitype reverse', function(assert) {
@@ -207,4 +217,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.multitype.test.js
+++ b/test/geocode-unit.multitype.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({maxzoom:6, geocoder_types:['region','place']}, function() {}),
@@ -14,7 +16,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id:1,
         geometry: {
             type: 'Polygon',
@@ -35,7 +37,7 @@ tape('index region', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         geometry: {
             type: 'Polygon',
@@ -55,7 +57,7 @@ tape('index place', function(t) {
 });
 
 tape('index poi', function(t) {
-    addFeature(conf.poi, {
+    queueFeature(conf.poi, {
         id:1,
         geometry: {
             type: 'Point',

--- a/test/geocode-unit.name-conflict.test.js
+++ b/test/geocode-unit.name-conflict.test.js
@@ -101,6 +101,15 @@ tape('index poi', function(t) {
     }, i);
     q.awaitAll(t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('Descending Gappy', function(t) {
     c.geocode('Waterford Valley Canada', {}, function(err, res) {

--- a/test/geocode-unit.name-conflict.test.js
+++ b/test/geocode-unit.name-conflict.test.js
@@ -3,8 +3,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 var conf = {

--- a/test/geocode-unit.name-conflict.test.js
+++ b/test/geocode-unit.name-conflict.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 var conf = {
@@ -34,7 +36,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region', function(t) {
@@ -46,7 +48,7 @@ tape('index region', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index postcode', function(t) {
@@ -58,7 +60,7 @@ tape('index postcode', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.postcode, postcode, t.end);
+    queueFeature(conf.postcode, postcode, t.end);
 });
 
 tape('index place', function(t) {
@@ -70,7 +72,7 @@ tape('index place', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index neighborhood', function(t) {
@@ -82,13 +84,13 @@ tape('index neighborhood', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.neighborhood, neighborhood, t.end);
+    queueFeature(conf.neighborhood, neighborhood, t.end);
 });
 
 tape('index poi', function(t) {
     var q = queue(1);
     for (var i = 1; i < 20; i++) q.defer(function(i, done) {
-        addFeature(conf.poi, {
+        queueFeature(conf.poi, {
             id:i,
             properties: {
                 'carmen:text':'Canada Post ' + i + 'a',

--- a/test/geocode-unit.named.test.js
+++ b/test/geocode-unit.named.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     place_a: new mem({maxzoom:6, geocoder_name:'place'}, function() {}),

--- a/test/geocode-unit.named.test.js
+++ b/test/geocode-unit.named.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     place_a: new mem({maxzoom:6, geocoder_name:'place'}, function() {}),
@@ -12,7 +14,7 @@ var conf = {
 };
 var c = new Carmen(conf);
 tape('index place_a', function(t) {
-    addFeature(conf.place_a, {
+    queueFeature(conf.place_a, {
         id:1,
         properties: {
             'carmen:text':'sadtown',
@@ -22,7 +24,7 @@ tape('index place_a', function(t) {
     }, t.end);
 });
 tape('index place_b', function(t) {
-    addFeature(conf.place_b, {
+    queueFeature(conf.place_b, {
         id:2,
         properties: {
             'carmen:text':'funtown',

--- a/test/geocode-unit.named.test.js
+++ b/test/geocode-unit.named.test.js
@@ -4,6 +4,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -33,6 +34,15 @@ tape('index place_b', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 tape('sadtown', function(t) {
     c.geocode('sadtown', { limit_verify:1 }, function(err, res) {
         t.ifError(err);
@@ -54,4 +64,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.noauto.test.js
+++ b/test/geocode-unit.noauto.test.js
@@ -35,7 +35,7 @@ var addFeature = require('../lib/util/addfeature'),
                 'carmen:center':[0,0]
             }
         };
-        queueFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, function() { buildQueued(conf.place, t.end) });
     });
     tape('abc - with autocomplete', function(t) {
         c.geocode('abc', { limit_verify:1 }, function(err, res) {
@@ -100,7 +100,7 @@ var addFeature = require('../lib/util/addfeature'),
                 'carmen:center':[0,0]
             }
         };
-        queueFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, function() { buildQueued(conf.place, t.end) });
     });
     tape('place - with autocomplete', function(t) {
         c.geocode('place', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.noauto.test.js
+++ b/test/geocode-unit.noauto.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Confirm that disabling autocomplete works, and that in situations where an autocomplete
 // result scores highest, the winner changes depending on whether or not autocomplete is enabled

--- a/test/geocode-unit.noauto.test.js
+++ b/test/geocode-unit.noauto.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Confirm that disabling autocomplete works, and that in situations where an autocomplete
 // result scores highest, the winner changes depending on whether or not autocomplete is enabled
@@ -21,7 +23,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index second place', function(t) {
         var place = {
@@ -33,7 +35,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('abc - with autocomplete', function(t) {
         c.geocode('abc', { limit_verify:1 }, function(err, res) {
@@ -98,7 +100,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('place - with autocomplete', function(t) {
         c.geocode('place', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.numeric-address.test.js
+++ b/test/geocode-unit.numeric-address.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})
@@ -22,7 +24,7 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('100 17th', function(t) {

--- a/test/geocode-unit.numeric-address.test.js
+++ b/test/geocode-unit.numeric-address.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, function() {})

--- a/test/geocode-unit.numeric-address.test.js
+++ b/test/geocode-unit.numeric-address.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -25,6 +26,15 @@ tape('index address', function(t) {
         }
     };
     queueFeature(conf.address, address, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('100 17th', function(t) {
@@ -55,4 +65,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     postcode: new mem({maxzoom: 6}, function() {})
@@ -10,7 +12,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index', function(assert) {
-    addFeature(conf.postcode, {
+    queueFeature(conf.postcode, {
         id:1,
         properties: {
             'carmen:text':'22209',
@@ -21,7 +23,7 @@ tape('index', function(assert) {
 });
 
 tape('index', function(assert) {
-    addFeature(conf.postcode, {
+    queueFeature(conf.postcode, {
         id:2,
         properties: {
             'carmen:text':'22209 restaurant',

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     postcode: new mem({maxzoom: 6}, function() {})

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -31,6 +32,15 @@ tape('index', function(assert) {
             'carmen:center':[0,0]
         }
     }, assert.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('query', function(t) {
@@ -65,4 +75,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/geocode-unit.order.test.js
+++ b/test/geocode-unit.order.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -81,6 +82,15 @@ tape('index poi', function(t) {
         }
     };
     queueFeature(conf.poi, poi, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('Winston-Salem North Carolina', function(t) {

--- a/test/geocode-unit.order.test.js
+++ b/test/geocode-unit.order.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -25,7 +27,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region', function(t) {
@@ -37,7 +39,7 @@ tape('index region', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index place', function(t) {
@@ -49,7 +51,7 @@ tape('index place', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index address', function(t) {
@@ -66,7 +68,7 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
 });
 
 tape('index poi', function(t) {
@@ -78,7 +80,7 @@ tape('index poi', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.poi, poi, t.end);
+    queueFeature(conf.poi, poi, t.end);
 });
 
 tape('Winston-Salem North Carolina', function(t) {

--- a/test/geocode-unit.order.test.js
+++ b/test/geocode-unit.order.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Tests New York (place), New York (region), USA (country)
 // identically-named features should reverse the gappy penalty and

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -2,7 +2,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Tests New York (place), New York (region), USA (country)
 // identically-named features should reverse the gappy penalty and
@@ -16,7 +19,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -38,7 +41,7 @@ tape('index country', function(t) {
 });
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -60,7 +63,7 @@ tape('index region', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -79,6 +82,16 @@ tape('index place', function(t) {
             ]]
         }
     }, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('find new york', function(t) {
@@ -113,7 +126,7 @@ var conf2 = {
 var c2 = new Carmen(conf2);
 
 tape('index country', function(t) {
-    addFeature(conf2.country, {
+    queueFeature(conf2.country, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -134,7 +147,7 @@ tape('index country', function(t) {
 });
 
 tape('index region', function(t) {
-    addFeature(conf2.region, {
+    queueFeature(conf2.region, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -156,7 +169,7 @@ tape('index region', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf2.place, {
+    queueFeature(conf2.place, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -175,6 +188,16 @@ tape('index place', function(t) {
             ]]
         }
     }, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf2).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf2[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('find makkah', function(t) {

--- a/test/geocode-unit.promote-on-identical-name.test.js
+++ b/test/geocode-unit.promote-on-identical-name.test.js
@@ -6,7 +6,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
@@ -19,7 +22,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:score': 5,
@@ -57,7 +60,7 @@ tape('index country', function(t) {
 });
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id: 2,
         properties: {
             'carmen:score':3,
@@ -96,7 +99,7 @@ tape('index region', function(t) {
 
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id: 3,
         properties: {
             'carmen:score':1,
@@ -134,7 +137,7 @@ tape('index place', function(t) {
 });
 
 tape('index poi', function(t) {
-    addFeature(conf.poi, {
+    queueFeature(conf.poi, {
         id:4,
         properties: {
             'carmen:score': null,
@@ -147,6 +150,16 @@ tape('index poi', function(t) {
             coordinates: [-73.9666, 40.7811]
         }
     }, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('let\'s find new york', function(t) {
@@ -181,7 +194,7 @@ var conf2 = {
 var c2 = new Carmen(conf2);
 
 tape('index country', function(t) {
-    addFeature(conf2.country, {
+    queueFeature(conf2.country, {
         id: 10,
         properties: {
             'carmen:score': 10,
@@ -220,7 +233,7 @@ tape('index country', function(t) {
 
 ['region', 'district', 'place'].forEach(function(f, i) {
     tape('index ' + f, function(t) {
-        addFeature(conf2[f], {
+        queueFeature(conf2[f], {
             id: i + 1,
             properties: {
                 'carmen:score': 5 - i,
@@ -256,6 +269,15 @@ tape('index country', function(t) {
             }
         }, t.end);
     });
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf2).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf2[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('nonthaburi', function(t) {

--- a/test/geocode-unit.promote-on-identical-name.test.js
+++ b/test/geocode-unit.promote-on-identical-name.test.js
@@ -8,8 +8,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),

--- a/test/geocode-unit.promote-score.test.js
+++ b/test/geocode-unit.promote-score.test.js
@@ -2,7 +2,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Tests New York (place), New York (region), USA (country)
 // identically-named features should reverse the gappy penalty and
@@ -16,7 +19,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -38,7 +41,7 @@ tape('index country', function(t) {
 });
 
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id: 2,
         properties: {
             'carmen:center': [45,45],
@@ -59,7 +62,7 @@ tape('index country', function(t) {
 });
 
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id: 1,
         properties: {
             'carmen:center': [0,0],
@@ -80,7 +83,7 @@ tape('index region', function(t) {
 });
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id: 1,
         properties: {
             'carmen:center': [45,45],
@@ -98,6 +101,16 @@ tape('index place', function(t) {
             ]]
         }
     }, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('find georgia', function(t) {

--- a/test/geocode-unit.promote-score.test.js
+++ b/test/geocode-unit.promote-score.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Tests New York (place), New York (region), USA (country)
 // identically-named features should reverse the gappy penalty and

--- a/test/geocode-unit.proximity-polygon.test.js
+++ b/test/geocode-unit.proximity-polygon.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem({maxzoom: 12}, function() {})
@@ -63,7 +65,7 @@ tape('index place', function(t) {
     };
     docs.push(place);
 
-    addFeature(conf.place, docs, t.end);
+    queueFeature(conf.place, docs, function() { buildQueued(conf.place, t.end) });
 });
 
 tape('query', function(t) {

--- a/test/geocode-unit.proximity-polygon.test.js
+++ b/test/geocode-unit.proximity-polygon.test.js
@@ -3,8 +3,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem({maxzoom: 12}, function() {})

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -4,7 +4,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 1}, function() {}),
@@ -21,7 +24,7 @@ tape('index country', function(t) {
             'carmen:center':[-100,60]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 tape('index country', function(t) {
     var country = {
@@ -32,7 +35,7 @@ tape('index country', function(t) {
             'carmen:center':[-60,-20]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 //Across layers
@@ -45,7 +48,7 @@ tape('index province', function(t) {
             'carmen:center':[-80,40]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
 });
 tape('index province', function(t) {
     var country = {
@@ -56,7 +59,7 @@ tape('index province', function(t) {
             'carmen:center':[145,70]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 tape('index province', function(t) {
     var province = {
@@ -67,7 +70,7 @@ tape('index province', function(t) {
             'carmen:center':[-100,60]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
 });
 tape('index province', function(t) {
     var province = {
@@ -78,7 +81,16 @@ tape('index province', function(t) {
             'carmen:center':[-60,-20]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('error: invalid options.proximity type', function(t) {

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({maxzoom: 1}, function() {}),

--- a/test/geocode-unit.range.test.js
+++ b/test/geocode-unit.range.test.js
@@ -2,7 +2,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({
@@ -32,7 +35,7 @@ tape('index region', function(t) {
             'carmen:geocoder_name': 'region'
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index mx region', function(t) {
@@ -46,7 +49,7 @@ tape('index mx region', function(t) {
             'carmen:geocoder_name': 'region'
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index us place', function(t) {
@@ -59,7 +62,7 @@ tape('index us place', function(t) {
             'carmen:geocoder_name': 'place'
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index ca place', function(t) {
@@ -73,7 +76,7 @@ tape('index ca place', function(t) {
             'carmen:geocoder_name': 'place'
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index us address', function(t) {
@@ -92,7 +95,17 @@ tape('index us address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('reverse - good stack, good type', function(t) {

--- a/test/geocode-unit.range.test.js
+++ b/test/geocode-unit.range.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     region: new mem({

--- a/test/geocode-unit.relevance.test.js
+++ b/test/geocode-unit.relevance.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.relevance.test.js
+++ b/test/geocode-unit.relevance.test.js
@@ -2,7 +2,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -27,7 +30,7 @@ tape('index country', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, t.end);
+    queueFeature(conf.country, country, t.end);
 });
 
 tape('index region', function(t) {
@@ -39,7 +42,7 @@ tape('index region', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, t.end);
+    queueFeature(conf.region, region, t.end);
 });
 
 tape('index postcode', function(t) {
@@ -51,7 +54,7 @@ tape('index postcode', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.postcode, postcode, t.end);
+    queueFeature(conf.postcode, postcode, t.end);
 });
 
 tape('index place', function(t) {
@@ -63,7 +66,7 @@ tape('index place', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, t.end);
+    queueFeature(conf.place, place, t.end);
 });
 
 tape('index address', function(t) {
@@ -80,7 +83,16 @@ tape('index address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, address, t.end);
+    queueFeature(conf.address, address, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('Check relevance scoring', function(t) {

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -4,7 +4,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 // Confirms that you can forward search a ghost feature and that a scored featre will always win
 (function() {
@@ -20,7 +23,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index ghost place', function(t) {
         var place = {
@@ -32,7 +35,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index zip+4', function(t) {
         var place = {
@@ -44,7 +47,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index zip', function(t) {
         var place = {
@@ -56,7 +59,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, t.end);
     });
     tape('index ghost zip', function(t) {
         var place = {
@@ -68,7 +71,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.place, place, t.end);
+        queueFeature(conf.place, place, function() { buildQueued(conf.place, t.end) });
     });
     tape('fairfax', function(t) {
         c.geocode('fairfax', { limit_verify:1 }, function(err, res) {
@@ -124,7 +127,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
     tape('index province', function(t) {
         var province = {
@@ -135,7 +138,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[360/64*2,0]
             }
         };
-        addFeature(conf.province, province, t.end);
+        queueFeature(conf.province, province, t.end);
     });
     tape('index city', function(t) {
         var city = {
@@ -146,7 +149,16 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[360/64*4,0]
             }
         };
-        addFeature(conf.city, city, t.end);
+        queueFeature(conf.city, city, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
     tape('china', function(t) {
         c.geocode('china', { limit_verify:1 }, function(err, res) {
@@ -177,7 +189,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, t.end);
     });
     tape('index province', function(t) {
         var province = {
@@ -189,7 +201,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[360/64 * 2,0]
             }
         };
-        addFeature(conf.province, province, t.end);
+        queueFeature(conf.province, province, t.end);
     });
     tape('index city', function(t) {
         var city = {
@@ -201,7 +213,16 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[360/64 * 4,0]
             }
         };
-        addFeature(conf.city, city, t.end);
+        queueFeature(conf.city, city, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
     });
     tape('china', function(t) {
         c.geocode('china', { limit_verify:3, allow_dupes: true }, function(err, res) {
@@ -239,9 +260,9 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:center':[0,0]
             }
         };
-        addFeature(conf.country, country, t.end);
+        queueFeature(conf.country, country, function() { buildQueued(conf.country, t.end) });
     });
-    
+
     tape('query by id', function(t) {
         c.geocode('country.1', null, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.score.test.js
+++ b/test/geocode-unit.score.test.js
@@ -6,8 +6,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 // Confirms that you can forward search a ghost feature and that a scored featre will always win
 (function() {

--- a/test/geocode-unit.scoredist.test.js
+++ b/test/geocode-unit.scoredist.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 (function() {
@@ -14,7 +16,7 @@ var queue = require('d3-queue').queue;
     };
     var c = new Carmen(conf);
     tape('index address (signal 1)', function(t) {
-        addFeature(conf.address, {
+        queueFeature(conf.address, {
             id:200,
             properties: {
                 'carmen:text':'main st',
@@ -25,7 +27,7 @@ var queue = require('d3-queue').queue;
         }, t.end);
     });
     tape('index address (signal 2)', function(t) {
-        addFeature(conf.address, {
+        queueFeature(conf.address, {
             id:201,
             properties: {
                 'carmen:text':'main st',
@@ -38,7 +40,7 @@ var queue = require('d3-queue').queue;
     tape('index address (noise)', function(t) {
         var q = queue(1);
         for (var i = 1; i < 100; i++) q.defer(function(i, done) {
-            addFeature(conf.address, {
+            queueFeature(conf.address, {
                 id:i,
                 properties: {
                     'carmen:text':'main st',
@@ -50,6 +52,15 @@ var queue = require('d3-queue').queue;
         }, i);
         q.awaitAll(t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('geocode proximity=10,10 => superscored', function(t) {
         c.geocode('main st', { proximity:[10,10] }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.scoredist.test.js
+++ b/test/geocode-unit.scoredist.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 (function() {
@@ -52,15 +52,15 @@ var queue = require('d3-queue').queue;
         }, i);
         q.awaitAll(t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('geocode proximity=10,10 => superscored', function(t) {
         c.geocode('main st', { proximity:[10,10] }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.scorefactor.test.js
+++ b/test/geocode-unit.scorefactor.test.js
@@ -6,7 +6,9 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -17,7 +19,7 @@ var addFeature = require('../lib/util/addfeature');
     tape('index small score (noise)', function(t) {
         var q = queue(1);
         for (var i = 1; i < 41; i++) q.defer(function(i, done) {
-            addFeature(conf.place, {
+            queueFeature(conf.place, {
                 id:i,
                 properties: {
                     'carmen:score':10,
@@ -30,7 +32,7 @@ var addFeature = require('../lib/util/addfeature');
         q.awaitAll(t.end);
     });
     tape('index big score (noise)', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:score': 1e9,
@@ -41,7 +43,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index big score (signal)', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:2,
             properties: {
                 'carmen:score': 1e6,
@@ -51,6 +53,15 @@ var addFeature = require('../lib/util/addfeature');
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('query', function(t) {
         c.geocode('testplace', { limit_verify:1 }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.scorefactor.test.js
+++ b/test/geocode-unit.scorefactor.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -53,15 +53,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('query', function(t) {
         c.geocode('testplace', { limit_verify:1 }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.scoresort.test.js
+++ b/test/geocode-unit.scoresort.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 (function() {
@@ -19,7 +21,7 @@ var queue = require('d3-queue').queue;
     var c = new Carmen(conf);
     // very high max score in region index
     tape('index region (high score)', function(t) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             id:1,
             properties: {
                 'carmen:text':'bigtown',
@@ -34,7 +36,7 @@ var queue = require('d3-queue').queue;
     tape('index region (low score)', function(t) {
         var q = queue(1);
         for (var i =2; i < 25; i++) q.defer(function(i, done) {
-            addFeature(conf.region, {
+            queueFeature(conf.region, {
                 id:i,
                 properties: {
                     'carmen:text':'smallville' + i,
@@ -51,7 +53,7 @@ var queue = require('d3-queue').queue;
     tape('index region (medium score)', function(t) {
         var q = queue(1);
         for (var i =25; i < 50; i++) q.defer(function(i, done) {
-            addFeature(conf.region, {
+            queueFeature(conf.region, {
                 id:i,
                 properties: {
                     'carmen:text':'smallville' + i,
@@ -66,7 +68,7 @@ var queue = require('d3-queue').queue;
 
     // Feature is scored higher than all but one region
     tape('index place (high score)', function(t) {
-        addFeature(conf.place, {
+        queueFeature(conf.place, {
             id:1,
             properties: {
                 'carmen:text':'smallville1',
@@ -78,7 +80,7 @@ var queue = require('d3-queue').queue;
     });
 
     tape('index lamplace (high score)', function(t) {
-        addFeature(conf.lamplace, {
+        queueFeature(conf.lamplace, {
             id:1,
             properties: {
                 'carmen:text':'smallville1',
@@ -93,7 +95,7 @@ var queue = require('d3-queue').queue;
     tape('index lamplace (medium score)', function(t) {
         var q = queue(1);
         for (var i =2; i < 25; i++) q.defer(function(i, done) {
-            addFeature(conf.lamplace, {
+            queueFeature(conf.lamplace, {
                 id:i,
                 properties: {
                     'carmen:text':'smallville' + i,
@@ -107,7 +109,7 @@ var queue = require('d3-queue').queue;
     });
 
     tape('index namplace (high score)', function(t) {
-        addFeature(conf.namplace, {
+        queueFeature(conf.namplace, {
             id:1,
             properties: {
                 'carmen:text':'smallville1',
@@ -119,7 +121,7 @@ var queue = require('d3-queue').queue;
     });
 
     tape('index locality (low score)', function(t) {
-        addFeature(conf.locality, {
+        queueFeature(conf.locality, {
             id:1,
             properties: {
                 'carmen:text':'smallville1',
@@ -129,6 +131,16 @@ var queue = require('d3-queue').queue;
             }
         }, t.end);
     });
+
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     // High-scored feature wins over low-scored features in index with high max score
     tape('high score beats low score + high scorefactor', function(t) {

--- a/test/geocode-unit.scoresort.test.js
+++ b/test/geocode-unit.scoresort.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 var queue = require('d3-queue').queue;
 
 (function() {
@@ -132,15 +132,15 @@ var queue = require('d3-queue').queue;
         }, t.end);
     });
 
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     // High-scored feature wins over low-scored features in index with high max score
     tape('high score beats low score + high scorefactor', function(t) {

--- a/test/geocode-unit.spatialmatch.test.js
+++ b/test/geocode-unit.spatialmatch.test.js
@@ -8,8 +8,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem({maxzoom: 6}, function() {}),

--- a/test/geocode-unit.spatialmatch.test.js
+++ b/test/geocode-unit.spatialmatch.test.js
@@ -6,7 +6,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     place: new mem({maxzoom: 6}, function() {}),
@@ -22,7 +25,7 @@ tape('index place', function(t) {
             'carmen:center':[0,0],
         }
     };
-    addFeature(conf.place, feature, t.end);
+    queueFeature(conf.place, feature, t.end);
 });
 tape('index matching address', function(t) {
     var feature = {
@@ -38,7 +41,7 @@ tape('index matching address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, feature, t.end);
+    queueFeature(conf.address, feature, t.end);
 });
 tape('index other address', function(t) {
     var feature = {
@@ -54,7 +57,16 @@ tape('index other address', function(t) {
             coordinates: [[0,0]]
         }
     };
-    addFeature(conf.address, feature, t.end);
+    queueFeature(conf.address, feature, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 tape('test spatialmatch relev', function(t) {
     c.geocode('1 fake street fakecity', { limit_verify: 1 }, function(err, res) {

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -5,7 +5,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     province: new mem(null, function() {}),
@@ -23,7 +26,7 @@ tape('index province', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.province, province, t.end);
+    queueFeature(conf.province, province, t.end);
 });
 tape('index city', function(t) {
     var city = {
@@ -34,7 +37,7 @@ tape('index city', function(t) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.city, city, t.end);
+    queueFeature(conf.city, city, t.end);
 });
 tape('index street', function(t) {
     var street = {
@@ -45,7 +48,16 @@ tape('index street', function(t) {
             'carmen:center':[360/32,0]
         }
     };
-    addFeature(conf.street, street, t.end);
+    queueFeature(conf.street, street, t.end);
+});
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 // city beats street at context sort
 tape('windsor court (limit 2)', function(t) {

--- a/test/geocode-unit.stacky.test.js
+++ b/test/geocode-unit.stacky.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     province: new mem(null, function() {}),

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -5,7 +5,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem(null, function() {}),
@@ -14,7 +17,7 @@ var conf = {
 };
 var c = new Carmen(conf);
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:text':'australia',
@@ -24,7 +27,7 @@ tape('index country', function(t) {
     }, t.end);
 });
 tape('index province', function(t) {
-    addFeature(conf.province, {
+    queueFeature(conf.province, {
         id:2,
         properties: {
             'carmen:text':'western australia',
@@ -34,7 +37,7 @@ tape('index province', function(t) {
     }, t.end);
 });
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:3,
         properties: {
             'carmen:text':'albany',
@@ -43,6 +46,16 @@ tape('index place', function(t) {
         }
     }, t.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
 // should reflect relevance of albany + australia (relev ~ 1), not albany + western australia (relev ~ 0.8)
 tape('albany australia', function(t) {
     c.geocode('albany australia', {}, function(err, res) {

--- a/test/geocode-unit.text-trim.test.js
+++ b/test/geocode-unit.text-trim.test.js
@@ -2,16 +2,19 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
-        country: new mem({ maxzoom: 6 }, function() {}), 
+        country: new mem({ maxzoom: 6 }, function() {}),
         region: new mem({ maxzoom: 6, geocoder_format: '{region._name}, {country._name}'}, function() {}),
     };
     var c = new Carmen(conf);
     tape('index country', function(t) {
-        addFeature(conf.country, {
+        queueFeature(conf.country, {
             id:1,
             properties: {
                 'carmen:text': '  Colombia\n',
@@ -26,7 +29,7 @@ var addFeature = require('../lib/util/addfeature');
         }, t.end);
     });
     tape('index region', function(t) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             id:1,
             properties: {
                 'carmen:text': ' Bogotá ',
@@ -40,6 +43,15 @@ var addFeature = require('../lib/util/addfeature');
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
     tape('trims text (forward)', function(t) {
         c.geocode('Bogota', { limit_verify: 1 }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.text-trim.test.js
+++ b/test/geocode-unit.text-trim.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -43,15 +43,15 @@ var addFeature = require('../lib/util/addfeature'),
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
     tape('trims text (forward)', function(t) {
         c.geocode('Bogota', { limit_verify: 1 }, function(err, res) {
             t.ifError(err);

--- a/test/geocode-unit.tile-edge.test.js
+++ b/test/geocode-unit.tile-edge.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({maxzoom:14}, function() {})

--- a/test/geocode-unit.tile-edge.test.js
+++ b/test/geocode-unit.tile-edge.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({maxzoom:14}, function() {})
@@ -20,7 +22,7 @@ tape('index test', function(t) {
             'carmen:center':[-2.17405858745506,53.4619151830114]
         }
     };
-    addFeature(conf.test, feature, t.end);
+    queueFeature(conf.test, feature, function() { buildQueued(conf.test, t.end) });
 });
 
 tape('forward between tiles', function(t) {

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -4,7 +4,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {
@@ -26,7 +28,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address index for relev', function(t) {
         c.geocode('fake st', { limit_verify: 1 }, function(err, res) {
@@ -59,7 +61,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test address index for relev', function(t) {
         c.geocode('avenue du 18e régiment', { limit_verify: 1 }, function(err, res) {
@@ -98,7 +100,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test token replacement', function(t) {
         c.geocode('qabc', { limit_verify: 1 }, function(err, res) {
@@ -143,7 +145,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, t.end);
     });
     tape('geocoder token test', function(t) {
         var address = {
@@ -157,7 +159,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('unset opts', function(t) {
         addFeature.setOptions({});
@@ -211,7 +213,7 @@ var addFeature = require('../lib/util/addfeature');
                 coordinates: [0,0]
             }
         };
-        addFeature(conf.address, address, t.end);
+        queueFeature(conf.address, address, function() { buildQueued(conf.address, t.end) });
     });
     tape('test token replacement', function(t) {
         c.geocode('Talstrasse', { limit_verify: 1 }, function(err, res) {

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -5,8 +5,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
     var conf = {

--- a/test/geocode-unit.translation-noauto.test.js
+++ b/test/geocode-unit.translation-noauto.test.js
@@ -2,7 +2,7 @@
 
 var tape = require('tape');
 var Carmen = require('..');
-var Cache = require('../lib/util/cxxcache');
+var cxxcache = require('../lib/util/cxxcache');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature');
@@ -36,17 +36,15 @@ var runTests = function(mode) {
         // on the second run through the tests, force carmen-cache to use lazy
         // instead of in-memory caching
         tape('reload cache', function(t) {
-            var oldCache = c.byidx[0]._geocoder;
-            var newCache = new Cache(oldCache.id);
+            var cache = c.byidx[0]._geocoder;
 
             ['freq', 'grid'].forEach(function(type) {
                 var rocksdb = c.byidx[0].getBaseFilename() + '.' + type + '.rocksdb';
 
-                oldCache.pack(rocksdb, type);
-                newCache.loadSync(rocksdb, type);
+                cache[type].pack(rocksdb);
+                cache[type] = new cxxcache.RocksDBCache(cache[type].id, rocksdb)
             });
 
-            c.byidx[0]._geocoder = newCache;
             t.end();
         });
     }

--- a/test/geocode-unit.translation-noauto.test.js
+++ b/test/geocode-unit.translation-noauto.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var runTests = function(mode) {
     var conf = { region: new mem(null, function() {}) };
@@ -34,15 +34,15 @@ var runTests = function(mode) {
             }
         }, t.end);
     });
-	tape('build queued features', function(t) {
-	    var q = queue();
-	    Object.keys(conf).forEach(function(c) {
-	        q.defer(function(cb) {
-	            buildQueued(conf[c], cb);
-	        });
-	    });
-	    q.awaitAll(t.end);
-	});
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
 
     if (mode == "lazy") {
         // on the second run through the tests, force carmen-cache to use lazy

--- a/test/geocode-unit.translation-noauto.test.js
+++ b/test/geocode-unit.translation-noauto.test.js
@@ -5,13 +5,16 @@ var Carmen = require('..');
 var cxxcache = require('../lib/util/cxxcache');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var runTests = function(mode) {
     var conf = { region: new mem(null, function() {}) };
     var c = new Carmen(conf);
     tape('index first region', function(t) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             id:1,
             properties: {
                 'carmen:text':'South Carolina',
@@ -22,7 +25,7 @@ var runTests = function(mode) {
         }, t.end);
     });
     tape('index second region', function(t) {
-        addFeature(conf.region, {
+        queueFeature(conf.region, {
             id:2,
             properties: {
                 'carmen:text':'Delaware',
@@ -31,6 +34,15 @@ var runTests = function(mode) {
             }
         }, t.end);
     });
+	tape('build queued features', function(t) {
+	    var q = queue();
+	    Object.keys(conf).forEach(function(c) {
+	        q.defer(function(cb) {
+	            buildQueued(conf[c], cb);
+	        });
+	    });
+	    q.awaitAll(t.end);
+	});
 
     if (mode == "lazy") {
         // on the second run through the tests, force carmen-cache to use lazy

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -5,7 +5,10 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
@@ -17,7 +20,7 @@ var conf = {
 
 var c = new Carmen(conf);
 tape('index country', function(t) {
-    addFeature(conf.country, {
+    queueFeature(conf.country, {
         id:1,
         properties: {
             'carmen:score':25000,
@@ -29,7 +32,7 @@ tape('index country', function(t) {
     }, t.end);
 });
 tape('index region', function(t) {
-    addFeature(conf.region, {
+    queueFeature(conf.region, {
         id:1,
         properties: {
             'carmen:score':3500,
@@ -41,7 +44,7 @@ tape('index region', function(t) {
     }, t.end);
 });
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         properties: {
             'carmen:score':2500,
@@ -53,7 +56,7 @@ tape('index place', function(t) {
     }, t.end);
 });
 tape('index poi landmark', function(t) {
-    addFeature(conf.poi_cn, {
+    queueFeature(conf.poi_cn, {
         id:1,
         properties: {
             'carmen:score':500,
@@ -68,7 +71,7 @@ tape('index poi landmark', function(t) {
     }, t.end);
 });
 tape('index poi', function(t) {
-    addFeature(conf.poi_cn, {
+    queueFeature(conf.poi_cn, {
         id:2,
         properties: {
             'carmen:score':5,
@@ -83,7 +86,7 @@ tape('index poi', function(t) {
     }, t.end);
 });
 tape('index offset poi', function(t) {
-    addFeature(conf.poi_cn, {
+    queueFeature(conf.poi_cn, {
         id:3,
         properties: {
             'carmen:score':5,
@@ -96,6 +99,52 @@ tape('index offset poi', function(t) {
             coordinates: [113.651, 34.75]
         }
     }, t.end);
+});
+
+tape('index second poi (nonlandmark)', function(t) {
+    queueFeature(conf.poi_au, {
+        id:3,
+        properties: {
+            'carmen:score':50,
+            'carmen:text':'australia nonlandmark',
+            'carmen:zxy':['14/15152/9491'],
+            'carmen:center':[152.94, -27.44]
+        }
+    }, t.end);
+});
+
+tape('index second poi (landmark)', function(t) {
+    queueFeature(conf.poi_au, {
+        id:4,
+        properties: {
+            'carmen:score':51,
+            'carmen:text':'australia landmark',
+            'carmen:zxy':['14/15152/9491'],
+            'carmen:center':[152.94, -27.44]
+        }
+    }, t.end);
+});
+
+tape('index third poi (ambiguous landmark)', function(t) {
+    queueFeature(conf.poi_au, {
+        id:5,
+        properties: {
+            'carmen:score':51,
+            'carmen:text':'china lm',
+            'carmen:zxy':['14/15152/9491'],
+            'carmen:center':[152.94, -27.44]
+        }
+    }, t.end);
+});
+
+tape('build queued features', function(t) {
+	var q = queue();
+	Object.keys(conf).forEach(function(c) {
+		q.defer(function(cb) {
+			buildQueued(conf[c], cb);
+		});
+	});
+	q.awaitAll(t.end);
 });
 
 // invalid options.types type
@@ -127,7 +176,7 @@ tape('china types: ["asdf"]', function(t) {
 tape('china types: ["poi.landmark"]', function(t) {
     c.geocode('china', { types:['poi.landmark'] }, function(err, res) {
         t.ifError(err);
-        t.deepEqual(res.features.length, 1, '1 result');
+        t.deepEqual(res.features.length, 2, '2 results');
         t.deepEqual(res.features[0].text, 'china lm', 'landmarks beat pois');
         t.end();
     });
@@ -137,7 +186,7 @@ tape('china types: ["poi.landmark"]', function(t) {
 tape('china types:[poi.landmark, poi]', function(t) {
     c.geocode('china', { types:['poi.landmark', 'poi'] }, function(err, res) {
         t.ifError(err);
-        t.deepEqual(res.features.length, 3, '3 results');
+        t.deepEqual(res.features.length, 4, '4 results');
         t.deepEqual(res.features[0].text, 'china lm', 'subtypes work');
         t.end();
     });
@@ -147,7 +196,7 @@ tape('china types:[poi.landmark, poi]', function(t) {
 tape('china poi returns poi.landmark also', function(t) {
     c.geocode('china', { types:['poi'] }, function(err, res) {
         t.ifError(err);
-        t.deepEqual(res.features.length, 3, '2 results');
+        t.deepEqual(res.features.length, 4, '4 results');
         t.deepEqual(res.features[0].text, 'china lm', 'landmark ranks higher than poi.');
         t.end();
     });
@@ -311,42 +360,6 @@ tape('reverse: poi.landmark (limit 5, expect 1)', function(t) {
         ], 'preserves full context of place result (including place, region, country)');
         t.end();
     });
-});
-
-tape('index second poi (nonlandmark)', function(t) {
-    addFeature(conf.poi_au, {
-        id:3,
-        properties: {
-            'carmen:score':50,
-            'carmen:text':'australia nonlandmark',
-            'carmen:zxy':['14/15152/9491'],
-            'carmen:center':[152.94, -27.44]
-        }
-    }, t.end);
-});
-
-tape('index second poi (landmark)', function(t) {
-    addFeature(conf.poi_au, {
-        id:4,
-        properties: {
-            'carmen:score':51,
-            'carmen:text':'australia landmark',
-            'carmen:zxy':['14/15152/9491'],
-            'carmen:center':[152.94, -27.44]
-        }
-    }, t.end);
-});
-
-tape('index third poi (ambiguous landmark)', function(t) {
-    addFeature(conf.poi_au, {
-        id:5,
-        properties: {
-            'carmen:score':51,
-            'carmen:text':'china lm',
-            'carmen:zxy':['14/15152/9491'],
-            'carmen:center':[152.94, -27.44]
-        }
-    }, t.end);
 });
 
 tape('fwd: landmark filtering works w/ diff score ranges', function(t) {

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     country: new mem({ maxzoom: 6 }, function() {}),
@@ -138,13 +138,13 @@ tape('index third poi (ambiguous landmark)', function(t) {
 });
 
 tape('build queued features', function(t) {
-	var q = queue();
-	Object.keys(conf).forEach(function(c) {
-		q.defer(function(cb) {
-			buildQueued(conf[c], cb);
-		});
-	});
-	q.awaitAll(t.end);
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 // invalid options.types type

--- a/test/geocode-unit.unicode-replace.test.js
+++ b/test/geocode-unit.unicode-replace.test.js
@@ -6,8 +6,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({

--- a/test/geocode-unit.unicode-replace.test.js
+++ b/test/geocode-unit.unicode-replace.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({
@@ -17,14 +19,14 @@ var conf = {
 };
 var c = new Carmen(conf);
 tape('index Maréchal', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:1,
         properties: {
             'carmen:text':'Maréchal',
             'carmen:zxy':['6/32/32'],
             'carmen:center':[0,0]
         }
-    }, t.end);
+    }, function() { buildQueued(conf.test, t.end) });
 });
 tape('Mal => Maréchal', function(t) {
     c.geocode('Mal', { limit_verify:1 }, function(err, res) {

--- a/test/geocode-unit.unicode.test.js
+++ b/test/geocode-unit.unicode.test.js
@@ -7,8 +7,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({ maxzoom:6 }, function() {})

--- a/test/geocode-unit.unicode.test.js
+++ b/test/geocode-unit.unicode.test.js
@@ -5,14 +5,17 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     test: new mem({ maxzoom:6 }, function() {})
 };
 var c = new Carmen(conf);
 tape('index 京都市', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:1,
         properties: {
             'carmen:text':'京都市',
@@ -22,7 +25,7 @@ tape('index 京都市', function(t) {
     }, t.end);
 });
 tape('index москва', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:2,
         properties: {
             'carmen:text':'москва',
@@ -32,7 +35,7 @@ tape('index москва', function(t) {
     }, t.end);
 });
 tape('index josé', function(t) {
-    addFeature(conf.test, {
+    queueFeature(conf.test, {
         id:3,
         properties: {
             'carmen:text':'josé',
@@ -40,6 +43,16 @@ tape('index josé', function(t) {
             'carmen:center':[0,0]
         }
     }, t.end);
+});
+
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
 });
 
 tape('京 => 京都市', function(t) {

--- a/test/geocode-unit.unidecollide.test.js
+++ b/test/geocode-unit.unidecollide.test.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 (function() {
 
@@ -14,7 +16,7 @@ var addFeature = require('../lib/util/addfeature');
     };
     var c = new Carmen(conf);
     tape('index Alberta', function(t) {
-        addFeature(conf.place_a, {
+        queueFeature(conf.place_a, {
             id:1,
             properties: {
                 'carmen:text':'Alberta',
@@ -22,7 +24,7 @@ var addFeature = require('../lib/util/addfeature');
                 'carmen:zxy':['6/32/32'],
                 'carmen:center':[0,0]
             }
-        }, t.end);
+        }, function() { buildQueued(conf.place_a, t.end) });
     });
 
     tape('heading to Aruba, I hope you packed warm clothes', function(t) {
@@ -66,14 +68,14 @@ var addFeature = require('../lib/util/addfeature');
     };
     var c = new Carmen(conf);
     tape('index abc xyz', function(t) {
-        addFeature(conf.place_a, {
+        queueFeature(conf.place_a, {
             id:1,
             properties: {
                 'carmen:text':'abc Xyz',
                 'carmen:zxy':['6/32/32'],
                 'carmen:center':[0,0]
             }
-        }, t.end);
+        }, function() { buildQueued(conf.place_a, t.end) });
     });
 
     tape('check for collisions based on char prefixing', function(t) {

--- a/test/geocode-unit.unidecollide.test.js
+++ b/test/geocode-unit.unidecollide.test.js
@@ -6,8 +6,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 (function() {
 

--- a/test/geocode-unit.zeroscore.js
+++ b/test/geocode-unit.zeroscore.js
@@ -6,8 +6,8 @@ var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 
 var conf = {
     // make maxscore a string to simulate how carmen will encounter it after pulling it from the meta table in an mbtiles file

--- a/test/geocode-unit.zeroscore.js
+++ b/test/geocode-unit.zeroscore.js
@@ -5,7 +5,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 
 var conf = {
     // make maxscore a string to simulate how carmen will encounter it after pulling it from the meta table in an mbtiles file
@@ -15,7 +17,7 @@ var conf = {
 var c = new Carmen(conf);
 
 tape('index place', function(t) {
-    addFeature(conf.place, {
+    queueFeature(conf.place, {
         id:1,
         properties: {
             'carmen:score':0,
@@ -23,7 +25,7 @@ tape('index place', function(t) {
             'carmen:zxy':['6/32/32'],
             'carmen:center':[0,0]
         }
-    }, t.end);
+    }, function() { buildQueued(conf.place, t.end) });
 });
 
 // this should have been indexed properly despite having a zero score in an index with zero maxscore

--- a/test/index.merge.test.js
+++ b/test/index.merge.test.js
@@ -179,8 +179,8 @@ test('index - streaming interface', function(assert) {
 
     ["freq", "grid"].forEach(function(type) {
         assert.test('ensure merged index ' + type + ' and original ' + type + ' are 98 percent similar', function(q) {
-            var cSet = new Set(carmenC.indexes.country._geocoder.list(type));
-            var dSet = new Set(carmenD.indexes.country._geocoder.list(type));
+            var cSet = new Set(carmenC.indexes.country._geocoder[type].list());
+            var dSet = new Set(carmenD.indexes.country._geocoder[type].list());
             var intersection = new Set(Array.from(cSet).filter(function(x) { return dSet.has(x) }));
             var union = new Set(Array.from(cSet).concat(Array.from(dSet)));
             var percentage = 100 * intersection.size / (union.size);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,8 +104,8 @@ test('index.update -- error', function(t) {
             }
         }], { zoom: 6 }, function(err) {
             q.ifError(err);
-            q.deepEqual(conf.to._geocoder.get('freq', '__COUNT__'), [2]);
-            q.deepEqual(conf.to._geocoder.get('freq', '__MAX__'), [10]);
+            q.deepEqual(conf.to._geocoder.freq.get('__COUNT__'), [2]);
+            q.deepEqual(conf.to._geocoder.freq.get('__MAX__'), [10]);
             q.end();
         });
     });
@@ -124,8 +124,8 @@ test('index.update -- error', function(t) {
             }
         }], { zoom: 6 }, function(err) {
             q.ifError(err);
-            q.deepEqual(conf.to._geocoder.get('freq', '__COUNT__'), [4]);
-            q.deepEqual(conf.to._geocoder.get('freq', '__MAX__'), [10]);
+            q.deepEqual(conf.to._geocoder.freq.get('__COUNT__'), [4]);
+            q.deepEqual(conf.to._geocoder.freq.get('__MAX__'), [10]);
             q.end();
         });
     });
@@ -315,8 +315,8 @@ test('index phrase collection', function(assert) {
     function afterUpdate(err) {
         assert.ifError(err);
         var id1 = termops.encodePhrase('a');
-        assert.deepEqual(conf.test._geocoder.list('grid'), [ id1.toString() ], '1 phrase');
-        assert.deepEqual(conf.test._geocoder.get('grid',id1), [ 6755949230424065, 6755949230424066 ], 'grid has 2 zxy+feature ids');
+        assert.deepEqual(conf.test._geocoder.grid.list(), [ id1.toString() ], '1 phrase');
+        assert.deepEqual(conf.test._geocoder.grid.get(id1), [ 6755949230424065, 6755949230424066 ], 'grid has 2 zxy+feature ids');
         assert.end();
     }
 });

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -2,6 +2,7 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
+var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
 	queueFeature = addFeature.queueFeature,
 	buildQueued = addFeature.buildQueued;
@@ -85,6 +86,15 @@ tape('index place', function(assert) {
     };
     queueFeature(conf.place, place, assert.end);
 });
+tape('build queued features', function(t) {
+    var q = queue();
+    Object.keys(conf).forEach(function(c) {
+        q.defer(function(cb) {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('Toronto', function(assert) {
     c.geocode('Toronto', {}, function(err, res) {
@@ -120,4 +130,3 @@ tape('teardown', function(assert) {
     context.getTile.cache.reset();
     assert.end();
 });
-

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -4,8 +4,8 @@ var context = require('../lib/context');
 var mem = require('../lib/api-mem');
 var queue = require('d3-queue').queue;
 var addFeature = require('../lib/util/addfeature'),
-	queueFeature = addFeature.queueFeature,
-	buildQueued = addFeature.buildQueued;
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
 var fs = require('fs');
 
 var conf = {

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -2,7 +2,9 @@ var tape = require('tape');
 var Carmen = require('..');
 var context = require('../lib/context');
 var mem = require('../lib/api-mem');
-var addFeature = require('../lib/util/addfeature');
+var addFeature = require('../lib/util/addfeature'),
+	queueFeature = addFeature.queueFeature,
+	buildQueued = addFeature.buildQueued;
 var fs = require('fs');
 
 var conf = {
@@ -31,7 +33,7 @@ tape('index country', function(assert) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.country, country, assert.end);
+    queueFeature(conf.country, country, assert.end);
 });
 
 tape('index region', function(assert) {
@@ -53,7 +55,7 @@ tape('index region', function(assert) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.region, region, assert.end);
+    queueFeature(conf.region, region, assert.end);
 });
 
 tape('index place', function(assert) {
@@ -81,7 +83,7 @@ tape('index place', function(assert) {
             'carmen:center':[0,0]
         }
     };
-    addFeature(conf.place, place, assert.end);
+    queueFeature(conf.place, place, assert.end);
 });
 
 tape('Toronto', function(assert) {


### PR DESCRIPTION
This is the companion PR to https://github.com/mapbox/carmen-cache/pull/89 and reflects a significant refactor and API change in carmen-cache.

In particular:
* the `._geocoder` property is now no longer a carmen-cache instance, but an object with two keys `grid` and `freq`, each of which might be such an instance. So `source._geocoder.get('freq', phrase)` might now be `source._geocoder.freq.get(phrase)`. Situations in which references to carmen-caches were passed around (e.g., phrasematch subquery objects) now only pass around the relevant one (in that case, `._geocoder.grid`)
* those instances are no longer instances of a single carmen-cache class, but rather either instances of `MemoryCache` or `RocksDBCache`, decided dynamically at carmen instantiation time
* carmen's `store` operation now explicitly packs from each of the currently loaded caches and then reloads the new ones. The new ones are always `RocksDBCache`s, and are consequently read-only, so repeated store operations are no longer possible
* We did not employ this pattern in production carmen indexing or at runtime, but we did in tests, via the hacky `addFeature` function, which has now been eliminated, and replaced with `queueFeature`, which adds a feature to a pending queue, and `buildQueued`, which is a one-time indexing operation that consumes that queue and stores the resulting data
* All tests that used `addFeature` (which is most of them) have been rewritten to queue documents and perform the build step on each source before performing geocodes. In most cases we already structured our tests such that all indexing happened first and all geocoding happened after that for a given source, so for these tests this was just replacing `addFeature` with `queueFeature` and adding the build step after all features were queued. For some tests where indexing and geocoding were interspersed for the same sort, test rearrangement was necessary

These are major changes that, in my view, will make subsequent work (particularly around multilingual grid data) much easier to write, test, and reason about, but I recognize that the `addFeature` change in particular might be controversial, so would like to get people's okay before merging. The rocksdb branch could go out without this set of changes if necessary.