### PR TITLE
handle null center coords

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -301,7 +301,7 @@ function verifyCenter(center, tiles) {
     var i = 0;
     while (!found && i < tiles.length) {
         var bbox = tilebelt.tileToBBOX(tiles[i]);
-        if (center[0] >= bbox[0] && center[0] <= bbox[2] && center[1] >= bbox[1] && center[1] <= bbox[3]) {
+        if (center[0] >= bbox[0] && center[0] <= bbox[2] && center[1] >= bbox[1] && center[1] <= bbox[3] && center[0] !== null && center[1] !== null) {
             found = true;
         }
         i++;

--- a/test/indexdocs.test.js
+++ b/test/indexdocs.test.js
@@ -280,6 +280,9 @@ tape('indexdocs.standardize', function(assert) {
 tape('indexdocs.verifyCenter', function(assert) {
     assert.equal(indexdocs.verifyCenter([0,0], [[0,0,0]]), true, 'center in tiles');
     assert.equal(indexdocs.verifyCenter([0,-45], [[0,0,1],[1,0,1]]), false, 'center outside tiles');
+    assert.equal(indexdocs.verifyCenter([0,null], [[32,32,6]]), false, 'handle null lon');
+    assert.equal(indexdocs.verifyCenter([null,0], [[32,32,6]]), false, 'handle null lat');
+    assert.equal(indexdocs.verifyCenter([null,null], [[32,32,6]]), false, 'handle null lon,lat');
     assert.end();
 });
 


### PR DESCRIPTION
### Context
Javascript comparison operators handle the value `null` in a somewhat non-intuitive manner:

```sh
> null == 0
false
> null > 0
false
> null >= 0
true
```
As a result, in certain edge cases a null value in a feature's `carmen:center` property can sneak past the `verifyCenter` check when the feature exists on a tile abutting the equator or the prime meridian.

### Summary
* Check for null values in `verifyCenter`