### PR TITLE
carmen-cache@0.18.5

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,5 +4,6 @@
  */
 module.exports = {
     MAX_QUERY_CHARS: 256,
-    MAX_QUERY_TOKENS: 20
+    MAX_QUERY_TOKENS: 20,
+    PROXIMITY_RADIUS: 40
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,5 +5,5 @@
 module.exports = {
     MAX_QUERY_CHARS: 256,
     MAX_QUERY_TOKENS: 20,
-    PROXIMITY_RADIUS: 40
+    PROXIMITY_RADIUS: 200
 };

--- a/lib/spatialmatch.js
+++ b/lib/spatialmatch.js
@@ -3,6 +3,7 @@ var queue = require('d3-queue').queue;
 var coalesce = require('@mapbox/carmen-cache').coalesce;
 var bbox = require('./util/bbox.js');
 var termops = require('./util/termops');
+var constants = require('./constants');
 
 module.exports = spatialmatch;
 module.exports.stackable = stackable;
@@ -47,6 +48,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
                     options.proximity,
                     maxZoom
                 );
+                coalesceOpts.radius = constants.PROXIMITY_RADIUS;
             }
 
             if (options.bbox) {

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -80,8 +80,12 @@ function center2zxy(center, z) {
 function scoredist(meanScore, dist, zoom, radius) {
     zoom = Math.min(zoom, 14);
     var weightedRadius = radius * (15 - zoom);
-    var distVal = (weightedRadius/(Math.max(dist,0.0001)));
-    return parseFloat(((Math.pow(meanScore, 2) * distVal)).toFixed(4));
+    // flip distance to a float between 0-1, 1 being closest to the center point
+    var distVal = 1 - Math.min(dist / weightedRadius, 1);
+    // square to weight nearer features higher
+    distVal = Math.pow(distVal, 2);
+    // heuristic: the closest features can be up to 100x times the geometric mean
+    return parseFloat((100 * meanScore * distVal).toFixed(4));
 }
 
 /**

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -73,12 +73,14 @@ function center2zxy(center, z) {
  *
  * @param {Number} meanScore The geometric mean of the scores of the top 20 features.
  * @param {Number} dist The distance from the feature to the proximity point.
+ * @param {Number} zoom The index zoom level this scoredist is being calculated for.
+ * @param {Number} radius Radius (in miles) to apply the scoredist
  * @return {Number} proximity adjusted score value
  */
-function scoredist(meanScore, dist, zoom) {
+function scoredist(meanScore, dist, zoom, radius) {
     zoom = Math.min(zoom, 14);
-    var radius = 40 * (15 - zoom);
-    return Math.round(meanScore * (radius/(Math.max(dist,0.0001))) * 10000) / 10000;
+    var weightedRadius = radius * (15 - zoom);
+    return Math.round(meanScore * (weightedRadius/(Math.max(dist,0.0001))) * 10000) / 10000;
 }
 
 /**

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -80,7 +80,8 @@ function center2zxy(center, z) {
 function scoredist(meanScore, dist, zoom, radius) {
     zoom = Math.min(zoom, 14);
     var weightedRadius = radius * (15 - zoom);
-    return Math.round(meanScore * (weightedRadius/(Math.max(dist,0.0001))) * 10000) / 10000;
+    var distVal = (weightedRadius/(Math.max(dist,0.0001)));
+    return parseFloat(((Math.pow(meanScore, 2) * distVal)).toFixed(4));
 }
 
 /**

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -8,6 +8,7 @@ var proximity = require('./util/proximity');
 var closestLang = require('./util/closest-lang');
 var bbox = require('./util/bbox');
 var filter = require('./util/filter');
+var constants = require('./constants');
 
 module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
@@ -150,7 +151,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
         if (options.proximity && feat.properties["carmen:score"] >= 0) {
             feat.properties["carmen:scoredist"] = Math.max(
                 feat.properties["carmen:score"],
-                proximity.scoredist(meanScore, feat.properties["carmen:distance"], feat.properties["carmen:zoom"])
+                proximity.scoredist(meanScore, feat.properties["carmen:distance"], feat.properties["carmen:zoom"], constants.PROXIMITY_RADIUS)
             );
         } else {
             feat.properties["carmen:scoredist"] = feat.properties["carmen:score"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@mapbox/carmen",
-  "version": "23.0.3",
+  "version": "23.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@mapbox/carmen-cache": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/carmen-cache/-/carmen-cache-0.18.4.tgz",
-      "integrity": "sha1-YiteDiCMYtCJTb4+mVEjJBt5faE=",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/carmen-cache/-/carmen-cache-0.18.5.tgz",
+      "integrity": "sha512-RiDsNPBThHNsdqDZB/htUxIDxSGw0KM5v7dG/TDbFdItEBjQ3Qq4vdno5WUR2zDLJaqhH575zYn8yhCH8ihWgA==",
       "requires": {
         "nan": "2.5.1",
         "node-pre-gyp": "0.6.36",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.18.4",
+    "@mapbox/carmen-cache": "0.18.5",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.9.0",

--- a/test/geocode-unit.proximity-polygon.test.js
+++ b/test/geocode-unit.proximity-polygon.test.js
@@ -72,10 +72,10 @@ tape('query', (t) => {
     context.getTile.cache.reset();
     addFeature.resetLogs(conf);
     c.geocode('san', {debug: true, proximity: [3, -3]}, (err, res) => {
-        t.equal(res.features[1].id, 'place.3', 'proximity boosts lower-scored place');
-        t.equal(res.features[1].properties['carmen:score'] < res.features[2].properties['carmen:score'], true, 'place.3 has a lower score than place.2');
-        t.equal(res.features[1].properties['carmen:distance'] < res.features[2].properties['carmen:distance'], true, 'place.3 is closer than place.2 to proximity point');
-        t.equal(res.features[1].properties['carmen:scoredist'] > res.features[2].properties['carmen:scoredist'], true, 'place.2 has a higher scoredist than place.3');
+        t.equal(res.features[0].id, 'place.3', 'proximity boosts lower-scored place');
+        t.equal(res.features[0].properties['carmen:score'] < res.features[2].properties['carmen:score'], true, 'place.3 has a lower score than place.2');
+        t.equal(res.features[0].properties['carmen:distance'] < res.features[2].properties['carmen:distance'], true, 'place.3 is closer than place.2 to proximity point');
+        t.equal(res.features[0].properties['carmen:scoredist'] > res.features[2].properties['carmen:scoredist'], true, 'place.2 has a higher scoredist than place.3');
         t.end();
     });
 });

--- a/test/proximity.scoredist.test.js
+++ b/test/proximity.scoredist.test.js
@@ -92,12 +92,12 @@ test('scoredist', (t) => {
 // The radius of effect extends further at lower zooms
 test('zoom weighting', (t) => {
     let score = 1000;
-    let distance = 100; //miles
+    let distance = 30; //miles
 
-    t.deepEqual(scoredist(score, distance, 6, 40), 3600, 'zoom 6');
-    t.deepEqual(scoredist(score, distance, 8, 40), 2800, 'zoom 8');
-    t.deepEqual(scoredist(score, distance, 10, 40), 2000, 'zoom 10');
-    t.deepEqual(scoredist(score, distance, 12, 40), 1200, 'zoom 12');
-    t.deepEqual(scoredist(score, distance, 14, 40), 400, 'zoom 14');
+    t.deepEqual(scoredist(score, distance, 6, 40), 84027.7778, 'zoom 6');
+    t.deepEqual(scoredist(score, distance, 8, 40), 79719.3878, 'zoom 8');
+    t.deepEqual(scoredist(score, distance, 10, 40), 72250, 'zoom 10');
+    t.deepEqual(scoredist(score, distance, 12, 40), 56250, 'zoom 12');
+    t.deepEqual(scoredist(score, distance, 14, 40), 6250, 'zoom 14');
     t.end();
 });

--- a/test/proximity.scoredist.test.js
+++ b/test/proximity.scoredist.test.js
@@ -94,10 +94,10 @@ test('zoom weighting', (t) => {
     let score = 1000;
     let distance = 100; //miles
 
-    t.deepEqual(scoredist(score, distance, 6), 3600, 'zoom 6');
-    t.deepEqual(scoredist(score, distance, 8), 2800, 'zoom 8');
-    t.deepEqual(scoredist(score, distance, 10), 2000, 'zoom 10');
-    t.deepEqual(scoredist(score, distance, 12), 1200, 'zoom 12');
-    t.deepEqual(scoredist(score, distance, 14), 400, 'zoom 14');
+    t.deepEqual(scoredist(score, distance, 6, 40), 3600, 'zoom 6');
+    t.deepEqual(scoredist(score, distance, 8, 40), 2800, 'zoom 8');
+    t.deepEqual(scoredist(score, distance, 10, 40), 2000, 'zoom 10');
+    t.deepEqual(scoredist(score, distance, 12, 40), 1200, 'zoom 12');
+    t.deepEqual(scoredist(score, distance, 14, 40), 400, 'zoom 14');
     t.end();
 });


### PR DESCRIPTION
### Context

- Updates to carmen-cache@0.18.5 (https://github.com/mapbox/carmen-cache/pull/110)
- Switches hardcoded proximity radius value to a constant that is synced with carmen-cache
- Tweaks proximity heuristics in carmen to better surface low scored features when nearby but respect massively scored features far away (2 orders of magnitude seems to be the right heuristic)

cc @mapbox/geocoding-gang
