### PR TITLE
Index streets (with no housenum) with full relevance

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -353,9 +353,8 @@ function getIndexableText(replacer, globalTokens, doc) {
                         var withHousenums = [range[l]].concat(tokens);
                         add(withHousenums, language);
                     }
-                } else {
-                    add(tokens, language);
                 }
+                add(tokens, language);
             }
         }
     }

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -232,7 +232,7 @@ const addFeature = require('../lib/util/addfeature'),
     tape('Search for an address without a number (multiple layers)', (t) => {
         c.geocode('fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":0.8,"place_type": ['address'],"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
+            t.deepEquals(res,  {"type":"FeatureCollection","query":["fake","street"],"features":[{"id":"address.1","type":"Feature","text":"fake street","place_name":"fake street springfield, maine 12345, united states","relevance":1.0,"place_type": ['address'],"properties":{},"center":[0,0],"geometry":{"type":"GeometryCollection","geometries":[{"type":"MultiPoint","coordinates":[[0,0],[0,0],[0,0]]}]},"context":[{"id":"place.1","text":"springfield"},{"id":"postcode.1","text":"12345"},{"id":"region.1","text":"maine"},{"id":"country.1","text":"united states"}]}]});
             t.end();
         });
     });
@@ -283,6 +283,14 @@ const addFeature = require('../lib/util/addfeature'),
 
     tape('test address index for DE relev', (t) => {
         c.geocode('fake street 9', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 1.00);
+            t.end();
+        });
+    });
+
+    tape('test address index for DE relev', (t) => {
+        c.geocode('fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].relevance, 1.00);
             t.end();

--- a/test/geocode-unit.order.test.js
+++ b/test/geocode-unit.order.test.js
@@ -115,7 +115,7 @@ tape('Log Cabin Ln North Carolina Winston-Salem', (t) => {
     c.geocode('Log Cabin Ln North Carolina Winston-Salem', {limit_verify: 2}, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].text, "Log Cabin Ln", "ok when query order is mixed up");
-        t.equal(res.features[0].relevance, 0.7666666666666666, "Mixed-up order lowers relevance");
+        t.equal(res.features[0].relevance, 0.8333333333333333, "Mixed-up order lowers relevance");
         t.end();
     });
 });

--- a/test/termops.getIndexableText.test.js
+++ b/test/termops.getIndexableText.test.js
@@ -120,6 +120,7 @@ test('termops.getIndexableText', (t) => {
         { languages: [ 'default' ], tokens: ['1##', 'main', 'street' ] },
         { languages: [ 'default' ], tokens: ['##', 'main', 'street' ] },
         { languages: [ 'default' ], tokens: ['#', 'main', 'street' ] },
+        { languages: [ 'default' ], tokens: ['main', 'street' ] }
     ];
     t.deepEqual(termops.getIndexableText(replacer, [],  doc), texts, 'with range');
 


### PR DESCRIPTION
### Before

In `carmen@master` we index an address feature with house numbers like this:

```
1.0 ## main st
0.8 main st
```
Where the phrase variant without the house number gets a fixed `0.2` relevance penalty. This would be conceptually fine if all `main st` features in the world had house numbers, but in actuality some data has address features that actually have no house numbers associated with them. This creates a weird imbalance where these features actually get a strong relevance bonus in comparison:

```
// feature A, has house numbers
1.0 ## main st
0.8 main st

// feature B, has no house numbers
1.0 main st
```

### After

This branch treats house num-less features all equally in terms of relevance, allowing you to search for just a street name with much more reliable results.

```
// feature A, has house numbers
1.0 ## main st
1.0 main st

// feature B, has no house numbers
1.0 main st
```

cc @mapbox/geocoding-gang @alianthes @AnnaStaley 
