### PR TITLE
Janky, but try sorting buffers instead of strings before dawg insert

### DIFF
--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -19,10 +19,11 @@ WriteCache.prototype.dump = function() {
     var dawg = new _dawgCache.Dawg();
     var prefixes = Array.from(this.data.keys()).sort();
     for (var i = 0; i < prefixes.length; i++) {
-        var phrases = Array.from(this.data.get(prefixes[i]));
-        phrases.sort();
+        var phrases = [];
+        this.data.get(prefixes[i]).forEach(function(item) { phrases.push(new Buffer(item)); });
+        phrases.sort(Buffer.compare);
         for (var j = 0; j < phrases.length; j++) {
-            dawg.insert(phrases[j]);
+            dawg.insert(phrases[j].toString());
         }
     }
     dawg.finish();


### PR DESCRIPTION
### Context
@sbma44 had an issue with an index build where the DAWG construction was failing. I was pretty sure this was a sorting problem post-unidecode, in which in certain corner cases, strings containing complex characters might sort character-wise differently than they do byte-wise. Strings were already bucketed by their first three characters, so most comparisons should already be apples-to-apples by script, but I think a corner case may exist when comparing strings that contain a mix of different complex scripts. We weren't actually able to pin down the specific string causing the failure, but this PR caused the index build to succeed.


### Fixes/Adds
Converts strings to buffers before sorting, and then sorts using the `Buffer.compare` sort function.