### PR TITLE
Avoid shard ID collisions

### DIFF
--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -127,22 +127,26 @@ function getFeatureByCover(source, cover, callback) {
         }
 
         var zxy = source.zoom + '/' + cover.x + '/' + cover.y;
+        var features = [];
         var feature;
+        var normalized;
         for (var id in loaded) {
             if (loaded[id].properties['carmen:zxy'].indexOf(zxy) === -1) continue;
             try {
-                feature = normalize(source, loaded[id]);
+                normalized = normalize(source, loaded[id]);
+                features.push(normalized);
             } catch (err) {
                 return callback(err);
             }
-            break;
         }
 
-        if (!feature) {
+        if (!features.length) {
             console.warn('[warning] Feature not found: %s.%d (%s)', source.name, cover.id, source.id);
             return callback();
         }
-
+        if (features.length === 1) {
+            feature = features[0];
+        }
         return callback(null, feature);
     });
 }

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -144,9 +144,13 @@ function getFeatureByCover(source, cover, callback) {
             console.warn('[warning] Feature not found: %s.%d (%s)', source.name, cover.id, source.id);
             return callback();
         }
-        if (features.length === 1) {
-            feature = features[0];
-        }
+
+        // sometimes multiple features will have the same sharded ID + z/x/y coords.
+        // In that case, match on score as well.
+        if (features.length > 1) features = sortFeatures(features, cover, source);
+
+        feature = features[0];
+
         return callback(null, feature);
     });
 }
@@ -263,3 +267,13 @@ function storableProperties(properties, type) {
     return storable;
 }
 
+function sortFeatures(features, cover, source) {
+    var scoreSimple3Bit;
+    var scoreSimple;
+    for (var i=0; i<features.length; i++) {
+        scoreSimple3Bit = termops.encode3BitLogScale(features[i].properties['carmen:score'], source.maxscore);
+        scoreSimple = termops.decode3BitLogScale(scoreSimple3Bit, source.maxscore);
+        if (scoreSimple !== cover.score) features.splice(i, 1);
+    }
+    return features;
+}

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -270,6 +270,7 @@ function storableProperties(properties, type) {
 
 // Compare feature score to cover score. Requires converting feature score to the cover's 3-bit simplified score bucket
 function matchScore(features, cover, source) {
+    if (typeof source.maxscore === 'undefined') return features;
     var scoreSimple3Bit;
     var scoreSimple;
     features = features.filter(function(feature) {

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -147,8 +147,9 @@ function getFeatureByCover(source, cover, callback) {
 
         // sometimes multiple features will have the same sharded ID + z/x/y coords.
         // In that case, match on score as well.
-        if (features.length > 1) features = sortFeatures(features, cover, source);
-
+        if (features.length > 1) features = matchScore(features, cover, source);
+        // Check text as well if score isn't sufficient
+        if (features.length > 1) features = matchText(features, cover);
         feature = features[0];
 
         return callback(null, feature);
@@ -267,13 +268,34 @@ function storableProperties(properties, type) {
     return storable;
 }
 
-function sortFeatures(features, cover, source) {
+// Compare feature score to cover score. Requires converting feature score to the cover's 3-bit simplified score bucket
+function matchScore(features, cover, source) {
     var scoreSimple3Bit;
     var scoreSimple;
-    for (var i=0; i<features.length; i++) {
-        scoreSimple3Bit = termops.encode3BitLogScale(features[i].properties['carmen:score'], source.maxscore);
+    features = features.filter(function(feature) {
+        scoreSimple3Bit = termops.encode3BitLogScale(feature.properties['carmen:score'], source.maxscore);
         scoreSimple = termops.decode3BitLogScale(scoreSimple3Bit, source.maxscore);
-        if (scoreSimple !== cover.score) features.splice(i, 1);
-    }
+        return scoreSimple === cover.score;
+    })
+    return features;
+}
+
+// If score isn't enought to match a cover to a single feature, look at text properties.
+function matchText(features, cover) {
+    var re;
+    features = features.filter(function(feature) {
+        var matches = false;
+        for (var key of Object.keys(feature.properties)) {
+            if (!feature.properties[key] || !/^carmen:text/.exec(key)) continue;
+            feature.properties[key].split(',').forEach(function(label) {
+                re = new RegExp(cover.text);
+                if (re.exec(label)) {
+                    matches = true;
+                }
+            });
+            break;
+        }
+        return matches;
+    });
     return features;
 }

--- a/test/feature.putFeatures.test.js
+++ b/test/feature.putFeatures.test.js
@@ -53,6 +53,20 @@ tape('putFeatures', function(assert) {
             }
         },
         {
+            id: 2814870916619710,
+            type: 'Feature',
+            properties: {
+                'carmen:text': 'Frankenstein',
+                'carmen:center': [ 0, 0 ],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:score': 1500
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [ 0, 0 ]
+            }
+        },
+        {
             id: 11111222222183870,
             type: 'Feature',
             properties: {
@@ -103,7 +117,7 @@ tape('getFeatureByCover', function(assert) {
 });
 
 tape('getFeatureByCover, collision', function(assert) {
-    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000 }, function(err, data) {
+    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000, text:'Mr Hyde' }, function(err, data) {
         assert.equal(data.id, 6832527855771070);
         assert.end();
     });

--- a/test/feature.putFeatures.test.js
+++ b/test/feature.putFeatures.test.js
@@ -49,6 +49,34 @@ tape('putFeatures', function(assert) {
                 coordinates: [360/64+0.001,0]
             }
         },
+        {
+            id: 11111222222183870,
+            type: 'Feature',
+            properties: {
+                'carmen:text': 'Dr Jekyll',
+                'carmen:center': [ 0, 0 ],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:score': 1000
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [ 0, 0 ]
+            }
+        },
+        {
+            id: 6832527855771070,
+            type: 'Feature',
+            properties: {
+                'carmen:text': 'Mr Hyde',
+                'carmen:center': [ 0, 0 ],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:score': 10
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [ 0, 0 ]
+            }
+        },
     ], function(err) {
         assert.ifError(err);
         assert.equal(source._shards.feature[1], '{"1":{"id":1,"type":"Feature","properties":{"carmen:text":"a","carmen:center":[0,0],"carmen:zxy":["6/32/32"]},"geometry":{"type":"Point","coordinates":[0,0]}},"1048577":{"id":1048577,"type":"Feature","properties":{"carmen:text":"c","carmen:center":[5.626,0],"carmen:zxy":["6/33/32"]},"geometry":{"type":"Point","coordinates":[5.626,0]}}}', 'has feature shard 1');
@@ -67,6 +95,13 @@ tape('getFeatureByCover', function(assert) {
 tape('getFeatureByCover', function(assert) {
     feature.getFeatureByCover(conf.source, { id:1, x:33, y:32 }, function(err, data) {
         assert.equal(data.id, 1048577);
+        assert.end();
+    });
+});
+
+tape('getFeatureByCover, collision', function(assert) {
+    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32 }, function(err, data) {
+        console.log("data", data)
         assert.end();
     });
 });

--- a/test/feature.putFeatures.test.js
+++ b/test/feature.putFeatures.test.js
@@ -3,7 +3,10 @@ var feature = require('../lib/util/feature.js');
 var Memsource = require('../lib/api-mem.js');
 var Carmen = require('../index.js');
 
-var source = new Memsource(null, function() {});
+var source = new Memsource({
+    maxzoom: 6,
+    maxscore: 2000
+}, function() {});
 var conf = { source: source };
 var carmen = new Carmen(conf);
 
@@ -56,7 +59,7 @@ tape('putFeatures', function(assert) {
                 'carmen:text': 'Dr Jekyll',
                 'carmen:center': [ 0, 0 ],
                 'carmen:zxy': ['6/32/32'],
-                'carmen:score': 1000
+                'carmen:score': 10
             },
             geometry: {
                 type: 'Point',
@@ -70,7 +73,7 @@ tape('putFeatures', function(assert) {
                 'carmen:text': 'Mr Hyde',
                 'carmen:center': [ 0, 0 ],
                 'carmen:zxy': ['6/32/32'],
-                'carmen:score': 10
+                'carmen:score': 1000
             },
             geometry: {
                 type: 'Point',
@@ -100,8 +103,8 @@ tape('getFeatureByCover', function(assert) {
 });
 
 tape('getFeatureByCover, collision', function(assert) {
-    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32 }, function(err, data) {
-        console.log("data", data)
+    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000 }, function(err, data) {
+        assert.equal(data.id, 6832527855771070);
         assert.end();
     });
 });


### PR DESCRIPTION
### Context
During indexing, we [shard features](https://github.com/mapbox/carmen/blob/master/lib/util/feature.js#L188-L190) by a 20-bit integer derived from the feature ID. When retrieving features from their cover, we then look at the z/x/y coordinates of the returned features to pick the correct feature from that shard.

In rare cases, multiple features will share both the same shard ID and z/x/y tile coordinates, which can prevent a feature from being found in a forward geocode.

### Fixes/Adds
In cases when there are multiple features with the same z/x/y coordinates in a given shard, this adds an additional check that compares the feature score to the cover's score.


### Summary
* Loop through all loaded features in `getFeatureByCover`
* When there are multiple matches, check the feature score and remove from results if they don't match
* This uses the simplified 3-bit score, so it's still possible for there to be collisions, it's just somewhat less likely now.