### PR TITLE
collapsing across variants of arabic YEH

### DIFF
--- a/lib/util/remove-diacritics.js
+++ b/lib/util/remove-diacritics.js
@@ -7,10 +7,12 @@ var latinDiacritics = {"\u24B6":"A","\uFF21":"A","\u00C0":"A","\u00C1":"A","\u00
 
 // I (@apendleton) hand-curated these from the relevant sections of https://en.wikipedia.org/wiki/Diacritic#Diacritics_specific_to_non-Latin_alphabets
 var cyrillicDiacritics = {"\u045E":"\u0443","\u040E":"\u0423","\u0451":"\u0435","\u0401":"\u0415","\u0450":"\u0435","\u0400":"\u0415","\u0491":"\u0433","\u0490":"\u0413","\u0439":"\u0438","\u0419":"\u0418","\u0457":"\u0456","\u0407":"\u0406","\u045C":"\u043A","\u040C":"\u041A","\u0453":"\u0433","\u0403":"\u0413","\u045D":"\u0438","\u040D":"\u0418"};
-var greekDiacritics = {"\u03AC":"\u03B1","\u0386":"\u0391","\u03AD":"\u03B5","\u0388":"\u0395","\u03AE":"\u03B7","\u0389":"\u0397","\u03AF":"\u03B9","\u038A":"\u0399","\u03CC":"\u03BF","\u038C":"\u039F","\u03CD":"\u03C5","\u038E":"\u03A5","\u03CE":"\u03C9","\u038F":"\u03A9","\u0390":"\u03B9","\u03B0":"\u03C5","\u03CA":"\u03B9","\u03AA":"\u0399","\u03CB":"\u03C5","\u03AB":"\u03A5"}
+var greekDiacritics = {"\u03AC":"\u03B1","\u0386":"\u0391","\u03AD":"\u03B5","\u0388":"\u0395","\u03AE":"\u03B7","\u0389":"\u0397","\u03AF":"\u03B9","\u038A":"\u0399","\u03CC":"\u03BF","\u038C":"\u039F","\u03CD":"\u03C5","\u038E":"\u03A5","\u03CE":"\u03C9","\u038F":"\u03A9","\u0390":"\u03B9","\u03B0":"\u03C5","\u03CA":"\u03B9","\u03AA":"\u0399","\u03CB":"\u03C5","\u03AB":"\u03A5"};
+// @boblannon - This collapses two variants of the Arabic letter YEH into 'ARABIC LETTER ALEF MAKSURA'
+var arabicDiacritics = {"\u064A": "\u0649", "\u06CC": "\u0649"};
 
 var diaMap = new Map();
-[latinDiacritics, cyrillicDiacritics, greekDiacritics].forEach(function(diacritics) {
+[latinDiacritics, cyrillicDiacritics, greekDiacritics, arabicDiacritics].forEach(function(diacritics) {
     Object.keys(diacritics).forEach(function(k) { diaMap.set(k, diacritics[k]); });
 });
 

--- a/test/diacritics.test.js
+++ b/test/diacritics.test.js
@@ -8,6 +8,7 @@ tape('removeDiacritics', (t) => {
     t.equal(removeDiacritics("किसी वर्ण के मूल चिह्न के ऊपर, नीचे, अलग-बगल लगने"), "किसी वर्ण के मूल चिह्न के ऊपर, नीचे, अलग-बगल लगने", "nothing happens to Hindi text");
     t.equal(removeDiacritics("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"), "αΑεΕηΗιΙοΟυΥ αΑεΕηΗιΙοΟυΥ", "greek diacritics are removed and other characters stay the same");
     t.equal(removeDiacritics("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"), "уУеЕеЕгГиИ уУеЕеЕгГиИ", "cyrillic diacritics are removed and other characters stay the same");
+    t.equal(removeDiacritics("يی ى"), "ىى ى", "arabic diacritics are removed and other characters stay the same");
 
     t.end();
 });

--- a/test/diacritics.test.js
+++ b/test/diacritics.test.js
@@ -8,7 +8,7 @@ tape('removeDiacritics', (t) => {
     t.equal(removeDiacritics("किसी वर्ण के मूल चिह्न के ऊपर, नीचे, अलग-बगल लगने"), "किसी वर्ण के मूल चिह्न के ऊपर, नीचे, अलग-बगल लगने", "nothing happens to Hindi text");
     t.equal(removeDiacritics("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"), "αΑεΕηΗιΙοΟυΥ αΑεΕηΗιΙοΟυΥ", "greek diacritics are removed and other characters stay the same");
     t.equal(removeDiacritics("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"), "уУеЕеЕгГиИ уУеЕеЕгГиИ", "cyrillic diacritics are removed and other characters stay the same");
-    t.equal(removeDiacritics("يی ى"), "ىى ى", "arabic diacritics are removed and other characters stay the same");
+    t.equal(removeDiacritics("ي,ی ى"), "ى,ى ى", "arabic diacritics are removed and other characters stay the same");
 
     t.end();
 });


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
The arabic character "YEH" varies slightly in the Persian writing system, which causes some queries to miss.

| query for "tabriz" | unicode for "YEH"                | matches?   |
|:-------------------|:---------------------------------|:-----------|
| تبريز              | `U+064A ARABIC LETTER YEH`       | ✅          |
| تبریز              | `U+06CC ARABIC LETTER FARSI YEH` | ❌        |‎ |

### Fixes/Adds
<!-- with link to relevant ticket(s) or short description -->
New pattern replacements to `removeDiacritics` that collapse three variants of this character into the same character.