### PR TITLE
Robustify matching text handling when geocoder_format is set

### DIFF
--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -74,7 +74,7 @@ function getPlaceName(context, formatString, language, languageMode, matched) {
                 if (templateProp == carmenProp) {
                     if (templateSubprop == '_name') {
                         // `name` is a hardcoded subproperty that maps to carmen:text
-                        val = closestLang.getText(language, f.properties).text;
+                        val = matched && f.matching_text ? f.matching_text : closestLang.getText(language, f.properties).text;
                         formatString = formatString.replace('{' + templateProp + '._name}',val);
                     } else if (templateSubprop == '_number') {
                         // `address` is a hardcored subproperty that maps to carmen:address
@@ -144,12 +144,14 @@ function toFeature(context, format, languages, languageMode, debug, geocoder) {
             memo.place_name = memo[`place_name${suffix}`];
 
             // Get matching place name if no language matching occurred.
-            if (!formatString && geocoder) {
+            if (geocoder) {
                 for (var k = 0; k < context.length; k++) {
+                    var last = k === context.length - 1;
                     var matched = !!context[k].properties['carmen:query_text'] && getMatchingText(context[k], geocoder, language);
                     if (matched) {
                         context[k].matching_text = matched.matching_text;
                         context[k].matching_language = matched.matching_language;
+                        if (k === 0) feature.matching_text = matched.matching_text;
                         feature.matching_place_name = getPlaceName(context, formatString, language, languageMode, !!matched);
                         break;
                     }

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -146,7 +146,6 @@ function toFeature(context, format, languages, languageMode, debug, geocoder) {
             // Get matching place name if no language matching occurred.
             if (geocoder) {
                 for (var k = 0; k < context.length; k++) {
-                    var last = k === context.length - 1;
                     var matched = !!context[k].properties['carmen:query_text'] && getMatchingText(context[k], geocoder, language);
                     if (matched) {
                         context[k].matching_text = matched.matching_text;

--- a/test/geocode-unit.matching-text.test.js
+++ b/test/geocode-unit.matching-text.test.js
@@ -1,0 +1,96 @@
+
+var tape = require('tape');
+var Carmen = require('..');
+var mem = require('../lib/api-mem');
+var context = require('../lib/context');
+var queue = require('d3-queue').queue;
+var addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+(function() {
+    var conf = {
+        country: new mem({ maxzoom: 6, geocoder_name: 'country', geocoder_format: '{country._name}' }, function() {}),
+        region: new mem({ maxzoom: 6, geocoder_name: 'region', geocoder_format: '{region._name} {country._name}' }, function() {})
+    };
+    var c = new Carmen(conf);
+    tape('index country', function(t) {
+        var country = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:text': 'United States,America'
+            },
+            id: 1,
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+                ]
+            },
+            bbox: [0,-5.615985819155337,5.625,0]
+        };
+        queueFeature(conf.country, country, t.end);
+    });
+    tape('index region', function(t) {
+        var region = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:text': 'Kansas,Jayhawks'
+            },
+            id: 1,
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[0,-5.615985819155337],[0,0],[5.625,0],[5.625,-5.615985819155337],[0,-5.615985819155337]]]
+                ]
+            },
+            bbox: [0,-5.615985819155337,5.625,0]
+        };
+        queueFeature(conf.region, region, t.end);
+    });
+    tape('build queued features', function(t) {
+        var q = queue();
+        Object.keys(conf).forEach(function(c) {
+            q.defer(function(cb) {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+    tape('kansas america', function(assert) {
+        c.geocode('kansas america', { limit_verify:1 }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, 'Kansas United States');
+            assert.equal(res.features[0].matching_text, undefined, 'feature.matching_text');
+            assert.equal(res.features[0].matching_place_name, 'Kansas America');
+            assert.end();
+        });
+    });
+    tape('america', function(assert) {
+        c.geocode('america', { limit_verify:1 }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, 'United States');
+            assert.equal(res.features[0].matching_text, 'America');
+            assert.equal(res.features[0].matching_place_name, 'America');
+            assert.end();
+        });
+    });
+    tape('jayhawks', function(assert) {
+        c.geocode('jayhawks', { limit_verify:1 }, function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.features[0].place_name, 'Kansas United States');
+            assert.equal(res.features[0].matching_text, 'Jayhawks');
+            assert.equal(res.features[0].matching_place_name, 'Jayhawks United States');
+            assert.end();
+        });
+    });
+})();
+
+tape('teardown', function(assert) {
+    context.getTile.cache.reset();
+    assert.end();
+});


### PR DESCRIPTION
### Context

Desired behavior:

- Include `matching_place_name` on a feature if any part of the query matches part of the result feature's context and adjusts the text to be displayed based on what the user typed (e.g. matching a synonym for part of the context)
  - Example query/matching: **Kansas, Am**erica
  - Canonical placename: Kansas, United States
- Include `matching_text` property on a resulting feature if the feature itself is where the canonical/matching discrepancy lies:
  - Example query/matching: **Ameri**ca
  - Canonical text: United States

This PR fixes up a few cases where this desired behavior ^^ was not being captured fully if 
 `geocoder_format` was set.

cc @mapbox/geocoding-gang 