### PR TITLE
The Numnum Bug

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -151,7 +151,7 @@ function tokenize(query, lonlat) {
  * is a valid address
  *
  * @param {Array} query tokenized query
- * @param {Array} tokenized cover text
+ * @param {String} cover text
  * @param {Integer} mask a mask for the given query
  * @return {Object} returns an address object or null
 */

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -4,7 +4,6 @@ var idPattern = /^(\S+)\.([0-9]+)$/;
 var token = require('./token');
 var permute = require('./permute');
 var cl = require('./closest-lang');
-var levenshtein = require('fast-levenshtein');
 
 module.exports.id = id;
 module.exports.terms = terms;

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -4,6 +4,7 @@ var idPattern = /^(\S+)\.([0-9]+)$/;
 var token = require('./token');
 var permute = require('./permute');
 var cl = require('./closest-lang');
+var levenshtein = require('fast-levenshtein');
 
 module.exports.id = id;
 module.exports.terms = terms;
@@ -151,14 +152,20 @@ function tokenize(query, lonlat) {
  * is a valid address
  *
  * @param {Array} query tokenized query
+ * @param {Array} tokenized cover text
  * @param {Integer} mask a mask for the given query
  * @return {Object} returns an address object or null
 */
-function maskAddress(query, mask) {
+function maskAddress(query, coverText, mask) {
+    var coverTokens = new Set(tokenize(coverText));
     for (var i = 0; i < query.length; i++) {
         if (mask & (1 << i)) {
-            var addr = address(query[i]);
-            if (addr) return {addr: addr, pos: i};
+            if (coverTokens.has(query[i])) {
+                coverTokens.delete(query[i]);
+            } else {
+                var addr = address(query[i]);
+                if (addr) return {addr: addr, pos: i};
+            }
         }
     }
     return null;

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -94,7 +94,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
         var source = geocoder.byidx[cover.idx];
 
         // Calculate to see if there is room for an address in the query based on bitmask
-        var address = termops.maskAddress(query, cover.mask);
+        var address = termops.maskAddress(query, cover.text, cover.mask);
 
         if (source.geocoder_address) {
 

--- a/test/geocode-unit.address-numnum.test.js
+++ b/test/geocode-unit.address-numnum.test.js
@@ -1,0 +1,98 @@
+// Test for a termops.maskAddress bug where a housenumber (115) could be
+// interpolated for on the same street name (115) without having a matching
+// query token.
+const tape = require('tape');
+const Carmen = require('..');
+const context = require('../lib/context');
+const mem = require('../lib/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+(() => {
+    const conf = {
+        country: new mem({maxzoom: 6}, () => {}),
+        postcode: new mem({maxzoom: 6}, () => {}),
+        address: new mem({maxzoom: 6, geocoder_address: 1}, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index address', (assert) => {
+        queueFeature(conf.address, {
+            id:1,
+            properties: {
+                'carmen:text':'115',
+                'carmen:center':[0,0],
+                'carmen:rangetype':'tiger',
+                'carmen:lfromhn': '0',
+                'carmen:ltohn': '200',
+            },
+            geometry: {
+                type:'LineString',
+                coordinates:[[0,0],[0,0.5]]
+            }
+        }, () => {
+            buildQueued(conf.address, assert.end);
+        });
+    });
+    tape('index postcode', (assert) => {
+        queueFeature(conf.postcode, {
+            id:3,
+            properties: {
+                'carmen:text': '115 37',
+                'carmen:center': [-0.5,-0.5]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-0.5,-0.5]
+            }
+        }, () => {
+            buildQueued(conf.postcode, assert.end);
+        });
+    });
+    tape('index country', (assert) => {
+        queueFeature(conf.country, {
+            id:2,
+            properties: {
+                'carmen:text': 'Sweden',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                    [-1,-1],
+                    [-1, 1],
+                    [ 1, 1],
+                    [ 1,-1],
+                    [-1,-1]
+                ]]
+            }
+        }, () => {
+            buildQueued(conf.country, assert.end);
+        });
+    });
+    tape('test "115 37 sweden" matches postcode, then address', (assert) => {
+        c.geocode('115 37 Sweden', {}, (err, res) => {
+            assert.ifError(err);
+            assert.deepEqual(res.features[0].place_name, '115 37, Sweden');
+            assert.deepEqual(res.features[0].place_type, ['postcode']);
+            assert.deepEqual(res.features[1].place_name, '37 115, Sweden');
+            assert.deepEqual(res.features[1].place_type, ['address']);
+            assert.end();
+        });
+    });
+    tape('test "115 115 sweden" matches address', (assert) => {
+        c.geocode('115 115 Sweden', {}, (err, res) => {
+            assert.ifError(err);
+            assert.deepEqual(res.features[0].place_name, '115 115, Sweden');
+            assert.deepEqual(res.features[0].place_type, ['address']);
+            assert.end();
+        });
+    });
+})();
+
+tape('teardown', (assert) => {
+    context.getTile.cache.reset();
+    assert.end();
+});
+

--- a/test/geocode-unit.address-numnum.test.js
+++ b/test/geocode-unit.address-numnum.test.js
@@ -5,7 +5,6 @@ const tape = require('tape');
 const Carmen = require('..');
 const context = require('../lib/context');
 const mem = require('../lib/api-mem');
-const queue = require('d3-queue').queue;
 const addFeature = require('../lib/util/addfeature'),
     queueFeature = addFeature.queueFeature,
     buildQueued = addFeature.buildQueued;

--- a/test/termops.maskAddress.test.js
+++ b/test/termops.maskAddress.test.js
@@ -2,13 +2,15 @@ const termops = require('../lib/util/termops');
 const test = require('tape');
 
 test('maskAddress', (q) => {
-    q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100'], parseInt('1110',2)), {addr: '100', pos: 3});
-    q.deepEqual(termops.maskAddress(['100', '1', 'fake', 'street'], parseInt('1111',2)), {addr: '100', pos: 0});
-    q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100b'], parseInt('1110',2)), {addr: '100b', pos: 3});
-    q.deepEqual(termops.maskAddress(['100b', '1', 'fake', 'street'], parseInt('1111',2)), {addr: '100b', pos: 0});
-    q.deepEqual(termops.maskAddress(['1s13', 'fake', 'street'], parseInt('111',2)), {addr: '1s13', pos: 0});
-    q.deepEqual(termops.maskAddress(['6n486', 'fake', 'street'], parseInt('111',2)), {addr: '6n486', pos: 0});
-    q.deepEqual(termops.maskAddress(['54w32', 'fake', 'street'], parseInt('111',2)), {addr: '54w32', pos: 0});
-    q.deepEqual(termops.maskAddress(['8e234', 'fake', 'street'], parseInt('111',2)), {addr: '8e234', pos: 0});
+    q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100'], 'fake street ###', parseInt('1110',2)), {addr: '100', pos: 3});
+    q.deepEqual(termops.maskAddress(['100', '1', 'fake', 'street'], '### 1 fake street', parseInt('1111',2)), {addr: '100', pos: 0});
+    q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100b'], 'fake street ###', parseInt('1110',2)), {addr: '100b', pos: 3});
+    q.deepEqual(termops.maskAddress(['100b', '1', 'fake', 'street'], '', parseInt('1111',2)), {addr: '100b', pos: 0});
+    q.deepEqual(termops.maskAddress(['1s13', 'fake', 'street'], '## fake street', parseInt('111',2)), {addr: '1s13', pos: 0});
+    q.deepEqual(termops.maskAddress(['6n486', 'fake', 'street'], '### fake street', parseInt('111',2)), {addr: '6n486', pos: 0});
+    q.deepEqual(termops.maskAddress(['54w32', 'fake', 'street'], '## fake street', parseInt('111',2)), {addr: '54w32', pos: 0});
+    q.deepEqual(termops.maskAddress(['8e234', 'fake', 'street'], '### fake street', parseInt('111',2)), {addr: '8e234', pos: 0});
+    q.deepEqual(termops.maskAddress(['115', '37'], '## 115', parseInt('11',2)), {addr: '37', pos: 1});
+    q.deepEqual(termops.maskAddress(['115', '115'], '## 115', parseInt('11',2)), {addr: '115', pos: 1});
     q.end();
 });


### PR DESCRIPTION
Ran into this debugging a wacky address query in Sweden:

```
115 39 Sweden
```

Can currently return something like 

```
# this has relevance 1
115 115, 269 76 Torekov, Skåne län, Sweden
```

What's going on here where we end up with the house 115 on street 115 but no sign of 39 to be found?

### What's going on

- Query gets numtokenized and normalized to these two permutations: `## 115` `1## 39` (we always index the data with housenum first).
- `## 115` matches data
- On the way back out, the `maskAddress` is `11` (both term positions are potential house numbers) and maskAddress is called against the original _query_ which has tokens in this order `115 39`
- It snags the first housenum-like value, `115`
- And pairs it with the street that's been found, `115`

And so we end up with `115 115`.

### The short-term fix (in this branch)

Make `maskAddress` a bit smarter by looking at both the coverText and query to determine if it's about to reuse a housenum that was really originally interpreted as a street.

### The long-term fix

When we `numTokenize` at the initial phrasematch stage, extracting the housenumber early may make more sense rather than masking and then doing forensics later to try to guess at what happened.

---

For now have put the stopgap short term fix in place.

cc @mapbox/geocoding-gang
