### PR TITLE
Remove stacky, gappy penalties

### DIFF
--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -244,8 +244,6 @@ function verifyContexts(contexts, sets, indexes) {
 
 function verifyContext(context, peers, strict, loose, indexes) {
     var addressOrder = context[0].properties['carmen:geocoder_address_order'];
-    var gappy = 0;
-    var stacky = false;
     var usedmask = 0;
     var lastmask = -1;
     var lastgroup = -1;
@@ -289,8 +287,6 @@ function verifyContext(context, peers, strict, loose, indexes) {
             } else if (direction === "descending") {
                 backy = lastmask < matched.mask;
             }
-            stacky = true;
-            gappy += Math.abs(indexes[feat.properties["carmen:index"]].ndx - lastgroup) - 1;
         }
 
         usedmask = usedmask | matched.mask;
@@ -303,8 +299,6 @@ function verifyContext(context, peers, strict, loose, indexes) {
         }
     }
 
-    if (!stacky) relevance -= 0.01;
-
     // small bonus if feature order matches the expected order of the index
     if (direction) relevance -= 0.01;
     if (addressOrder === direction) relevance += 0.01;
@@ -315,8 +309,6 @@ function verifyContext(context, peers, strict, loose, indexes) {
     // exact carmen:text value with something in its context (e.g. New York, New York)
     if (squishy > 0)
         context[0].properties["carmen:scoredist"] += squishy;
-    else
-        relevance -= 0.001 * gappy;
 
     relevance = relevance > 0 ? relevance : 0;
 

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -118,7 +118,7 @@ tape('bin/carmen-index', (t) => {
 tape('bin/carmen DEBUG', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query="canada" --debug="38"', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.99 Canada/.test(stdout), true, 'finds canada');
+        t.equal(/\d+\.\d+ Canada/.test(stdout), true, 'finds canada');
         t.ok(stdout.indexOf('PhraseMatch\n-----------') !== -1, 'debug phrase match');
         t.ok(stdout.indexOf('SpatialMatch\n------------') !== -1, 'debug spatial');
         t.ok(stdout.indexOf('spatialmatch position: 0') !== -1, 'debug spatial');
@@ -145,7 +145,7 @@ tape('bin/carmen version', (t) => {
 tape('bin/carmen query', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.99 Brazil/.test(stdout), true, 'finds brazil');
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
         t.end();
     });
 });
@@ -179,7 +179,7 @@ tape('bin/carmen query w/ stats', (t) => {
 tape('bin/carmen query w/ global tokens', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --tokens="'+__dirname + '/fixtures/tokens.json"', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.99 Canada/.test(stdout), true, 'finds canada');
+        t.equal(/\d+\.\d+ Canada/.test(stdout), true, 'finds canada');
         t.end();
     });
 });
@@ -187,7 +187,7 @@ tape('bin/carmen query w/ global tokens', (t) => {
 tape('bin/carmen query types', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --types="test-carmen-index-' + rand + '"', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.99 Brazil/.test(stdout), true, 'finds brazil');
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
         t.end();
     });
 });
@@ -206,14 +206,14 @@ tape('bin/carmen query wrong stacks', (t) => {
 tape('bin/carmen query language=es', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --language="es"', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.\d+ Brasil/.test(stdout), true, 'finds brasil');
+        t.equal(/\d+\.\d+ Brasil/.test(stdout), true, 'finds brasil');
         t.end();
     });
 });
 tape('bin/carmen query language=es,en', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --language="es,en"', (err, stdout, stderr) => {
         t.ifError(err);
-        t.equal(/0\.\d+ Brasil/.test(stdout), true, 'finds brasil');
+        t.equal(/\d+\.\d+ Brasil/.test(stdout), true, 'finds brasil');
         t.end();
     });
 });

--- a/test/fixtures/output.default.geojson
+++ b/test/fixtures/output.default.geojson
@@ -7,15 +7,15 @@
         {
             "id": "place.1",
             "type": "Feature",
-            "text": "Toronto",
-            "place_name": "Toronto, Ontario, Canada",
             "place_type": [
                 "place"
             ],
-            "relevance": 0.99,
+            "relevance": 1,
             "properties": {
                 "wikidata": "Q172"
             },
+            "text": "Toronto",
+            "place_name": "Toronto, Ontario, Canada",
             "bbox": [
                 -40,
                 -40,
@@ -35,12 +35,12 @@
             },
             "context": [
                 {
-                    "text": "Ontario",
-                    "id": "region.1"
+                    "id": "region.1",
+                    "text": "Ontario"
                 },
                 {
-                    "text": "Canada",
-                    "id": "country.1"
+                    "id": "country.1",
+                    "text": "Canada"
                 }
             ]
         }

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -7,12 +7,10 @@
         {
             "id": "place.1",
             "type": "Feature",
-            "text": "Toronto",
-            "place_name": "Toronto, Ontario, Canada",
             "place_type": [
                 "place"
             ],
-            "relevance": 0.99,
+            "relevance": 1,
             "properties": {
                 "wikidata": "Q172",
                 "carmen:text": "Toronto",
@@ -320,6 +318,8 @@
                 "carmen:query_text": "toronto",
                 "carmen:idx": 2
             },
+            "text": "Toronto",
+            "place_name": "Toronto, Ontario, Canada",
             "bbox": [
                 -40,
                 -40,
@@ -339,12 +339,12 @@
             },
             "context": [
                 {
-                    "text": "Ontario",
-                    "id": "region.1"
+                    "id": "region.1",
+                    "text": "Ontario"
                 },
                 {
-                    "text": "Canada",
-                    "id": "country.1"
+                    "id": "country.1",
+                    "text": "Canada"
                 }
             ]
         }

--- a/test/fixtures/output.reverse-dev.geojson
+++ b/test/fixtures/output.reverse-dev.geojson
@@ -8,8 +8,6 @@
         {
             "id": "place.1",
             "type": "Feature",
-            "text": "Toronto",
-            "place_name": "Toronto, Ontario, Canada",
             "place_type": [
                 "place"
             ],
@@ -292,6 +290,8 @@
                 "carmen:geomtype": 3,
                 "carmen:reverseMode": false
             },
+            "text": "Toronto",
+            "place_name": "Toronto, Ontario, Canada",
             "bbox": [
                 -40,
                 -40,
@@ -311,20 +311,18 @@
             },
             "context": [
                 {
-                    "text": "Ontario",
-                    "id": "region.1"
+                    "id": "region.1",
+                    "text": "Ontario"
                 },
                 {
-                    "text": "Canada",
-                    "id": "country.1"
+                    "id": "country.1",
+                    "text": "Canada"
                 }
             ]
         },
         {
             "id": "region.1",
             "type": "Feature",
-            "text": "Ontario",
-            "place_name": "Ontario, Canada",
             "place_type": [
                 "region"
             ],
@@ -604,6 +602,8 @@
                 "carmen:geomtype": 3,
                 "carmen:reverseMode": false
             },
+            "text": "Ontario",
+            "place_name": "Ontario, Canada",
             "bbox": [
                 -40,
                 -40,
@@ -623,16 +623,14 @@
             },
             "context": [
                 {
-                    "text": "Canada",
-                    "id": "country.1"
+                    "id": "country.1",
+                    "text": "Canada"
                 }
             ]
         },
         {
             "id": "country.1",
             "type": "Feature",
-            "text": "Canada",
-            "place_name": "Canada",
             "place_type": [
                 "country"
             ],
@@ -912,6 +910,8 @@
                 "carmen:geomtype": 3,
                 "carmen:reverseMode": false
             },
+            "text": "Canada",
+            "place_name": "Canada",
             "bbox": [
                 -40,
                 -40,

--- a/test/geocode-unit.address-alphanumeric.test.js
+++ b/test/geocode-unit.address-alphanumeric.test.js
@@ -34,7 +34,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9B FAKE STREET', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -91,7 +91,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('70 WASHINGTON STREET #501', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found: 70 WASHINGTON STREET');
-            t.equals(res.features[0].relevance, 0.49);
+            t.equals(res.features[0].relevance, 0.50);
             t.end();
         });
     });
@@ -121,7 +121,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9b fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -151,7 +151,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9b fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -183,7 +183,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9b fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.equals(res.features[0].address, '9b', 'address number is 9b');
             t.end();
         });
@@ -226,7 +226,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9b fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street', 'found 9b fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.equals(res.features[0].address, '9b', 'address number is 9b');
             t.end();
         });
@@ -289,7 +289,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test UK postcode not getting confused w/ address range', (t) => {
         c.geocode('B77 1AB', { limit_verify: 10 }, (err, res) => {
             t.equals(res.features[0].place_name, 'B77 1AB', 'found feature \'B77 1AB\'');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.equals(res.features[0].id.split('.')[0], 'postcode', 'feature is from layer postcode');
             let addressInResultSet = res.features.some((feature) => { return feature.id.split('.')[0] === 'address' });
             t.ok(!addressInResultSet, 'result set does not include address feature');
@@ -324,7 +324,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('23-414 beach street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '23-414 beach street', 'found 23-414 beach street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -232,7 +232,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('Search for an address without a number (multiple layers)', (t) => {
         c.geocode('fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":0.79,"place_type": ['address'],"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
+            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":0.8,"place_type": ['address'],"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
             t.end();
         });
     });
@@ -276,7 +276,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test address index for US relev', (t) => {
         c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -284,7 +284,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test address index for DE relev', (t) => {
         c.geocode('fake street 9', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -325,7 +325,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test address index for relev', (t) => {
         c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.49);
+            t.equals(res.features[0].relevance, 0.50);
             t.end();
         });
     });

--- a/test/geocode-unit.address-misc.test.js
+++ b/test/geocode-unit.address-misc.test.js
@@ -111,7 +111,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('3 Grundarstræti', null, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '3 Grundarstræti', 'Matched ITP');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });

--- a/test/geocode-unit.address-omitted.test.js
+++ b/test/geocode-unit.address-omitted.test.js
@@ -34,7 +34,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9 fake street', 'found 9 fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });
@@ -70,7 +70,7 @@ const addFeature = require('../lib/util/addfeature'),
         c.geocode('102 fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '102 fake street', 'found 102 fake street');
-            t.equals(res.features[0].relevance, 0.99);
+            t.equals(res.features[0].relevance, 1.00);
             t.end();
         });
     });

--- a/test/geocode-unit.cluster-vs-range.test.js
+++ b/test/geocode-unit.cluster-vs-range.test.js
@@ -65,7 +65,7 @@ tape('test address query with address range', (t) => {
     c.geocode('100 fake street', { limit_verify: 2 }, (err, res) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, '100 fake street', 'found 100 fake street');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.dataterm.test.js
+++ b/test/geocode-unit.dataterm.test.js
@@ -61,7 +61,7 @@ tape('test address', (t) => {
     c.geocode('1500 fake street', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, '1500 fake street', 'found 1500 fake street');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.index-limit.test.js
+++ b/test/geocode-unit.index-limit.test.js
@@ -40,7 +40,7 @@ tape('query place', (t) => {
     c.geocode('Chicago', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'Chicago', 'found Chicago');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.jp-order.test.js
+++ b/test/geocode-unit.jp-order.test.js
@@ -98,7 +98,7 @@ tape('Check order, 632 中黒 Japan 岩出市', (t) => {
     c.geocode('632 中黒 Japan 岩出市', { limit_verify: 1}, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].address, '632', "Gets correct address");
-        t.equal(res.features[0].relevance, 0.8223333333333333, "Mixed-up order lowers relevance")
+        t.equal(res.features[0].relevance, 0.8233333333333333, "Mixed-up order lowers relevance")
         t.end();
     });
 });

--- a/test/geocode-unit.localtext.test.js
+++ b/test/geocode-unit.localtext.test.js
@@ -94,7 +94,7 @@ tape('Российская => Russian Federation (autocomplete without language 
         t.ifError(err);
         t.deepEqual(res.features.length, 1, '1 result');
         t.deepEqual(res.features[0].place_name, 'Russian Federation');
-        t.ok(res.features[0].relevance < .9, 'Relevance penalty was applied for out-of-language match');
+        t.ok(res.features[0].relevance <= .9, 'Relevance penalty was applied for out-of-language match');
         t.deepEqual(res.features[0].id, 'country.2');
         t.deepEqual(res.features[0].id, 'country.2');
         t.end();
@@ -119,7 +119,7 @@ tape('Российская => Российская Федерация (autocompl
         t.ifError(err);
         t.deepEqual(res.features.length, 1, '1 result');
         t.deepEqual(res.features[0].place_name, 'Russian Federation');
-        t.ok(res.features[0].relevance < .9, 'Relevance penalty was applied for out-of-language match');
+        t.ok(res.features[0].relevance <= .9, 'Relevance penalty was applied for out-of-language match');
         t.deepEqual(res.features[0].place_name_ru, 'Российская Федерация');
         t.deepEqual(res.features[0].id, 'country.2');
         t.end();

--- a/test/geocode-unit.numeric.test.js
+++ b/test/geocode-unit.numeric.test.js
@@ -67,9 +67,9 @@ tape('query', (t) => {
         t.ifError(err);
         // 22209 does not win here until we have suggest vs final modes.
         t.equals(res.features[0].place_name, '22209', 'found 22209');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.equals(res.features[1].place_name, '22209 restaurant', 'found 22209 restaurant');
-        t.equals(res.features[1].relevance, 0.99);
+        t.equals(res.features[1].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.promote-language.test.js
+++ b/test/geocode-unit.promote-language.test.js
@@ -113,7 +113,7 @@ tape('find nueva york, language=es', (t) => {
 tape('find nueva york, language=ca', (t) => {
     c.geocode('nueva york', { language: 'ca' }, (err, res) => {
         t.equal(res.features[0].id, 'place.1');
-        t.equal(res.features[0].relevance, 0.99, "query has full relevance because 'nueva york' has no ca translation but es falls back");
+        t.equal(res.features[0].relevance, 1.00, "query has full relevance because 'nueva york' has no ca translation but es falls back");
         t.end();
     });
 });
@@ -211,7 +211,7 @@ tape('build queued features', (t) => {
 tape('find makkah', (t) => {
     c2.geocode('makkah', {}, (err, res) => {
         t.equal(res.features[0].id, 'place.1');
-        t.equal(res.features[0].relevance, 0.99);
+        t.equal(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.promote-score.test.js
+++ b/test/geocode-unit.promote-score.test.js
@@ -116,7 +116,7 @@ tape('build queued features', (t) => {
 tape('find georgia', (t) => {
     c.geocode('georgia', {}, (err, res) => {
         t.equal(res.features[0].id, 'region.1');
-        t.equal(res.features[0].relevance, 0.99);
+        t.equal(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.proximity.test.js
+++ b/test/geocode-unit.proximity.test.js
@@ -146,7 +146,7 @@ tape('forward country - single layer - limit', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.1', 'found country.1');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -156,7 +156,7 @@ tape('forward country - proximity - single layer - limit', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.2', 'found country.2');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -166,7 +166,7 @@ tape('forward country - proximity - single layer - limit', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.1', 'found country.1');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -176,7 +176,7 @@ tape('forward country - multi layer - limit', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'province', 'found province');
         t.equals(res.features[0].id, 'country.3', 'found country.3');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -186,7 +186,7 @@ tape('forward country - single layer', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.1', 'found country.1');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -196,7 +196,7 @@ tape('forward country - proximity - single layer', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.2', 'found country.2');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -206,7 +206,7 @@ tape('forward country - proximity - single layer', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'country', 'found country');
         t.equals(res.features[0].id, 'country.1', 'found country.1');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -216,7 +216,7 @@ tape('forward country - multi layer', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'province', 'found province');
         t.equals(res.features[0].id, 'country.3', 'found country.3');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });
@@ -227,7 +227,7 @@ tape('forward country - scoredist wins', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'province, country', 'found province');
         t.equals(res.features[0].id, 'province.1', 'found province.1');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.relevance.test.js
+++ b/test/geocode-unit.relevance.test.js
@@ -98,11 +98,11 @@ tape('build queued features', (t) => {
 tape('Check relevance scoring', (t) => {
     c.geocode('11027 S. Pikes Peak Drive #201', {limit_verify: 1}, (err, res) => {
         t.ifError(err);
-        t.equal(res.features[0].relevance, .49, "Apt. number lowers relevance");
+        t.equal(res.features[0].relevance, 0.50, "Apt. number lowers relevance");
     });
     c.geocode('11027 S. Pikes Peak Drive', {limit_verify: 1}, (err, res) => {
         t.ifError(err);
-        t.equal(res.features[0].relevance, .99, "High relevance with no apartment number");
+        t.equal(res.features[0].relevance, 1.00, "High relevance with no apartment number");
         t.end()
     });
 });

--- a/test/geocode-unit.strictloose.test.js
+++ b/test/geocode-unit.strictloose.test.js
@@ -61,7 +61,7 @@ tape('albany australia', (t) => {
     c.geocode('albany australia', {}, (err, res) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'albany, western australia, australia');
-        t.deepEqual(res.features[0].relevance, 0.999);
+        t.deepEqual(res.features[0].relevance, 1.0);
         t.end();
     });
 });

--- a/test/geocode-unit.tile-edge.test.js
+++ b/test/geocode-unit.tile-edge.test.js
@@ -30,7 +30,7 @@ tape('forward between tiles', (t) => {
         t.ifError(err);
         t.equals(res.features[0].place_name, 'test', 'found feature');
         t.equals(res.features[0].id, 'test.1', 'found feature');
-        t.equals(res.features[0].relevance, 0.99);
+        t.equals(res.features[0].relevance, 1.00);
         t.end();
     });
 });

--- a/test/geocode-unit.tokens.test.js
+++ b/test/geocode-unit.tokens.test.js
@@ -33,7 +33,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test address index for relev', (t) => {
         c.geocode('fake st', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token replacement test, fake st');
+            t.equals(res.features[0].relevance, 1.00, 'token replacement test, fake st');
             t.end();
         });
     });
@@ -66,14 +66,14 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test address index for relev', (t) => {
         c.geocode('avenue du 18e régiment', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'avenue du 18e');
+            t.equals(res.features[0].relevance, 1.00, 'avenue du 18e');
             t.end();
         });
     });
     tape('test address index for relev', (t) => {
         c.geocode('avenue du dix-huitième régiment', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'avenue du dix-huitième régiment');
+            t.equals(res.features[0].relevance, 1.00, 'avenue du dix-huitième régiment');
             t.end();
         });
     });
@@ -105,7 +105,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test token replacement', (t) => {
         c.geocode('qabc', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token regex numbered group test, qabc => qcba');
+            t.equals(res.features[0].relevance, 1.00, 'token regex numbered group test, qabc => qcba');
             t.end();
         });
     });
@@ -240,21 +240,21 @@ const addFeature = require('../lib/util/addfeature'),
     tape('test token replacement', (t) => {
         c.geocode('Talstrasse', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token replacement for str -> strasse');
+            t.equals(res.features[0].relevance, 1.00, 'token replacement for str -> strasse');
             t.end();
         });
     });
     tape('test token replacement', (t) => {
         c.geocode('Talstr ', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token replacement for str -> strasse');
+            t.equals(res.features[0].relevance, 1.00, 'token replacement for str -> strasse');
             t.end();
         });
     });
     tape('test token replacement', (t) => {
         c.geocode('Tal str ', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.99, 'token replacement for str -> strasse');
+            t.equals(res.features[0].relevance, 1.00, 'token replacement for str -> strasse');
             t.end();
         });
     });


### PR DESCRIPTION
TL;DR I think it's time to remove the gappy/stacky penalties.

In `master` we apply a very slight penalty and a very slight bonus in these scenarios:

- If you search for something using text that gives it additional context, we give a slight bonus to that feature ("stacking")
  - Example Query: "Atlanta Georgia"
    - "Atlanta Georgia" (the place, region) gets a slight text relev bonus in comparison to
    - "Atlanta Georgia's Best Beer Brewery" (the poi)
- If you search for something where the context is closer in hierarchy to the feature involved, it gets a higher bonus than a feature where the context is very far away in hierarchy
  - Example Query: "100 Main Street United States" << `address <=> country` context distance is far
  - Example Query: "100 Main Street Buffalo" << `address <=> place` context distance is short

These bonuses and penalties were meant to address a variety of corner case issues. One that I remember distinctly is this:

`12345 Georgia`

This could be a postcode search (the postcode `12345` in the state of `Georgia`) or maybe it's the beginning of an address (`12345 Georgia Ave`). In `master` we've decided to favor the former.

---

## Now consider these cases...

### A

For the query `69th Ave Oakland` we are currently matching

1. `69th Ave` (address) in `Oakland Gardens` (neighborhood) in `New York` (place)
2. `69th Ave` (address) in `Oakland` (place)

**Explanation:** 1 is beating 2 here because of the `gappy` penalty -- neighborhood and address are closer in our hierarchy than place and address. :disappointed:

**My personal response:** this feels super arbitrary and wrong.

### B

Roughly the same story. For the query `1509 16th St NW` we are currently matching

1. `1509 16th St` (address) in `Northwest Everett` (neighborhood) in `Everett` (place)
2. `1509 16th St NW` (address) in `Washington DC` (place)

**Explanation:** 1 is beating 2 here because of the `stacky` bonus. 2 is a contiguous query, while 1 has "additional context" ("NW" => "Northwest Everett") supplied to the address component.

**My personal response:** this also feels super arbitrary and wrong.

---

## Time to remove

Based on these cases and some IRL testing, the actual cases that stacky and gappy bonus/penalties were addressing seem to have been addressed through other means (e.g. @mattficke's work penalizing directional flips). For example, our stacky and gappy unit tests still pass with this functionality removed :smirk:

cc @mapbox/geocoding-gang
