### PR TITLE
Remove Non-existent Function from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,6 @@ be passed to `pointer` or omitted.
 Analyze index relations for a given source. Generates stats on degenerate terms,
 term => phrase relations, etc.
 
-### wipe(source, callback)
-
-Clear all geocoding indexes on a source.
-
 ### copy(from, to, callback)
 
 Copy an index wholesale between `from` and `to`.


### PR DESCRIPTION
### Context
@mtmail helpfully pointed out that this function isn't a part of Carmen's API in #439  

### Summary of Changes
- [x] remove `wipe()` from readme to fix #439 
- [ ] merge into next release

cc @mapbox/geocoding-gang
