### PR TITLE
clone token object before creating replacers, don't mutate in place

### DIFF
--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -6,6 +6,7 @@ const WORD_BOUNDARY = "[\\s\\u2000-\\u206F\\u2E00-\\u2E7F\\\\'!\"#$%&()*+,\\-.\\
 
 module.exports.createReplacer = function(tokens, inverseOpts) {
     // opts
+    tokens = JSON.parse(JSON.stringify(tokens));
     inverseOpts = inverseOpts || {};
     inverseOpts.includeUnambiguous = inverseOpts.includeUnambiguous || false;
 

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -274,7 +274,7 @@ test('custom reverse replacement', (q) => {
     ]);
     q.deepEqual(token.enumerateTokenReplacements(tokensRC, 'e first st'), [
         '',
-        [ 'East', 'e' ],
+        [ 'e', 'East' ],
         '',
         [ ' 1st ', ' first ' ],
         '',

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -202,7 +202,9 @@ let tokenList = {
     "Rio": "R",
     "S.": "S"
 };
-let tokenClone = JSON.parse(JSON.stringify(tokenList));
+// store an original copy of the tokenList object that we can compare against
+const tokenClone = JSON.parse(JSON.stringify(tokenList));
+
 let tokens = token.createReplacer(tokenList);
 var tokensR = token.createReplacer(tokenList, {includeUnambiguous: true});
 
@@ -228,6 +230,8 @@ var tokensRC = token.createReplacer(tokenList, {
     }
 })
 
+// We use the same tokens object to create both indexer and runtime token replacers.
+// Test that indexer-only token replacers don't leak into runtime replacers.
 test('createReplacer', (q) => {
     q.deepEqual(tokenList, tokenClone, 'createReplacer does not change original value of tokenList');
     q.end();

--- a/test/replace.test.js
+++ b/test/replace.test.js
@@ -202,7 +202,7 @@ let tokenList = {
     "Rio": "R",
     "S.": "S"
 };
-
+let tokenClone = JSON.parse(JSON.stringify(tokenList));
 let tokens = token.createReplacer(tokenList);
 var tokensR = token.createReplacer(tokenList, {includeUnambiguous: true});
 
@@ -227,6 +227,11 @@ var tokensRC = token.createReplacer(tokenList, {
         }
     }
 })
+
+test('createReplacer', (q) => {
+    q.deepEqual(tokenList, tokenClone, 'createReplacer does not change original value of tokenList');
+    q.end();
+});
 
 test('token replacement', (q) => {
     q.deepEqual(token.replaceToken(tokens, 'fargo street northeast, san francisco'),'fargo St NE, sf');


### PR DESCRIPTION
### Context
When creating inverse token replacers for use at index time, the `geocoder_tokens` object can be mutated in a way such that the inverse tokens (which only should be used at index time) are included in the runtime token replacers.

Cloning the tokens object before adding inverse tokens avoids accidentally mutating a shared object.

### Summary of Changes
* Clone tokens object when creating replacers

cc @mapbox/geocoding-gang
