### PR TITLE
Fix behavior of carmen-index.js if it receives a global tokens in the form of a JS file

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ function Geocoder(indexes, options) {
     var q = queue(10);
 
     this.indexes = indexes;
-    this.replacer = token.createGlobalReplacer(options.tokens || {});
+
+    let globalTokens = options.tokens || {};
+    if (typeof globalTokens !== 'object') throw new Error('globalTokens must be an object');
+
+    this.replacer = token.createGlobalReplacer(globalTokens);
+
     this.globaltokens = options.tokens;
     this.byname = {};
     this.bytype = {};

--- a/scripts/carmen-index.js
+++ b/scripts/carmen-index.js
@@ -36,6 +36,9 @@ if (!argv.index) throw new Error('--index argument required');
 var tokens = {};
 if (argv.tokens) {
     tokens = require(path.resolve(argv.tokens));
+    if (typeof tokens === "function") {
+        tokens = tokens();
+    }
 }
 
 var inverseTokens = {};

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -10,6 +10,7 @@ const MBTiles = require('@mapbox/mbtiles');
 const rand = Math.random().toString(36).substr(2, 5);
 const tmpindex = path.join(tmpdir, 'test-carmen-index-' + rand + '.mbtiles');
 const tmpindex2 = path.join(tmpdir, 'test-carmen-index2-' + rand + '.mbtiles');
+const tmpindex3 = path.join(tmpdir, 'test-carmen-index3-' + rand + '.mbtiles');
 const addFeature = require('../lib/util/addfeature'),
     queueFeature = addFeature.queueFeature,
     buildQueued = addFeature.buildQueued;
@@ -23,6 +24,10 @@ tape('clean tmp index', (t) => {
         fs.unlinkSync(tmpindex2)
         fs.removeSync(tmpindex2.replace(".mbtiles", ".freq.rocksdb"));
         fs.removeSync(tmpindex2.replace(".mbtiles", ".grid.rocksdb"));
+
+        fs.unlinkSync(tmpindex3)
+        fs.removeSync(tmpindex3.replace(".mbtiles", ".freq.rocksdb"));
+        fs.removeSync(tmpindex3.replace(".mbtiles", ".grid.rocksdb"));
     } catch (err) {
         //File does not exist
     } finally {
@@ -98,6 +103,13 @@ tape('bin/carmen-index', (t) => {
 
 tape('bin/carmen-index', (t) => {
     exec(bin + '/carmen-index.js --config="'+__dirname + '/fixtures/index-bin-config.json" --tokens="'+__dirname + '/fixtures/tokens.json" --index="'+tmpindex2+'" < ./test/fixtures/small-docs.jsonl', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.end();
+    });
+});
+
+tape('bin/carmen-index', (t) => {
+    exec(bin + '/carmen-index.js --config="'+__dirname + '/fixtures/index-bin-config.json" --tokens="'+__dirname + '/fixtures/tokens.js" --index="'+tmpindex3+'" < ./test/fixtures/small-docs.jsonl', (err, stdout, stderr) => {
         t.ifError(err);
         t.end();
     });

--- a/test/fixtures/tokens.js
+++ b/test/fixtures/tokens.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+    return {
+        "P\\.?\\ ?O\\.? Box [0-9]+": "",
+        "Brazil": "Canada"
+    }
+}


### PR DESCRIPTION
### Context
In some circumstances it might be desirable to have the global tokens file passed into the carmen-index.js be a Javascript file that can dynamically construct a set of token replacements, rather than a simple JSON file. In the event that such a file is used, it needs to be properly run and the resulting token object retrieved.

### Summary of Changes
- [x] add check in carmen-index.js for if the result of requiring the global tokens file is a function or an object, and if a function, run it to get the object
- [x] add check in the carmen constructor to make sure the tokens it gets are in the form of an object
- [x] add a bin test that runs carmen-index.js with a function-containing tokens JS file, to make sure it clears the above hurdles

cc @mapbox/geocoding-gang
