### PR TITLE
Support duplicate address numbers in address clusters in forward queries

### DIFF
--- a/lib/pure/addresscluster.js
+++ b/lib/pure/addresscluster.js
@@ -13,9 +13,15 @@ function forward(feature, address) {
     for (var c_it = 0; c_it < cluster.length; c_it++) {
         if (!cluster[c_it]) continue;
 
-        // Check is cluster is pt geom
+        // this code identifies all the indexes of cluster[c_it] that have a1 or, if that fails, a2
+        // equivalent approximately to python [i for i,e in enumerate(cluster[c_it]) if e == a1]
+        // expressed as a reduction starting with an empty array `a` that, if the value e at each step
+        // `e` is equal to `a1`, gets the current index `i` appended to it
+        // more info at https://stackoverflow.com/questions/20798477/how-to-find-index-of-all-occurrences-of-element-in-array#comment69744472_20798754
         var a_index = cluster[c_it].reduce((a, e, i) => (e === a1) ? a.concat(i) : a, []);
         if (!a_index.length) a_index = cluster[c_it].reduce((a, e, i) => (e === a2) ? a.concat(i) : a, []);
+
+        // Check is cluster is pt geom
         if (a_index.length && feature.geometry.geometries[c_it].type === 'MultiPoint') {
             return a_index.map((idx) => {
                 return {

--- a/lib/pure/addresscluster.js
+++ b/lib/pure/addresscluster.js
@@ -14,15 +14,18 @@ function forward(feature, address) {
         if (!cluster[c_it]) continue;
 
         // Check is cluster is pt geom
-        var a_index = cluster[c_it].indexOf(a1) === -1 ? cluster[c_it].indexOf(a2) : cluster[c_it].indexOf(a1);
-        if (a_index > -1 && feature.geometry.geometries[c_it].type === 'MultiPoint') {
-            return {
-                type:'Point',
-                coordinates: [
-                    Math.round(feature.geometry.geometries[c_it].coordinates[a_index][0]*1e6)/1e6,
-                    Math.round(feature.geometry.geometries[c_it].coordinates[a_index][1]*1e6)/1e6
-                ]
-            };
+        var a_index = cluster[c_it].reduce((a, e, i) => (e === a1) ? a.concat(i) : a, []);
+        if (!a_index.length) a_index = cluster[c_it].reduce((a, e, i) => (e === a2) ? a.concat(i) : a, []);
+        if (a_index.length && feature.geometry.geometries[c_it].type === 'MultiPoint') {
+            return a_index.map((idx) => {
+                return {
+                    type:'Point',
+                    coordinates: [
+                        Math.round(feature.geometry.geometries[c_it].coordinates[idx][0]*1e6)/1e6,
+                        Math.round(feature.geometry.geometries[c_it].coordinates[idx][1]*1e6)/1e6
+                    ]
+                };
+            });
         }
     }
 

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -84,11 +84,11 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     var meanScore = 1;
     var result = [];
-    var feat;
+    var feats;
     for (var pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
 
-        feat = loaded[pos];
+        feats = [loaded[pos]];
 
         var spatialmatch = spatialmatches[pos];
         var cover = spatialmatch.covers[0];
@@ -99,45 +99,53 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
 
         if (source.geocoder_address) {
 
-            if (address && (feat.properties['carmen:addressnumber'] || feat.properties['carmen:rangetype'])) {
-                feat.properties['carmen:address'] = address.addr;
+            if (address && (feats[0].properties['carmen:addressnumber'] || feats[0].properties['carmen:rangetype'])) {
+                feats[0].properties['carmen:address'] = address.addr;
 
-                var addressPoint = null;
-                if (feat.properties['carmen:addressnumber']) {
-                    addressPoint = addressCluster.forward(feat, address.addr);
+                var addressPoints = [];
+                if (feats[0].properties['carmen:addressnumber']) {
+                    addressPoints = addressCluster.forward(feats[0], address.addr);
                 }
 
-                if (!addressPoint && feat.properties['carmen:rangetype']) {
-                    addressPoint = addressItp.forward(feat, address.addr);
+                if (!addressPoints.length && feats[0].properties['carmen:rangetype']) {
+                    let itpPoint = addressItp.forward(feats[0], address.addr);
+                    addressPoints = itpPoint ? [itpPoint] : [];
                 }
 
-                if (addressPoint) {
-                    feat.geometry = addressPoint;
-                    feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;
+                if (addressPoints.length) {
+                    let newFeats = addressPoints.map(function(addressPoint) {
+                        let feat = JSON.parse(JSON.stringify(feats[0]));
+                        feat.geometry = addressPoint;
+                        feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;
+                        return feat;
+                    });
+                    feats = newFeats;
                 } else {
                     // The feature is an address cluster or range but does not match this cover, skip it.
                     continue;
                 }
 
             } else {
-                feat.properties['carmen:address'] = null;
+                feats[0].properties['carmen:address'] = null;
             }
         }
 
-        if (options.bbox && !bbox.inside(feat.properties["carmen:center"], options.bbox)) continue;
+        for (let feat of feats) {
+            if (options.bbox && !bbox.inside(feat.properties["carmen:center"], options.bbox)) continue;
 
-        var lastType = feat.properties["carmen:types"].slice(-1)[0];
-        feat.properties["carmen:score"] = feat.properties["carmen:score"] || 0;
-        feat.properties["carmen:extid"] = lastType + '.' + feat.id;
-        feat.properties["carmen:tmpid"] = cover.tmpid;
-        feat.properties["carmen:relev"] = cover.relev;
-        feat.properties["carmen:distance"] = proximity.distance(options.proximity, feat.properties["carmen:center"], cover);
-        feat.properties["carmen:position"] = pos;
-        feat.properties["carmen:spatialmatch"] = spatialmatch;
-        feat.properties["carmen:geocoder_address_order"] = source.geocoder_address_order;
-        feat.properties["carmen:zoom"] = cover.zoom;
-        if (feat.properties["carmen:score"] > 0) meanScore *= feat.properties["carmen:score"];
-        result.push(feat);
+            var lastType = feat.properties["carmen:types"].slice(-1)[0];
+            feat.properties["carmen:score"] = feat.properties["carmen:score"] || 0;
+            feat.properties["carmen:extid"] = lastType + '.' + feat.id;
+            feat.properties["carmen:tmpid"] = cover.tmpid;
+            feat.properties["carmen:relev"] = cover.relev;
+            feat.properties["carmen:distance"] = proximity.distance(options.proximity, feat.properties["carmen:center"], cover);
+            feat.properties["carmen:position"] = pos;
+            feat.properties["carmen:spatialmatch"] = spatialmatch;
+            feat.properties["carmen:geocoder_address_order"] = source.geocoder_address_order;
+            feat.properties["carmen:zoom"] = cover.zoom;
+            if (feat.properties["carmen:score"] > 0) meanScore *= feat.properties["carmen:score"];
+            result.push(feat);
+        }
     }
 
     // Use a geometric mean for calculating final _scoredist.
@@ -146,7 +154,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     if (result.length) meanScore = Math.pow(meanScore, 1/result.length);
     // Set a score + distance combined heuristic.
     for (var k = 0; k < result.length; k++) {
-        feat = result[k];
+        let feat = result[k];
         // ghost features don't participate
         if (options.proximity && feat.properties["carmen:score"] >= 0) {
             feat.properties["carmen:scoredist"] = Math.max(
@@ -167,7 +175,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     var filtered = [];
     var byText = {};
     for (var i = 0; i < result.length; i++) {
-        feat = result[i];
+        let feat = result[i];
         var languageText = options.language ? closestLang(options.language[0], feat.properties, "carmen:text_") : false;
         var text = languageText || feat.properties["carmen:text"];
         if (feat.properties["carmen:scoredist"] >= 0 || !byText[text]) {

--- a/test/address.test.js
+++ b/test/address.test.js
@@ -423,6 +423,26 @@ test('address point clustering', (t) => {
     t.deepEqual(
         addressCluster.forward({
             properties: {
+                'carmen:addressnumber': [[9,10,7,9]]
+            },
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [{
+                    type: 'MultiPoint',
+                    coordinates: [ [1,1], [2,2], [0,0], [6,6] ]
+                }]
+            }
+        },9), [{
+            type:'Point',
+            coordinates:[1,1]
+        }, {
+            type:'Point',
+            coordinates:[6,6]
+        }]
+    );
+    t.deepEqual(
+        addressCluster.forward({
+            properties: {
                 'carmen:addressnumber': [[9,10,7]]
             },
             geometry: {
@@ -432,10 +452,10 @@ test('address point clustering', (t) => {
                     coordinates: [ [1,1], [2,2], [0,0] ]
                 }]
             }
-        },9), {
+        },9), [{
             type:'Point',
             coordinates:[1,1]
-        }
+        }]
     );
     t.end();
 });

--- a/test/geocode-unit.duplicate-address.test.js
+++ b/test/geocode-unit.duplicate-address.test.js
@@ -1,0 +1,59 @@
+const tape = require('tape');
+const Carmen = require('..');
+const context = require('../lib/context');
+const mem = require('../lib/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+const conf = {
+    address: new mem({maxzoom: 6, geocoder_address: 1, geocoder_name:'address'}, () => {})
+};
+const c = new Carmen(conf);
+
+tape('index address', (t) => {
+    let address = {
+        id:100,
+        properties: {
+            'carmen:text':'Main st',
+            'carmen:center':[0,0],
+            'carmen:addressnumber': ['100','101','102','100']
+        },
+        geometry: {
+            type: 'MultiPoint',
+            coordinates: [[0,0],[1,1],[2,2],[3,3]]
+        }
+    };
+    queueFeature(conf.address, address, t.end);
+});
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('101 Main st', (t) => {
+    c.geocode('101 Main st', { allow_dupes: true }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features.length, 1);
+        t.end();
+    });
+});
+
+tape('100 Main st', (t) => {
+    c.geocode('100 Main st', { allow_dupes: true }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features.length, 2);
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});


### PR DESCRIPTION
### Context
At present, if an address cluster contains multiple entries for a single address number, only one of them is considered in verifymatch. This PR alters the address cluster logic to return an array rather than a single point, of all matching numbers, so that verifymatch can consider any of them as potential responses.

Note that the deduplication mechanism that runs before results are returned will still collapse down to a single response if the duplicates end up having identical `place_name` values. There are a couple of circumstances where this change is still important, though:
* when a bbox excludes the value that would otherwise have been the one arbitrarily chosen as the response (in current production you get no results in this circumstance)
* when other layers in the stack end up giving different addresses within the cluster different `place_name` values, for example if a single address cluster spans multiple postcodes


### Summary of Changes
- [x] alter addressCluster.forward to return an array of all responsive values rather than a single value
- [x] alter verifymatch to expect an array and to potentially add multiple results per loaded feature
- [x] add tests of the addresscluster function as well as to geocodes over clusters with duplicate values


### Next Steps
None

### To-do for later
As of this PR there will be an inconsistency in the interfaces between the addressCluster.forward function, which returns an array, and the addressItp.forward function, which still returns a single object. Eventually we should adjust addressItp also, probably in a conceptually similar way so if more than one interpolation line in the same cluster could include the same address number, we return multiple candidate ITP points. I'm not sure how exactly this should work though, so I'm just doing this half for now in the interests of expediency.

cc @ingalls @mapbox/geocoding-gang
