### PR TITLE
Trim stacks and add tests

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -59,7 +59,7 @@ module.exports = function(geocoder, query, options, callback) {
             return callback(errcode('options.stacks must be an array with at least 1 stack', 'EINVALID'));
         var k = options.stacks.length;
         while (k--) {
-            options.stacks[k] = options.stacks[k].toLowerCase();
+            options.stacks[k] = options.stacks[k].toLowerCase().trim();
 
             if (!geocoder.bystack[options.stacks[k]])
                 return callback(errcode('Stack "' + options.stacks[k] + '" is not a known stack. Must be one of: ' + Object.keys(geocoder.bystack).join(', '), 'EINVALID'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,49 @@
 {
   "name": "@mapbox/carmen",
-  "version": "22.4.2",
+  "version": "22.4.3",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@mapbox/carmen-cache": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@mapbox/carmen-cache/-/carmen-cache-0.18.1.tgz",
-      "integrity": "sha1-FAxljpWzicZbGZ0bRuX8E3/gH8w="
+      "integrity": "sha1-FAxljpWzicZbGZ0bRuX8E3/gH8w=",
+      "requires": {
+        "nan": "2.5.1",
+        "node-pre-gyp": "0.6.36",
+        "protozero": "1.5.1"
+      }
     },
     "@mapbox/geojsonhint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-2.0.1.tgz",
-      "integrity": "sha1-MtrHMA8Es+uux0tbqYU9+0JTI1Q="
+      "integrity": "sha1-MtrHMA8Es+uux0tbqYU9+0JTI1Q=",
+      "requires": {
+        "concat-stream": "1.5.2",
+        "jsonlint-lines": "1.7.1",
+        "minimist": "1.2.0",
+        "vfile": "2.0.0",
+        "vfile-reporter": "3.0.0"
+      }
     },
     "@mapbox/locking": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/locking/-/locking-3.1.0.tgz",
-      "integrity": "sha1-KrmNckiT076UPJllTCQs4k2B/pg="
+      "integrity": "sha1-KrmNckiT076UPJllTCQs4k2B/pg=",
+      "requires": {
+        "lru-cache": "4.1.1"
+      }
     },
     "@mapbox/mbtiles": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mbtiles/-/mbtiles-0.9.0.tgz",
       "integrity": "sha1-Ne4WT9lsi4stHZRfLEfoM96KFvE=",
+      "requires": {
+        "@mapbox/sphericalmercator": "1.0.5",
+        "@mapbox/tiletype": "0.3.1",
+        "d3-queue": "2.0.3",
+        "sqlite3": "3.1.8"
+      },
       "dependencies": {
         "d3-queue": {
           "version": "2.0.3",
@@ -38,7 +60,10 @@
     "@mapbox/tile-cover": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.2.tgz",
-      "integrity": "sha1-4Qsbv+Ze4op/GgEn3raZY10PjXo="
+      "integrity": "sha1-4Qsbv+Ze4op/GgEn3raZY10PjXo=",
+      "requires": {
+        "@mapbox/tilebelt": "1.0.1"
+      }
     },
     "@mapbox/tilebelt": {
       "version": "1.0.1",
@@ -49,6 +74,12 @@
       "version": "5.12.6",
       "resolved": "https://registry.npmjs.org/@mapbox/tilelive/-/tilelive-5.12.6.tgz",
       "integrity": "sha1-ALPv4LmZ6DB7wcwJnLdw2nZ2aQs=",
+      "requires": {
+        "@mapbox/sphericalmercator": "1.0.5",
+        "minimist": "0.2.0",
+        "progress-stream": "0.5.0",
+        "queue-async": "1.0.7"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.2.0",
@@ -65,37 +96,63 @@
     "@turf/bbox": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-4.4.0.tgz",
-      "integrity": "sha1-MUlFjrQUBEJ894apD7NoCg6Kq1U="
+      "integrity": "sha1-MUlFjrQUBEJ894apD7NoCg6Kq1U=",
+      "requires": {
+        "@turf/meta": "4.4.0"
+      }
     },
     "@turf/bearing": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-4.4.0.tgz",
-      "integrity": "sha1-uFGd0uYDlyBrMynlI3GxHcC3d+0="
+      "integrity": "sha1-uFGd0uYDlyBrMynlI3GxHcC3d+0=",
+      "requires": {
+        "@turf/invariant": "4.4.0"
+      }
     },
     "@turf/center": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-4.4.0.tgz",
-      "integrity": "sha1-WQe01k+qi5K25URrhPKhUMPg4Js="
+      "integrity": "sha1-WQe01k+qi5K25URrhPKhUMPg4Js=",
+      "requires": {
+        "@turf/bbox": "4.4.0",
+        "@turf/helpers": "4.4.0"
+      }
     },
     "@turf/destination": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-4.4.0.tgz",
-      "integrity": "sha1-InWeiI9g0vvREbVRvjpNEuP6Rug="
+      "integrity": "sha1-InWeiI9g0vvREbVRvjpNEuP6Rug=",
+      "requires": {
+        "@turf/helpers": "4.4.0",
+        "@turf/invariant": "4.4.0"
+      }
     },
     "@turf/distance": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-4.4.0.tgz",
-      "integrity": "sha1-YQH1lRyvTn7lwAZUCQBXSvLxBr0="
+      "integrity": "sha1-YQH1lRyvTn7lwAZUCQBXSvLxBr0=",
+      "requires": {
+        "@turf/helpers": "4.4.0",
+        "@turf/invariant": "4.4.0"
+      }
     },
     "@turf/explode": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-4.4.0.tgz",
-      "integrity": "sha1-JoCosw6hP1PhuefGQk/fvLC2yr0="
+      "integrity": "sha1-JoCosw6hP1PhuefGQk/fvLC2yr0=",
+      "requires": {
+        "@turf/helpers": "4.4.0",
+        "@turf/meta": "4.4.0"
+      }
     },
     "@turf/flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-4.4.0.tgz",
-      "integrity": "sha1-gezvM+andTrogeBX3a0hE8bN39w="
+      "integrity": "sha1-gezvM+andTrogeBX3a0hE8bN39w=",
+      "requires": {
+        "@turf/helpers": "4.4.0",
+        "@turf/meta": "4.4.0"
+      }
     },
     "@turf/helpers": {
       "version": "4.4.0",
@@ -105,7 +162,10 @@
     "@turf/inside": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/inside/-/inside-4.4.0.tgz",
-      "integrity": "sha1-WnjeLA7ZpotJRQj1OuL0tz3XcO8="
+      "integrity": "sha1-WnjeLA7ZpotJRQj1OuL0tz3XcO8=",
+      "requires": {
+        "@turf/invariant": "4.4.0"
+      }
     },
     "@turf/invariant": {
       "version": "4.4.0",
@@ -115,7 +175,13 @@
     "@turf/line-distance": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/line-distance/-/line-distance-4.4.0.tgz",
-      "integrity": "sha1-1xKkIKQjQJrBrmHMaqLHZKqwIEk="
+      "integrity": "sha1-1xKkIKQjQJrBrmHMaqLHZKqwIEk=",
+      "requires": {
+        "@turf/distance": "4.4.0",
+        "@turf/flatten": "4.4.0",
+        "@turf/helpers": "4.4.0",
+        "@turf/meta": "4.4.0"
+      }
     },
     "@turf/meta": {
       "version": "4.4.0",
@@ -125,7 +191,14 @@
     "@turf/point-on-surface": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@turf/point-on-surface/-/point-on-surface-4.4.0.tgz",
-      "integrity": "sha1-Zk7juAsvc8xlgOa9wqAAh+j2ZSw="
+      "integrity": "sha1-Zk7juAsvc8xlgOa9wqAAh+j2ZSw=",
+      "requires": {
+        "@turf/center": "4.4.0",
+        "@turf/distance": "4.4.0",
+        "@turf/explode": "4.4.0",
+        "@turf/helpers": "4.4.0",
+        "@turf/inside": "4.4.0"
+      }
     },
     "abbrev": {
       "version": "1.1.0",
@@ -143,6 +216,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -155,7 +231,11 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -167,7 +247,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -199,19 +284,29 @@
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.2"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -267,6 +362,11 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -278,7 +378,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -296,33 +403,54 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
       "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "platform": "1.3.4"
+      }
     },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "bops": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
-      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo="
+      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
+      "requires": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -340,7 +468,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -365,12 +496,21 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
       "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "requires": {
+        "ansi-styles": "1.0.0",
+        "has-color": "0.1.7",
+        "strip-ansi": "0.1.1"
+      },
       "dependencies": {
         "strip-ansi": {
           "version": "0.1.1",
@@ -389,7 +529,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -403,6 +546,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -426,13 +574,19 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
       "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -443,11 +597,24 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -471,6 +638,13 @@
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -488,13 +662,26 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "har-validator": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.10.0",
+            "is-my-json-valid": "2.16.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "qs": {
           "version": "6.3.2",
@@ -506,7 +693,29 @@
           "version": "2.79.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
         },
         "tunnel-agent": {
           "version": "0.4.3",
@@ -519,12 +728,18 @@
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "d": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "d3-queue": {
       "version": "3.0.7",
@@ -535,6 +750,9 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -547,14 +765,34 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/dawg-cache/-/dawg-cache-0.4.2.tgz",
       "integrity": "sha1-8Whu2YekzioTHVZXOxs0WPv0EHQ=",
+      "requires": {
+        "es6-iterator": "2.0.0",
+        "es6-symbol": "3.0.2",
+        "nan": "2.5.1",
+        "node-pre-gyp": "0.5.31"
+      },
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.5.31",
           "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.0",
+            "nopt": "3.0.1",
+            "npmlog": "0.1.1",
+            "rc": "0.5.2",
+            "request": "2.47.0",
+            "rimraf": "2.2.8",
+            "semver": "4.1.0",
+            "tar": "1.0.1",
+            "tar-pack": "2.0.0"
+          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
               "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -565,6 +803,9 @@
             "nopt": {
               "version": "3.0.1",
               "bundled": true,
+              "requires": {
+                "abbrev": "1.0.5"
+              },
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
@@ -575,6 +816,9 @@
             "npmlog": {
               "version": "0.1.1",
               "bundled": true,
+              "requires": {
+                "ansi": "0.3.0"
+              },
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
@@ -585,6 +829,12 @@
             "rc": {
               "version": "0.5.2",
               "bundled": true,
+              "requires": {
+                "deep-extend": "0.2.11",
+                "ini": "1.1.0",
+                "minimist": "0.0.10",
+                "strip-json-comments": "0.1.3"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.2.11",
@@ -607,6 +857,24 @@
             "request": {
               "version": "2.47.0",
               "bundled": true,
+              "requires": {
+                "aws-sign2": "0.5.0",
+                "bl": "0.9.3",
+                "caseless": "0.6.0",
+                "combined-stream": "0.0.5",
+                "forever-agent": "0.5.2",
+                "form-data": "0.1.4",
+                "hawk": "1.1.1",
+                "http-signature": "0.10.0",
+                "json-stringify-safe": "5.0.0",
+                "mime-types": "1.0.2",
+                "node-uuid": "1.4.1",
+                "oauth-sign": "0.4.0",
+                "qs": "2.3.1",
+                "stringstream": "0.0.4",
+                "tough-cookie": "0.12.1",
+                "tunnel-agent": "0.4.0"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
@@ -615,10 +883,19 @@
                 "bl": {
                   "version": "0.9.3",
                   "bundled": true,
+                  "requires": {
+                    "readable-stream": "1.0.33"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
                       "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
@@ -647,6 +924,9 @@
                 "combined-stream": {
                   "version": "0.0.5",
                   "bundled": true,
+                  "requires": {
+                    "delayed-stream": "0.0.5"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
@@ -661,6 +941,11 @@
                 "form-data": {
                   "version": "0.1.4",
                   "bundled": true,
+                  "requires": {
+                    "async": "0.9.0",
+                    "combined-stream": "0.0.5",
+                    "mime": "1.2.11"
+                  },
                   "dependencies": {
                     "async": {
                       "version": "0.9.0",
@@ -675,14 +960,26 @@
                 "hawk": {
                   "version": "1.1.1",
                   "bundled": true,
+                  "requires": {
+                    "boom": "0.4.2",
+                    "cryptiles": "0.2.2",
+                    "hoek": "0.9.1",
+                    "sntp": "0.2.4"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "0.4.2",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "0.9.1"
+                      }
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "boom": "0.4.2"
+                      }
                     },
                     "hoek": {
                       "version": "0.9.1",
@@ -690,13 +987,21 @@
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "0.9.1"
+                      }
                     }
                   }
                 },
                 "http-signature": {
                   "version": "0.10.0",
                   "bundled": true,
+                  "requires": {
+                    "asn1": "0.1.11",
+                    "assert-plus": "0.1.2",
+                    "ctype": "0.5.2"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.1.11",
@@ -739,6 +1044,9 @@
                 "tough-cookie": {
                   "version": "0.12.1",
                   "bundled": true,
+                  "requires": {
+                    "punycode": "1.3.2"
+                  },
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
@@ -763,14 +1071,28 @@
             "tar": {
               "version": "1.0.1",
               "bundled": true,
+              "requires": {
+                "block-stream": "0.0.7",
+                "fstream": "1.0.2",
+                "inherits": "2.0.1"
+              },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.7",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.1"
+                  }
                 },
                 "fstream": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "requires": {
+                    "graceful-fs": "3.0.4",
+                    "inherits": "2.0.1",
+                    "mkdirp": "0.5.0",
+                    "rimraf": "2.2.8"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.4",
@@ -787,6 +1109,17 @@
             "tar-pack": {
               "version": "2.0.0",
               "bundled": true,
+              "requires": {
+                "debug": "0.7.4",
+                "fstream": "0.1.31",
+                "fstream-ignore": "0.0.7",
+                "graceful-fs": "1.2.3",
+                "once": "1.1.1",
+                "readable-stream": "1.0.33",
+                "rimraf": "2.2.8",
+                "tar": "0.1.20",
+                "uid-number": "0.0.3"
+              },
               "dependencies": {
                 "debug": {
                   "version": "0.7.4",
@@ -795,6 +1128,12 @@
                 "fstream": {
                   "version": "0.1.31",
                   "bundled": true,
+                  "requires": {
+                    "graceful-fs": "3.0.4",
+                    "inherits": "2.0.1",
+                    "mkdirp": "0.5.0",
+                    "rimraf": "2.2.8"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "3.0.4",
@@ -809,6 +1148,11 @@
                 "fstream-ignore": {
                   "version": "0.0.7",
                   "bundled": true,
+                  "requires": {
+                    "fstream": "0.1.31",
+                    "inherits": "2.0.1",
+                    "minimatch": "0.2.14"
+                  },
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
@@ -817,6 +1161,10 @@
                     "minimatch": {
                       "version": "0.2.14",
                       "bundled": true,
+                      "requires": {
+                        "lru-cache": "2.5.0",
+                        "sigmund": "1.0.0"
+                      },
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
@@ -842,6 +1190,12 @@
                 "readable-stream": {
                   "version": "1.0.33",
                   "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -864,10 +1218,18 @@
                 "tar": {
                   "version": "0.1.20",
                   "bundled": true,
+                  "requires": {
+                    "block-stream": "0.0.7",
+                    "fstream": "0.1.31",
+                    "inherits": "2.0.1"
+                  },
                   "dependencies": {
                     "block-stream": {
                       "version": "0.0.7",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.1"
+                      }
                     },
                     "inherits": {
                       "version": "2.0.1",
@@ -888,7 +1250,10 @@
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "debuglog": {
       "version": "1.0.1",
@@ -925,6 +1290,10 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      },
       "dependencies": {
         "object-keys": {
           "version": "1.0.11",
@@ -944,7 +1313,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -960,19 +1338,30 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asap": "2.0.5",
+        "wrappy": "1.0.2"
+      }
     },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "err-code": {
       "version": "1.1.2",
@@ -983,59 +1372,106 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "requires": {
+        "es6-iterator": "2.0.0",
+        "es6-symbol": "3.1.1"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "requires": {
+            "es5-ext": "0.10.23"
+          }
         },
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23"
+          }
         }
       }
     },
     "es6-iterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w="
+      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.0.2"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.23"
+          }
         },
         "es6-iterator": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
           "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23",
+            "es6-symbol": "3.1.1"
+          }
         },
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23"
+          }
         }
       }
     },
@@ -1044,55 +1480,96 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.23"
+          }
         },
         "es6-iterator": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
           "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23",
+            "es6-symbol": "3.1.1"
+          }
         },
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23"
+          }
         }
       }
     },
     "es6-symbol": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-      "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk="
+      "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.23"
+          }
         },
         "es6-iterator": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
           "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23",
+            "es6-symbol": "3.1.1"
+          }
         },
         "es6-symbol": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.23"
+          }
         }
       }
     },
@@ -1106,6 +1583,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "estraverse": {
           "version": "1.9.3",
@@ -1119,13 +1603,56 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.5.2",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.6.1",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -1137,7 +1664,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -1145,7 +1679,11 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "2.7.3",
@@ -1157,13 +1695,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -1182,12 +1727,19 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.23"
+          }
         }
       }
     },
@@ -1217,25 +1769,42 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -1251,12 +1820,21 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-extra": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1266,12 +1844,23 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
     },
     "fstream-ignore": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
     },
     "function-bind": {
       "version": "1.1.0",
@@ -1281,7 +1870,17 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.1.2",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -1293,22 +1892,36 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "geojson-area": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.1.0.tgz",
-      "integrity": "sha1-1I2AcILPrfSnjfE0m+UPOL8YlK4="
+      "integrity": "sha1-1I2AcILPrfSnjfE0m+UPOL8YlK4=",
+      "requires": {
+        "wgs84": "0.0.0"
+      }
     },
     "geojson-rewind": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.2.0.tgz",
       "integrity": "sha1-6lWOnkT/A7hlXQoIt1B43DOhXnk=",
+      "requires": {
+        "concat-stream": "1.2.1",
+        "geojson-area": "0.1.0",
+        "minimist": "0.0.5"
+      },
       "dependencies": {
         "concat-stream": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.2.1.tgz",
-          "integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA="
+          "integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA=",
+          "requires": {
+            "bops": "0.0.6"
+          }
         },
         "minimist": {
           "version": "0.0.5",
@@ -1321,6 +1934,9 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1332,7 +1948,15 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1344,7 +1968,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -1362,12 +1994,21 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1379,17 +2020,27 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg="
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-color": {
       "version": "0.1.7",
@@ -1410,7 +2061,13 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -1426,7 +2083,12 @@
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "ignore": {
       "version": "3.3.3",
@@ -1443,7 +2105,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1460,6 +2126,21 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -1471,7 +2152,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -1495,7 +2183,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -1512,7 +2203,10 @@
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-function": {
       "version": "1.0.1",
@@ -1525,6 +2219,12 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
@@ -1544,13 +2244,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -1562,13 +2268,19 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -1602,6 +2314,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -1613,13 +2341,23 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -1631,7 +2369,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -1651,7 +2392,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1663,7 +2408,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
       "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jju": "1.3.0"
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1673,7 +2421,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1683,7 +2434,10 @@
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -1693,7 +2447,11 @@
     "jsonlint-lines": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz",
-      "integrity": "sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8="
+      "integrity": "sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8=",
+      "requires": {
+        "JSV": "4.0.2",
+        "nomnom": "1.8.1"
+      }
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -1705,6 +2463,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1722,7 +2486,10 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -1741,7 +2508,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -1759,6 +2530,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "1.1.3"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -1768,7 +2542,14 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -1781,20 +2562,44 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "mapnik": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.6.2.tgz",
       "integrity": "sha1-Scqqt9l8BNQ5mzLmqY7CsWWfIYw=",
+      "requires": {
+        "mapnik-vector-tile": "1.4.0",
+        "nan": "2.5.1",
+        "node-pre-gyp": "0.6.36",
+        "protozero": "1.5.1"
+      },
       "dependencies": {
         "node-pre-gyp": {
           "version": "0.6.36",
           "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -1805,6 +2610,10 @@
             "nopt": {
               "version": "4.0.1",
               "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              },
               "dependencies": {
                 "abbrev": {
                   "version": "1.1.0",
@@ -1813,6 +2622,10 @@
                 "osenv": {
                   "version": "0.1.4",
                   "bundled": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  },
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.2",
@@ -1829,10 +2642,20 @@
             "npmlog": {
               "version": "4.1.0",
               "bundled": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
                   "bundled": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.11"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
@@ -1841,6 +2664,15 @@
                     "readable-stream": {
                       "version": "2.2.11",
                       "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.0.1",
+                        "string_decoder": "1.0.2",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -1864,7 +2696,10 @@
                         },
                         "string_decoder": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "safe-buffer": "5.0.1"
+                          }
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -1881,6 +2716,16 @@
                 "gauge": {
                   "version": "2.7.4",
                   "bundled": true,
+                  "requires": {
+                    "aproba": "1.1.2",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  },
                   "dependencies": {
                     "aproba": {
                       "version": "1.1.2",
@@ -1901,6 +2746,11 @@
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
@@ -1909,6 +2759,9 @@
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -1921,6 +2774,9 @@
                     "strip-ansi": {
                       "version": "3.0.1",
                       "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
@@ -1930,7 +2786,10 @@
                     },
                     "wide-align": {
                       "version": "1.1.2",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
                     }
                   }
                 },
@@ -1943,6 +2802,12 @@
             "rc": {
               "version": "1.2.1",
               "bundled": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.2",
@@ -1965,6 +2830,30 @@
             "request": {
               "version": "2.81.0",
               "bundled": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.0",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -1981,6 +2870,9 @@
                 "combined-stream": {
                   "version": "1.0.5",
                   "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -1999,6 +2891,11 @@
                 "form-data": {
                   "version": "2.1.4",
                   "bundled": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  },
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
@@ -2009,10 +2906,18 @@
                 "har-validator": {
                   "version": "4.2.1",
                   "bundled": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  },
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
                       "bundled": true,
+                      "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                      },
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
@@ -2021,6 +2926,9 @@
                         "json-stable-stringify": {
                           "version": "1.0.1",
                           "bundled": true,
+                          "requires": {
+                            "jsonify": "0.0.0"
+                          },
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
@@ -2039,14 +2947,26 @@
                 "hawk": {
                   "version": "3.1.3",
                   "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -2054,13 +2974,21 @@
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     }
                   }
                 },
                 "http-signature": {
                   "version": "1.1.1",
                   "bundled": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.1"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
@@ -2069,6 +2997,12 @@
                     "jsprim": {
                       "version": "1.4.0",
                       "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
@@ -2084,13 +3018,26 @@
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
                     "sshpk": {
                       "version": "1.13.1",
                       "bundled": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -2103,20 +3050,32 @@
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
                           "bundled": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.5"
+                          }
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "bundled": true,
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "bundled": true
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "jsbn": {
                           "version": "0.1.1",
@@ -2147,6 +3106,9 @@
                 "mime-types": {
                   "version": "2.1.15",
                   "bundled": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
@@ -2177,6 +3139,9 @@
                 "tough-cookie": {
                   "version": "2.3.2",
                   "bundled": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
@@ -2186,7 +3151,10 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.0"
+                  }
                 },
                 "uuid": {
                   "version": "3.0.1",
@@ -2197,10 +3165,21 @@
             "rimraf": {
               "version": "2.6.1",
               "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              },
               "dependencies": {
                 "glob": {
                   "version": "7.1.2",
                   "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -2209,6 +3188,10 @@
                     "inflight": {
                       "version": "1.0.6",
                       "bundled": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -2223,10 +3206,17 @@
                     "minimatch": {
                       "version": "3.0.4",
                       "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.7"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
                           "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -2243,6 +3233,9 @@
                     "once": {
                       "version": "1.4.0",
                       "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -2265,14 +3258,28 @@
             "tar": {
               "version": "2.2.1",
               "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
                 },
                 "fstream": {
                   "version": "1.0.11",
                   "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
@@ -2289,10 +3296,23 @@
             "tar-pack": {
               "version": "3.4.0",
               "bundled": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.11",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              },
               "dependencies": {
                 "debug": {
                   "version": "2.6.8",
                   "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
@@ -2303,6 +3323,12 @@
                 "fstream": {
                   "version": "1.0.11",
                   "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.11",
@@ -2317,6 +3343,11 @@
                 "fstream-ignore": {
                   "version": "1.0.5",
                   "bundled": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  },
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
@@ -2325,10 +3356,17 @@
                     "minimatch": {
                       "version": "3.0.4",
                       "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.7"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
                           "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -2347,6 +3385,9 @@
                 "once": {
                   "version": "1.4.0",
                   "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
@@ -2357,6 +3398,15 @@
                 "readable-stream": {
                   "version": "2.2.11",
                   "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "safe-buffer": "5.0.1",
+                    "string_decoder": "1.0.2",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -2380,7 +3430,10 @@
                     },
                     "string_decoder": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "bundled": true,
+                      "requires": {
+                        "safe-buffer": "5.0.1"
+                      }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -2411,12 +3464,18 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -2427,6 +3486,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -2465,28 +3527,59 @@
     "node-pre-gyp": {
       "version": "0.6.36",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y="
+      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+      "requires": {
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.0",
+        "rc": "1.2.1",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.0"
+      }
     },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc="
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "requires": {
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
+      }
     },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00="
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.0",
+        "osenv": "0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "npmlog": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
+      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -2517,7 +3610,10 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -2530,6 +3626,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -2549,7 +3649,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2564,7 +3672,11 @@
     "osenv": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2604,7 +3716,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "platform": {
       "version": "1.3.4",
@@ -2615,7 +3730,10 @@
     "plur": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo="
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "1.2.0"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -2643,7 +3761,12 @@
     "progress-stream": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-0.5.0.tgz",
-      "integrity": "sha1-zEdZFnpv9PBYdheThPC2rg0ddYc="
+      "integrity": "sha1-zEdZFnpv9PBYdheThPC2rg0ddYc=",
+      "requires": {
+        "single-line-log": "0.3.1",
+        "speedometer": "0.1.4",
+        "through2": "0.2.3"
+      }
     },
     "protozero": {
       "version": "1.5.1",
@@ -2673,42 +3796,86 @@
     "rc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU="
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "read-installed": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debuglog": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "read-package-json": "2.0.5",
+        "readdir-scoped-modules": "1.0.2",
+        "semver": "5.3.0",
+        "slide": "1.1.6",
+        "util-extend": "1.0.3"
+      }
     },
     "read-package-json": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
       "integrity": "sha1-+Tpk5kFSnfaKCMZN5GOJ6KP4iEU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "json-parse-helpfulerror": "1.0.3",
+        "normalize-package-data": "2.3.8"
+      }
     },
     "readable-stream": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00="
+      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdir-scoped-modules": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "graceful-fs": "4.1.11",
+        "once": "1.4.0"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -2723,19 +3890,50 @@
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -2747,19 +3945,32 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "retire": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/retire/-/retire-1.3.2.tgz",
       "integrity": "sha1-tJsMeLOo66OnZNTvw1RfKI/m3oI=",
       "dev": true,
+      "requires": {
+        "commander": "2.5.1",
+        "read-installed": "4.0.3",
+        "request": "2.81.0",
+        "walkdir": "0.0.7"
+      },
       "dependencies": {
         "commander": {
           "version": "2.5.1",
@@ -2774,18 +3985,27 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -2812,7 +4032,12 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -2839,20 +4064,29 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -2874,7 +4108,10 @@
     "split": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64="
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -2886,6 +4123,10 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
       "integrity": "sha1-TLz5Zdi5AdGxAVy8f8QVquFX36o=",
+      "requires": {
+        "nan": "2.4.0",
+        "node-pre-gyp": "0.6.31"
+      },
       "dependencies": {
         "nan": {
           "version": "2.4.0",
@@ -2896,11 +4137,25 @@
           "version": "0.6.31",
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz",
           "integrity": "sha1-2KAN2qMBqUBhXbzIyq1AJNWPYBc=",
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.0.0",
+            "rc": "1.1.6",
+            "request": "2.76.0",
+            "rimraf": "2.5.4",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.3.0"
+          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -2913,6 +4168,9 @@
               "version": "3.0.6",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "requires": {
+                "abbrev": "1.0.9"
+              },
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.9",
@@ -2925,11 +4183,21 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
               "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
+              "requires": {
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.6.0",
+                "set-blocking": "2.0.0"
+              },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.1.5"
+                  },
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
@@ -2940,6 +4208,15 @@
                       "version": "2.1.5",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                       "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "buffer-shims": {
                           "version": "1.0.0",
@@ -2989,6 +4266,17 @@
                   "version": "2.6.0",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
                   "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-color": "0.1.7",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.1",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.0"
+                  },
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
@@ -3019,11 +4307,19 @@
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "requires": {
+                        "code-point-at": "1.0.1",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
                           "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -3036,6 +4332,9 @@
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
@@ -3050,6 +4349,9 @@
                       "version": "3.0.1",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -3061,7 +4363,10 @@
                     "wide-align": {
                       "version": "1.1.0",
                       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
+                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
                     }
                   }
                 },
@@ -3076,6 +4381,12 @@
               "version": "1.1.6",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+              "requires": {
+                "deep-extend": "0.4.1",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "1.0.4"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
@@ -3103,6 +4414,28 @@
               "version": "2.76.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
               "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.5.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.1",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.12",
+                "node-uuid": "1.4.7",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.0",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3"
+              },
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -3123,6 +4456,9 @@
                   "version": "1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -3145,6 +4481,11 @@
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
                   "integrity": "sha1-St8DQuGnmvoehMjDIKn/yCOSofM=",
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.12"
+                  },
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
@@ -3157,11 +4498,24 @@
                   "version": "2.0.6",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.15.0",
+                    "pinkie-promise": "2.0.1"
+                  },
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
@@ -3177,6 +4531,9 @@
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
@@ -3189,6 +4546,9 @@
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
@@ -3208,6 +4568,9 @@
                       "version": "2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
@@ -3220,6 +4583,12 @@
                       "version": "2.15.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                       "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.0",
+                        "xtend": "4.0.1"
+                      },
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -3230,6 +4599,9 @@
                           "version": "1.2.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -3254,6 +4626,9 @@
                       "version": "2.0.1",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -3268,16 +4643,28 @@
                   "version": "3.1.3",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -3287,7 +4674,10 @@
                     "sntp": {
                       "version": "1.0.9",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
                     }
                   }
                 },
@@ -3295,6 +4685,11 @@
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.3.1",
+                    "sshpk": "1.10.1"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
@@ -3305,6 +4700,11 @@
                       "version": "1.3.1",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                       "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
@@ -3319,7 +4719,10 @@
                         "verror": {
                           "version": "1.3.6",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
                         }
                       }
                     },
@@ -3327,6 +4730,17 @@
                       "version": "1.10.1",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.0",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.14.3"
+                      },
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -3342,29 +4756,44 @@
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
                           "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.3"
+                          }
                         },
                         "dashdash": {
                           "version": "1.14.0",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE="
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
                         },
                         "getpass": {
                           "version": "0.1.6",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY="
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
                         },
                         "jodid25519": {
                           "version": "1.0.2",
                           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                          "optional": true
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
                         },
                         "jsbn": {
                           "version": "0.1.0",
@@ -3401,6 +4830,9 @@
                   "version": "2.1.12",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+                  "requires": {
+                    "mime-db": "1.24.0"
+                  },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
@@ -3433,6 +4865,9 @@
                   "version": "2.3.2",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
@@ -3452,11 +4887,22 @@
               "version": "2.5.4",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "requires": {
+                "glob": "7.1.1"
+              },
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -3467,6 +4913,10 @@
                       "version": "1.0.6",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -3484,11 +4934,18 @@
                       "version": "3.0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -3508,6 +4965,9 @@
                       "version": "1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -3534,16 +4994,30 @@
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.10",
+                "inherits": "2.0.3"
+              },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
                 },
                 "fstream": {
                   "version": "1.0.10",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
                   "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "requires": {
+                    "graceful-fs": "4.1.9",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
@@ -3563,11 +5037,24 @@
               "version": "3.3.0",
               "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
               "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+              "requires": {
+                "debug": "2.2.0",
+                "fstream": "1.0.10",
+                "fstream-ignore": "1.0.5",
+                "once": "1.3.3",
+                "readable-stream": "2.1.5",
+                "rimraf": "2.5.4",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              },
               "dependencies": {
                 "debug": {
                   "version": "2.2.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                  "requires": {
+                    "ms": "0.7.1"
+                  },
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
@@ -3580,6 +5067,12 @@
                   "version": "1.0.10",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
                   "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+                  "requires": {
+                    "graceful-fs": "4.1.9",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
                   "dependencies": {
                     "graceful-fs": {
                       "version": "4.1.9",
@@ -3597,6 +5090,11 @@
                   "version": "1.0.5",
                   "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
                   "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+                  "requires": {
+                    "fstream": "1.0.10",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3"
+                  },
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
@@ -3607,11 +5105,18 @@
                       "version": "3.0.3",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
@@ -3633,6 +5138,9 @@
                   "version": "1.3.3",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
@@ -3645,6 +5153,15 @@
                   "version": "2.1.5",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -3698,6 +5215,16 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3709,18 +5236,31 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "string.prototype.trim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "1.1.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3730,7 +5270,10 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -3753,6 +5296,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -3764,7 +5315,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -3776,7 +5334,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -3785,6 +5347,21 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.6.3.tgz",
       "integrity": "sha1-Y353WB6ass4XV36b1M5PV1gG2LY=",
       "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.2.2",
+        "resolve": "1.1.7",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
@@ -3797,12 +5374,27 @@
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
     },
     "tar-pack": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ="
+      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+      "requires": {
+        "debug": "2.6.8",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.2",
+        "rimraf": "2.6.1",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -3819,6 +5411,10 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3828,7 +5424,13 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3845,7 +5447,10 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim": {
       "version": "0.0.1",
@@ -3861,7 +5466,10 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -3873,7 +5481,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -3886,6 +5497,11 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -3922,7 +5538,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3944,22 +5563,46 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "vfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.0.0.tgz",
-      "integrity": "sha1-iGIFAONrrQJaCwHMJRBtvLMJBUg="
+      "integrity": "sha1-iGIFAONrrQJaCwHMJRBtvLMJBUg=",
+      "requires": {
+        "has": "1.0.1",
+        "is-buffer": "1.1.5",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1",
+        "x-is-string": "0.1.0"
+      }
     },
     "vfile-reporter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-3.0.0.tgz",
       "integrity": "sha1-/lBxTjc+DSlAUQA4qZvWCb3IIJ8=",
+      "requires": {
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "repeat-string": "1.6.1",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "trim": "0.0.1",
+        "unist-util-stringify-position": "1.1.1"
+      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -3969,7 +5612,14 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -3988,12 +5638,18 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -4017,7 +5673,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "x-is-string": {
       "version": "0.1.0",
@@ -4032,7 +5691,10 @@
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "requires": {
+        "object-keys": "0.4.0"
+      }
     },
     "yallist": {
       "version": "2.1.2",
@@ -4044,7 +5706,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/test/geocode-unit.geocoder_stack.test.js
+++ b/test/geocode-unit.geocoder_stack.test.js
@@ -87,6 +87,14 @@ const addFeature = require('../lib/util/addfeature'),
         });
     });
 
+    tape('query filter - trim spaces', (t) => {
+        c.geocode('0,0', { stacks: ['CA '] }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Canada');
+            t.end();
+        });
+    });
+
     tape('query filter', (t) => {
         c.geocode('United States', { stacks: ['ca'] }, (err, res) => {
             t.ifError(err);


### PR DESCRIPTION
### Context

When human entering values during testing I often add a space between `geocoder_stack` values which throws a hard error. This PR adds trimming in addition to the current lower casing on all entered `geocoder_stack` values to prevent this from becoming a hard error.

### Summary of Changes
- [x] `trim()` all `geocoder_stack` values

cc @mapbox/geocoding-gang
