### PR TITLE
carmen-cache@0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.18.0",
+    "@mapbox/carmen-cache": "0.18.1",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/sphericalmercator": "~1.0.1",


### PR DESCRIPTION
### Context

Upstream tests were failing due to extraneious node-pre-gyp module. @apendleton tracked this down to cache pretest installing it in addition to package.json

### Summary of Changes
- [x] Update carmen-cache


### Next Steps
<!-- if you're still working on it -->
Tag and merge upstream

cc @mapbox/geocoding-gang
