### PR TITLE
Space out2

### DIFF
--- a/scripts/whitespace-analysis.js
+++ b/scripts/whitespace-analysis.js
@@ -1,6 +1,7 @@
 let fs = require('fs');
 let split = require('split');
 let stream = require('stream');
+let termops = require('../lib/util/termops.js');
 
 // 1. Add a basic no-op CLI command scripts/whitespace-analysis.js that
 // can handle an input stream and output the input without any changes
@@ -18,30 +19,18 @@ let stream = require('stream');
 // Springfield Town  => springfieldtown
 
 
-// 
+//
 // you may want to continue to read from `process.stdin`
 // by using stdin you can let `cat` do the file reading for you
 //
 // ```cat <any file> | <your command>
 // ```
 
-
-let file1 = require('../us-address-text-unique.txt');
-
 process.stdin
-.pipe(split())
-.on('data', function(line) {
-    console.log('Heres a line: ' + line);
-});
-
-let converter = new stream.Transform({ objectMode: true });
-converter._transform = function(data, enc, callback) {
-    let query = data.toString()
-    this.push(query + '\n');
-    callback();
-};
-
-
+    .pipe(split())
+    .on('data', function(line) {
+        console.log(termops.removeWhiteSpace(line));
+    });
 
 
 // # Next pass lets you go backwards from result to possible input values

--- a/scripts/whitespace-analysis.js
+++ b/scripts/whitespace-analysis.js
@@ -1,0 +1,48 @@
+let fs = require('fs');
+let split = require('split');
+let stream = require('stream');
+
+// 1. Add a basic no-op CLI command scripts/whitespace-analysis.js that
+// can handle an input stream and output the input without any changes
+//
+// eg. cat us-place-text-uniq.txt | ./scripts/whitespace-analysis.js
+//
+// 2. Modify the script to lowercase and call the whitespace remover
+// utility function on each incoming line
+//
+// 3. Adjust the script to store a mapping between output and input strings
+// and output the results in a format you can use to answer the questions above.
+
+// # Initial script just normalizes output
+// Spring Field Town => springfieldtown
+// Springfield Town  => springfieldtown
+
+
+// 
+// you may want to continue to read from `process.stdin`
+// by using stdin you can let `cat` do the file reading for you
+//
+// ```cat <any file> | <your command>
+// ```
+
+
+let file1 = require('../us-address-text-unique.txt');
+
+process.stdin
+.pipe(split())
+.on('data', function(line) {
+    console.log('Heres a line: ' + line);
+});
+
+let converter = new stream.Transform({ objectMode: true });
+converter._transform = function(data, enc, callback) {
+    let query = data.toString()
+    this.push(query + '\n');
+    callback();
+};
+
+
+
+
+// # Next pass lets you go backwards from result to possible input values
+// springfieldtown => ["Spring Field Town", "Springfield Town"]

--- a/scripts/whitespace-analysis.js
+++ b/scripts/whitespace-analysis.js
@@ -20,15 +20,50 @@ const termops = require('../lib/util/termops.js');
 // Spring Field Town => springfieldtown
 // Springfield Town  => springfieldtown
 
-
-process.stdin
-    .pipe(split())
-    .on('data', function(line) {
-      let result = line.toLowerCase();
-      result = termops.removeWhiteSpace(result)
-        console.log(result);
-    });
-
-
 // # Next pass lets you go backwards from result to possible input values
 // springfieldtown => ["Spring Field Town", "Springfield Town"]
+
+
+// What percentage of strings in each dataset end up overlapping with others
+// once normalized?
+//
+// What are the actual string values that do end up overlapping?
+// Which ones overlap in a potentially positive way
+// (e.g. if Lake View Rd and Lakeview Rd collapse, that’s “positive” in
+//   that users may expect to find one when searching for the other)?
+// Which ones overlap in a potentially unexpected or negative way?
+
+let total = 0;
+let hash = {};
+let result = 0;
+let sameAmt = 0;
+let array = [];
+
+process.stdin
+  .pipe(split())
+  .on('data', (line) => {
+    // normalize the lien
+      let resultLine = line.toLowerCase();
+      resultLine = termops.removeWhiteSpace(resultLine);
+      // track total lines
+      total++;
+      // track # of times the line is the same
+      if (hash[resultLine] !== undefined) {
+          sameAmt++;
+      } else {
+          hash[resultLine] = [];
+      }
+      hash[resultLine].push(line);
+  })
+  .on('end', () => {
+      console.log(hash);
+
+      Object.keys(hash).forEach((el) => {
+          if (hash[el].length > 1) {
+              array.push(hash[el]);
+          }
+      });
+      console.log(array);
+      result = sameAmt/total;
+      console.log(result);
+  });

--- a/scripts/whitespace-analysis.js
+++ b/scripts/whitespace-analysis.js
@@ -1,7 +1,9 @@
-let fs = require('fs');
-let split = require('split');
-let stream = require('stream');
-let termops = require('../lib/util/termops.js');
+#!/usr/bin/env node
+
+const fs = require('fs');
+const split = require('split');
+const stream = require('stream');
+const termops = require('../lib/util/termops.js');
 
 // 1. Add a basic no-op CLI command scripts/whitespace-analysis.js that
 // can handle an input stream and output the input without any changes
@@ -19,17 +21,12 @@ let termops = require('../lib/util/termops.js');
 // Springfield Town  => springfieldtown
 
 
-//
-// you may want to continue to read from `process.stdin`
-// by using stdin you can let `cat` do the file reading for you
-//
-// ```cat <any file> | <your command>
-// ```
-
 process.stdin
     .pipe(split())
     .on('data', function(line) {
-        console.log(termops.removeWhiteSpace(line));
+      let result = line.toLowerCase();
+      result = termops.removeWhiteSpace(result)
+        console.log(result);
     });
 
 

--- a/scripts/whitespace-analysis.js
+++ b/scripts/whitespace-analysis.js
@@ -5,33 +5,7 @@ const split = require('split');
 const stream = require('stream');
 const termops = require('../lib/util/termops.js');
 
-// 1. Add a basic no-op CLI command scripts/whitespace-analysis.js that
-// can handle an input stream and output the input without any changes
-//
-// eg. cat us-place-text-uniq.txt | ./scripts/whitespace-analysis.js
-//
-// 2. Modify the script to lowercase and call the whitespace remover
-// utility function on each incoming line
-//
-// 3. Adjust the script to store a mapping between output and input strings
-// and output the results in a format you can use to answer the questions above.
-
-// # Initial script just normalizes output
-// Spring Field Town => springfieldtown
-// Springfield Town  => springfieldtown
-
-// # Next pass lets you go backwards from result to possible input values
-// springfieldtown => ["Spring Field Town", "Springfield Town"]
-
-
-// What percentage of strings in each dataset end up overlapping with others
-// once normalized?
-//
-// What are the actual string values that do end up overlapping?
-// Which ones overlap in a potentially positive way
-// (e.g. if Lake View Rd and Lakeview Rd collapse, that’s “positive” in
-//   that users may expect to find one when searching for the other)?
-// Which ones overlap in a potentially unexpected or negative way?
+// see ticket: https://github.com/mapbox/carmen/issues/632
 
 let total = 0;
 let hash = {};
@@ -39,31 +13,37 @@ let result = 0;
 let sameAmt = 0;
 let array = [];
 
+const transmuteData = (line) => {
+    // normalize line
+    let resultLine = line.toLowerCase();
+    resultLine = termops.removeWhiteSpace(resultLine);
+    // track total lines
+    total++;
+    // track # of times the line is the same as other queries
+    if (hash[resultLine] !== undefined) {
+        sameAmt++;
+    } else {
+        hash[resultLine] = [];
+    }
+    hash[resultLine].push(line);
+};
+
+
+// In order to retrieve results run
+// `cat filename | ./scripts/whitespace-analysis.js  > results2.json`
+// in terminal
 process.stdin
   .pipe(split())
   .on('data', (line) => {
-    // normalize the lien
-      let resultLine = line.toLowerCase();
-      resultLine = termops.removeWhiteSpace(resultLine);
-      // track total lines
-      total++;
-      // track # of times the line is the same
-      if (hash[resultLine] !== undefined) {
-          sameAmt++;
-      } else {
-          hash[resultLine] = [];
-      }
-      hash[resultLine].push(line);
+      transmuteData(line);
   })
   .on('end', () => {
-      console.log(hash);
-
       Object.keys(hash).forEach((el) => {
           if (hash[el].length > 1) {
               array.push(hash[el]);
           }
       });
-      console.log(array);
       result = sameAmt/total;
-      console.log(result);
+      // console.log(result);
+      // console.log(JSON.stringify(array, null, 2));
   });


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
The purpose here is to normalize a query and understand how often they overlap. The results are given as a percentage.

Young pulled us-address & us-place data for analysis.  I ran this test and found that less than 3% of this data overlaps at all. After looking at the detailed overlapping queries I found there were very few concerning points. The worst examples were: 

```
  [
    “1 1/2 Ave”,
    “11/2 Ave”
  ],
  [
    “Ao Pl”,
    “A O Pl”
  ],
[
    “Le an St”,
    “Lean St”
  ],
[
    “Nace Ln”,
    “N Ace Ln”
  ],
  [
    “Nace Rd”,
    “N Ace Rd”
  ],

```

<!-- with link to relevant ticket(s) or short description -->
[ 632](https://github.com/mapbox/carmen/issues/632)

### Summary of Changes
- [ 632](https://github.com/mapbox/carmen/issues/632)


### Next Steps
<!-- if you're still working on it -->
[633](https://github.com/mapbox/carmen/issues/633)

cc @mapbox/geocoding-gang
