### PR TITLE
Fuzzworld

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -58,11 +58,14 @@ module.exports = function phrasematch(source, query, options, callback) {
                 dawg.hasPhraseOrNormalizations(text, scanPrefix) :
                 (latinCheck(query) ? dawg.hasPhrase(text, scanPrefix, true) : dawg.hasPhrase(text, scanPrefix, false));
 
+                console.log('*** dawgMatch: ', dawgMatch);
+                console.log('*** text', text);
             if (!dawgMatch) continue;
 
             var variants;
             if (!tryNormalization) {
-                variants = [{text: subquery.join(' '), prefix: scanPrefix}];
+                console.log('*** dawgMatch.text: ', dawgMatch.text);
+                variants = [{text: dawgMatch.text, prefix: scanPrefix}];
             } else if (scanPrefix) {
                 variants = [{text: subquery.join(' '), prefix: scanPrefix}];
                 for (let v of dawgMatch.normalizations) {
@@ -101,7 +104,7 @@ module.exports = function phrasematch(source, query, options, callback) {
                         return source.lang.lang_map[label || 'unmatched'];
                     }
                 });
-
+                console.log('*** variant: ', variant);
                 phrasematches.push(new Phrasematch(variant.text.split(' '), weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages));
             }
         }
@@ -122,6 +125,7 @@ module.exports.latinCheck = latinCheck;
 function latinCheck(query) {
     var regexp = /[A-z\u00C0-\u00ff]+/g;
     var latinFlag = regexp.test(query) ? true : false;
+    console.log('latin flag', latinFlag);
     return latinFlag;
 };
 

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -58,13 +58,10 @@ module.exports = function phrasematch(source, query, options, callback) {
                 dawg.hasPhraseOrNormalizations(text, scanPrefix) :
                 (latinCheck(query) ? dawg.hasPhrase(text, scanPrefix, true) : dawg.hasPhrase(text, scanPrefix, false));
 
-                console.log('*** dawgMatch: ', dawgMatch);
-                console.log('*** text', text);
             if (!dawgMatch) continue;
 
             var variants;
             if (!tryNormalization) {
-                console.log('*** dawgMatch.text: ', dawgMatch.text);
                 variants = [{text: dawgMatch.text, prefix: scanPrefix}];
             } else if (scanPrefix) {
                 variants = [{text: subquery.join(' '), prefix: scanPrefix}];
@@ -104,7 +101,6 @@ module.exports = function phrasematch(source, query, options, callback) {
                         return source.lang.lang_map[label || 'unmatched'];
                     }
                 });
-                console.log('*** variant: ', variant);
                 phrasematches.push(new Phrasematch(variant.text.split(' '), weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages));
             }
         }
@@ -125,7 +121,6 @@ module.exports.latinCheck = latinCheck;
 function latinCheck(query) {
     var regexp = /[A-z\u00C0-\u00ff]+/g;
     var latinFlag = regexp.test(query) ? true : false;
-    console.log('latin flag', latinFlag);
     return latinFlag;
 };
 

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -47,6 +47,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     while (l--) {
         var subquery = subqueries[l];
         var text = termops.encodableText(subquery);
+        var exactMatch = false;
         if (text) {
             var scanPrefix = subquery.ender && options.autocomplete;
 
@@ -59,6 +60,8 @@ module.exports = function phrasematch(source, query, options, callback) {
                 (latinCheck(query) ? dawg.hasPhrase(text, scanPrefix, true) : dawg.hasPhrase(text, scanPrefix, false));
 
             if (!dawgMatch) continue;
+
+            exactMatch = dawgMatch.exact_match;
 
             var variants;
             if (!tryNormalization) {
@@ -101,7 +104,7 @@ module.exports = function phrasematch(source, query, options, callback) {
                         return source.lang.lang_map[label || 'unmatched'];
                     }
                 });
-                phrasematches.push(new Phrasematch(variant.text.split(' '), weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages));
+                phrasematches.push(new Phrasematch(variant.text.split(' '), weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages, exactMatch));
             }
         }
     }
@@ -125,7 +128,7 @@ function latinCheck(query) {
 };
 
 module.exports.Phrasematch = Phrasematch;
-function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages) {
+function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages, exactMatch) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -139,9 +142,10 @@ function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zo
     this.idx = idx;
     this.cache = cache;
     this.zoom = zoom;
+    this.exactMatch = exactMatch;
 }
 
 Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages);
+    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages, this.exactMatch);
 };
 

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -47,6 +47,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     while (l--) {
         var subquery = subqueries[l];
         var text = termops.encodableText(subquery);
+        // exactMatch is a flag for whether the query matches exactly or not.
         var exactMatch = false;
         if (text) {
             var scanPrefix = subquery.ender && options.autocomplete;

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -117,6 +117,13 @@ function PhrasematchResult(phrasematches, source) {
     this.bmask = source.bmask;
 }
 
+module.exports.latinCheck = latinCheck;
+function latinCheck(query) {
+    var regexp = /[A-z\u00C0-\u00ff]+/g;
+    var latinFlag = regexp.test(query) ? true : false;
+    return latinFlag;
+};
+
 module.exports.Phrasematch = Phrasematch;
 function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages) {
     this.subquery = subquery;

--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -53,9 +53,10 @@ module.exports = function phrasematch(source, query, options, callback) {
             // only try text normalization if this index has it enabled, and if either we're not doing autocomplete or, if we are, the text is at least 3 chars long
             // (so th process isn't totally batshit slow)
             var tryNormalization = source.use_normalization_cache && (!scanPrefix || text.length >= 3);
+
             var dawgMatch = tryNormalization ?
                 dawg.hasPhraseOrNormalizations(text, scanPrefix) :
-                dawg.hasPhrase(text, scanPrefix);
+                (latinCheck(query) ? dawg.hasPhrase(text, scanPrefix, true) : dawg.hasPhrase(text, scanPrefix, false));
 
             if (!dawgMatch) continue;
 

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -102,6 +102,9 @@ WriteCache.prototype.dumpWithNormalizations = function(normalizationCachePath) {
 var ReadCache = _dawgCache.CompactDawg;
 
 ReadCache.prototype.hasPhrase = function(text, ender, fuzz) {
+    console.log('f', fuzz);
+    console.log(arguments)
+    if (typeof fuzz == "undefined") throw new Error();
     return ender ? this.lookupPrefix(text) : this.lookup(text, fuzz);
 }
 
@@ -146,9 +149,9 @@ ReadCache.prototype.properties = WriteCache.prototype.properties = {
 }
 
 // build a ReadCache at the last minute if hasPhrase is ever called on WriteCache; define after ReadCache to appease the linter
-WriteCache.prototype.hasPhrase = function(text, ender) {
+WriteCache.prototype.hasPhrase = function(text, ender, fuzz) {
     if (DEBUG) console.warn("calling hasPhrase on a DAWG WriteCache is very inefficient")
-    return (new ReadCache(this.dump())).hasPhrase(text, ender);
+    return (new ReadCache(this.dump())).hasPhrase(text, ender, fuzz);
 }
 
 WriteCache.prototype.hasPhraseOrNormalizations = function(text, ender) {

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -102,9 +102,6 @@ WriteCache.prototype.dumpWithNormalizations = function(normalizationCachePath) {
 var ReadCache = _dawgCache.CompactDawg;
 
 ReadCache.prototype.hasPhrase = function(text, ender, fuzz) {
-    console.log('f', fuzz);
-    console.log(arguments)
-    if (typeof fuzz == "undefined") throw new Error();
     return ender ? this.lookupPrefix(text) : this.lookup(text, fuzz);
 }
 

--- a/lib/util/dawg.js
+++ b/lib/util/dawg.js
@@ -101,8 +101,8 @@ WriteCache.prototype.dumpWithNormalizations = function(normalizationCachePath) {
 
 var ReadCache = _dawgCache.CompactDawg;
 
-ReadCache.prototype.hasPhrase = function(text, ender) {
-    return ender ? this.lookupPrefix(text) : this.lookup(text);
+ReadCache.prototype.hasPhrase = function(text, ender, fuzz) {
+    return ender ? this.lookupPrefix(text) : this.lookup(text, fuzz);
 }
 
 ReadCache.prototype.hasPhraseOrNormalizations = function(text, ender) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@turf/line-distance": "^4.0.1",
     "@turf/point-on-surface": "^4.0.1",
     "d3-queue": "3.0.x",
-    "dawg-cache": "https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35",
+    "dawg-cache": "https://github.com/mapbox/dawg-cache/tarball/fbe9528a560306bd67a02e53b12762fa46dcc765",
     "err-code": "^1.1.2",
     "fs-extra": "^2.1.2",
     "geojson-rewind": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@turf/line-distance": "^4.0.1",
     "@turf/point-on-surface": "^4.0.1",
     "d3-queue": "3.0.x",
-    "dawg-cache": "0.5.0",
+    "dawg-cache": "https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35",
     "err-code": "^1.1.2",
     "fs-extra": "^2.1.2",
     "geojson-rewind": "^0.2.0",

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -205,47 +205,40 @@ tape('dump/load DawgCache', (t) => {
 });
 
 // query in carmen
-// tape('query for "wall st new york"', (assert) => {
-//     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
-//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
-//         assert.end();
-//     });
-// });
-
-tape('query for "wallst new york"', (assert) => {
+tape('query for "wall st new york"', (assert) => {
+    // actual query
+    c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
+    });
+    // query missing a space
     c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
         assert.end();
     });
+
+    //landmark search with geocoder_address = 0
+    c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
+        assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
+        assert.end();
+    });
 });
-//
-// //landmark search with geocoder_address = 0
-// tape('query for "christ the redeemer, brazil"', (assert) => {
-//     c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
-//         assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
-//         assert.end();
-//     });
-// });
-// tape('test index contents for dict/christtheredeemer', (assert) => {
-//     assert.equal(Array.from(conf.landmark._dictcache)[0], 'christtheredeemer', 'test index contents for christ the redeemer');
-//     assert.end();
-// });
-//
-// //language flag test to trigger during getMatchingText();
-// tape('language fallback query: Wall St', (t) => {
-//     c.geocode('Wall St', { language: 'ar'}, (err, res) => {
-//         t.equal('Wall St', res.features[0].text, 'Fallback to English');
-//         t.equal('en', res.features[0].language, 'Language returned is English');
-//         t.ifError(err, 'no error');
-//         t.end();
-//     });
-// });
-// tape('language fallback query: Christ the Redeemer', (t) => {
-//     c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
-//         t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
-//         t.equal('en', res.features[0].language, 'Language returned is English');
-//         t.ifError(err, 'no error');
-//         t.end();
-//     });
-// });
+
+//language flag test to trigger during getMatchingText();
+tape('language fallback query: Wall St', (t) => {
+    c.geocode('Wall St', { language: 'ar'}, (err, res) => {
+        t.equal('Wall St', res.features[0].text, 'Fallback to English');
+        t.equal('en', res.features[0].language, 'Language returned is English');
+        t.ifError(err, 'no error');
+        t.end();
+    });
+});
+tape('language fallback query: Christ the Redeemer', (t) => {
+    c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
+        t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
+        t.equal('en', res.features[0].language, 'Language returned is English');
+        t.ifError(err, 'no error');
+        t.end();
+    });
+});

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -204,32 +204,21 @@ tape('dump/load DawgCache', (t) => {
     });
 });
 
-// // index contents
-// tape('test index contents for new york', (assert) => {
-//     assert.equal(Array.from(conf.city._dictcache)[0], 'new york', 'test index contents for new york');
-//     assert.end();
-// });
-//
-// tape('test index contents for wallst', (assert) => {
-//     assert.equal(Array.from(conf.street._dictcache)[0], 'wallst', 'test index contents for wallst');
-//     assert.end();
-// });
-//
-// // query in carmen
+// query in carmen
 // tape('query for "wall st new york"', (assert) => {
 //     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
 //         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
 //         assert.end();
 //     });
 // });
-//
-// tape('query for "wallst new york"', (assert) => {
-//     c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
-//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
-//         assert.end();
-//     });
-// });
+
+tape('query for "wallst new york"', (assert) => {
+    c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
+        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
+        assert.end();
+    });
+});
 //
 // //landmark search with geocoder_address = 0
 // tape('query for "christ the redeemer, brazil"', (assert) => {

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -196,7 +196,7 @@ tape('dump/load DawgCache', (t) => {
             // fuzzy search addition
             t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
             // fuzzy search deletion
-            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: true, text: 'a' }, 'not a');
+            t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
             t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: true, text: 'a' }, 'has a as degen');
 
             t.end();

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -187,27 +187,23 @@ tape('dump/load DawgCache', (t) => {
         zlib.gunzip(zdata, (err, data) => {
             t.ifError(err);
             let loaded = new DawgCache(data);
+            // lookupprefix = false
             for (let i = 1; i <= 4; i++) {
                 var phrase = loaded.hasPhrase(`a${i}`, false, true);
                 console.log(typeof phrase);
-                t.equal(phrase, { exact_match: true, final: true, text: `a${i}` }, `not { exact_match: true, final: true, text: a${i}}`);
+                t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
             }
-            t.equal(loaded.hasPhrase("a45", false, true), false, 'not a45');
-            t.equal(loaded.hasPhrase("a", false), false, 'not a');
-            t.equal(loaded.hasPhrase("a", true), true, 'has a as degen');
+            // fuzzy search addition
+            t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
+            // fuzzy search deletion
+            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: true, text: 'a' }, 'not a');
+            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: true, text: 'a' }, 'has a as degen');
 
             t.end();
         });
     });
 });
-//
-// // check dawg cache
-// tape('invalid data', (t) => {
-//     const dict = new DawgCache();
-//     t.throws(() => { dict.setText(""); });
-//     t.end();
-// });
-//
+
 // // index contents
 // tape('test index contents for new york', (assert) => {
 //     assert.equal(Array.from(conf.city._dictcache)[0], 'new york', 'test index contents for new york');

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -1,7 +1,6 @@
 const tape = require('tape');
 const zlib = require('zlib');
 const DawgCache = require('../lib/util/dawg');
-const termops = require('../lib/util/termops');
 const Carmen = require('..');
 const mem = require('../lib/api-mem');
 const queue = require('d3-queue').queue;
@@ -165,63 +164,63 @@ tape('build queued features', (t) => {
     });
     q.awaitAll(t.end);
 });
-//
-// // create and load DawgCache
-// tape('create', (t) => {
-//     const dict = new DawgCache();
-//     t.ok(dict, "dawg created")
-//     t.end();
-// });
-//
-// tape('dump/load DawgCache', (t) => {
-//     const dict = new DawgCache();
-//     dict.setText("a1");
-//     dict.setText("a2");
-//     dict.setText("a3");
-//     dict.setText("a4");
-//
-//
-//     zlib.gzip(dict.dump(), (err, zdata) => {
-//         t.ifError(err);
-//         t.ok(zdata.length < 200e3, 'gzipped dictcache < 200k');
-//         zlib.gunzip(zdata, (err, data) => {
-//             t.ifError(err);
-//             let loaded = new DawgCache(data);
-//             // lookupprefix = false
-//             for (let i = 1; i <= 4; i++) {
-//                 var phrase = loaded.hasPhrase(`a${i}`, false, true);
-//                 console.log(typeof phrase);
-//                 t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
-//             }
-//             // fuzzy search addition
-//             t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
-//             // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
-//             t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
-//             t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
-//
-//             t.end();
-//         });
-//     });
-// });
-//
-// // query in carmen
-// tape('query for "wall st new york"', (assert) => {
-//     // actual query
-//     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
-//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
-//     });
-//     // query missing a space
-//     c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
-//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
-//     });
-//     //landmark search with geocoder_address = 0
-//     c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
-//         assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
-//         assert.end();
-//     });
-// });
+
+// create and load DawgCache
+tape('create', (t) => {
+    const dict = new DawgCache();
+    t.ok(dict, "dawg created")
+    t.end();
+});
+
+tape('dump/load DawgCache', (t) => {
+    const dict = new DawgCache();
+    dict.setText("a1");
+    dict.setText("a2");
+    dict.setText("a3");
+    dict.setText("a4");
+
+
+    zlib.gzip(dict.dump(), (err, zdata) => {
+        t.ifError(err);
+        t.ok(zdata.length < 200e3, 'gzipped dictcache < 200k');
+        zlib.gunzip(zdata, (err, data) => {
+            t.ifError(err);
+            let loaded = new DawgCache(data);
+            // lookupprefix = false
+            for (let i = 1; i <= 4; i++) {
+                var phrase = loaded.hasPhrase(`a${i}`, false, true);
+                console.log(typeof phrase);
+                t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
+            }
+            // fuzzy search addition
+            t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
+            // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
+            t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
+            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
+
+            t.end();
+        });
+    });
+});
+
+// query in carmen
+tape('query for "wall st new york"', (assert) => {
+    // actual query
+    c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
+    });
+    // query missing a space
+    c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
+        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
+    });
+    //landmark search with geocoder_address = 0
+    c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
+        assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
+        assert.end();
+    });
+});
 
 // load and test indices in the dawgcache
 tape('dump/load DawgCache', (t) => {

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -165,63 +165,87 @@ tape('build queued features', (t) => {
     });
     q.awaitAll(t.end);
 });
+//
+// // create and load DawgCache
+// tape('create', (t) => {
+//     const dict = new DawgCache();
+//     t.ok(dict, "dawg created")
+//     t.end();
+// });
+//
+// tape('dump/load DawgCache', (t) => {
+//     const dict = new DawgCache();
+//     dict.setText("a1");
+//     dict.setText("a2");
+//     dict.setText("a3");
+//     dict.setText("a4");
+//
+//
+//     zlib.gzip(dict.dump(), (err, zdata) => {
+//         t.ifError(err);
+//         t.ok(zdata.length < 200e3, 'gzipped dictcache < 200k');
+//         zlib.gunzip(zdata, (err, data) => {
+//             t.ifError(err);
+//             let loaded = new DawgCache(data);
+//             // lookupprefix = false
+//             for (let i = 1; i <= 4; i++) {
+//                 var phrase = loaded.hasPhrase(`a${i}`, false, true);
+//                 console.log(typeof phrase);
+//                 t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
+//             }
+//             // fuzzy search addition
+//             t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
+//             // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
+//             t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
+//             t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
+//
+//             t.end();
+//         });
+//     });
+// });
+//
+// // query in carmen
+// tape('query for "wall st new york"', (assert) => {
+//     // actual query
+//     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
+//     });
+//     // query missing a space
+//     c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
+//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
+//     });
+//     //landmark search with geocoder_address = 0
+//     c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
+//         assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
+//         assert.end();
+//     });
+// });
 
-// create and load DawgCache
-tape('create', (t) => {
-    const dict = new DawgCache();
-    t.ok(dict, "dawg created")
-    t.end();
-});
-
+// load and test indices in the dawgcache
 tape('dump/load DawgCache', (t) => {
-    const dict = new DawgCache();
-    dict.setText("a1");
-    dict.setText("a2");
-    dict.setText("a3");
-    dict.setText("a4");
+    const dawg = new DawgCache();
 
+    const queries = ["Wall St", "New York", "Christ the Redeemer", "Brazil"]
 
-    zlib.gzip(dict.dump(), (err, zdata) => {
+    for (var i = 0; i < queries.length; i++) {
+        dawg.setText(queries[i])
+    }
+
+    zlib.gzip(dawg.dump(), (err, zdata) => {
         t.ifError(err);
         t.ok(zdata.length < 200e3, 'gzipped dictcache < 200k');
         zlib.gunzip(zdata, (err, data) => {
             t.ifError(err);
             let loaded = new DawgCache(data);
             // lookupprefix = false
-            for (let i = 1; i <= 4; i++) {
-                var phrase = loaded.hasPhrase(`a${i}`, false, true);
-                console.log(typeof phrase);
-                t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
+            for (let i = 0; i < 4; i++) {
+                var phrase = loaded.hasPhrase(queries[i], false, true);
+                t.deepEqual(phrase, { exact_match: true, final: true, text: queries[i] }, `return { exact_match: true, final: true, text: ${queries[i]}}`);
             }
-            // fuzzy search addition
-            t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
-            // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
-            t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
-            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
-
             t.end();
         });
-    });
-});
-
-// query in carmen
-tape('query for "wall st new york"', (assert) => {
-    // actual query
-    c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
-        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
-    });
-    // query missing a space
-    c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
-        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
-        assert.end();
-    });
-
-    //landmark search with geocoder_address = 0
-    c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
-        assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
-        assert.end();
     });
 });
 
@@ -231,10 +255,8 @@ tape('language fallback query: Wall St', (t) => {
         t.equal('Wall St', res.features[0].text, 'Fallback to English');
         t.equal('en', res.features[0].language, 'Language returned is English');
         t.ifError(err, 'no error');
-        t.end();
     });
-});
-tape('language fallback query: Christ the Redeemer', (t) => {
+
     c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
         t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
         t.equal('en', res.features[0].language, 'Language returned is English');
@@ -242,3 +264,4 @@ tape('language fallback query: Christ the Redeemer', (t) => {
         t.end();
     });
 });
+

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -4,7 +4,15 @@ const DawgCache = require('../lib/util/dawg');
 const Carmen = require('..');
 const mem = require('../lib/api-mem');
 const queue = require('d3-queue').queue;
-// const context = require('../lib/context');
+
+// for fuzz test
+const stackable = require('../lib/spatialmatch.js').stackable;
+const sortByRelevLengthIdx = require('../lib/spatialmatch.js').sortByRelevLengthIdx;
+const sortByZoomIdx = require('../lib/spatialmatch.js').sortByZoomIdx;
+const phrasematch = require('../lib/phrasematch');
+const Phrasematch = phrasematch.Phrasematch;
+const PhrasematchResult = phrasematch.PhrasematchResult;
+
 
 
 // be able to add a specific feature
@@ -189,7 +197,6 @@ tape('dump/load DawgCache', (t) => {
             // lookupprefix = false
             for (let i = 1; i <= 4; i++) {
                 var phrase = loaded.hasPhrase(`a${i}`, false, true);
-                console.log(typeof phrase);
                 t.deepEqual(phrase, { exact_match: true, final: true, text: `a${i}` }, `return { exact_match: true, final: true, text: a${i}}`);
             }
             // fuzzy search addition
@@ -197,7 +204,6 @@ tape('dump/load DawgCache', (t) => {
             // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
             t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
             t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
-
             t.end();
         });
     });
@@ -207,7 +213,6 @@ tape('dump/load DawgCache', (t) => {
 tape('query for "wall st new york"', (assert) => {
     // actual query
     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
-        console.log(res);
         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
     });
@@ -242,13 +247,14 @@ tape('dump/load DawgCache', (t) => {
             // lookupprefix = false
             for (let i = 0; i < 4; i++) {
                 var phrase = loaded.hasPhrase(queries[i], false, true);
+                // let phrasematching = new phrasematch(queries[i], 0.5, parseInt('10', 2), phrase, null, null, 0, 6, false, null, exactMatch);
+
                 t.deepEqual(phrase, { exact_match: true, final: true, text: queries[i] }, `return { exact_match: true, final: true, text: ${queries[i]}}`);
             }
             t.end();
         });
     });
 });
-
 //language flag test to trigger during getMatchingText();
 tape('language fallback query: Wall St', (t) => {
     c.geocode('Wall St', { language: 'ar'}, (err, res) => {
@@ -264,4 +270,3 @@ tape('language fallback query: Wall St', (t) => {
         t.end();
     });
 });
-

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -195,9 +195,9 @@ tape('dump/load DawgCache', (t) => {
             }
             // fuzzy search addition
             t.deepEqual(loaded.hasPhrase("a45", false, true), { exact_match: false, final: true, text: 'a4' }, 'not a45');
-            // fuzzy search deletion
+            // These tests we will need to update when we begin fixing the case where a prefix is found before an actual complete query.
             t.deepEqual(loaded.hasPhrase("a", false, true), null, 'not a');
-            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: true, text: 'a' }, 'has a as degen');
+            t.deepEqual(loaded.hasPhrase("a", true, true), { exact_match: true, final: false, text: 'a' }, 'has a as degen');
 
             t.end();
         });

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -203,10 +203,11 @@ tape('dump/load DawgCache', (t) => {
     });
 });
 
-// query in carmen
+// query in carmen with fuzzy relevance
 tape('query for "wall st new york"', (assert) => {
     // actual query
     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+        console.log(res);
         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
     });

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -188,8 +188,9 @@ tape('dump/load DawgCache', (t) => {
             t.ifError(err);
             let loaded = new DawgCache(data);
             for (let i = 1; i <= 4; i++) {
-                console.log(loaded.hasPhrase("a1"));
-                t.equal(loaded.hasPhrase("a" + i, false), true, 'has a' + i);
+                var phrase = loaded.hasPhrase(`a${i}`, false, true);
+                console.log(typeof phrase);
+                t.equal(phrase, { exact_match: true, final: true, text: `a${i}` }, `not { exact_match: true, final: true, text: a${i}}`);
             }
             t.equal(loaded.hasPhrase("a45", false, true), false, 'not a45');
             t.equal(loaded.hasPhrase("a", false), false, 'not a');
@@ -199,67 +200,67 @@ tape('dump/load DawgCache', (t) => {
         });
     });
 });
-
-// check dawg cache
-tape('invalid data', (t) => {
-    const dict = new DawgCache();
-    t.throws(() => { dict.setText(""); });
-    t.end();
-});
-
-// index contents
-tape('test index contents for new york', (assert) => {
-    assert.equal(Array.from(conf.city._dictcache)[0], 'new york', 'test index contents for new york');
-    assert.end();
-});
-
-tape('test index contents for wallst', (assert) => {
-    assert.equal(Array.from(conf.street._dictcache)[0], 'wallst', 'test index contents for wallst');
-    assert.end();
-});
-
-// query in carmen
-tape('query for "wall st new york"', (assert) => {
-    c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
-        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
-        assert.end();
-    });
-});
-
-tape('query for "wallst new york"', (assert) => {
-    c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
-        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
-        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
-        assert.end();
-    });
-});
-
-//landmark search with geocoder_address = 0
-tape('query for "christ the redeemer, brazil"', (assert) => {
-    c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
-        assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
-        assert.end();
-    });
-});
-tape('test index contents for dict/christtheredeemer', (assert) => {
-    assert.equal(Array.from(conf.landmark._dictcache)[0], 'christtheredeemer', 'test index contents for christ the redeemer');
-    assert.end();
-});
-
-//language flag test to trigger during getMatchingText();
-tape('language fallback query: Wall St', (t) => {
-    c.geocode('Wall St', { language: 'ar'}, (err, res) => {
-        t.equal('Wall St', res.features[0].text, 'Fallback to English');
-        t.equal('en', res.features[0].language, 'Language returned is English');
-        t.ifError(err, 'no error');
-        t.end();
-    });
-});
-tape('language fallback query: Christ the Redeemer', (t) => {
-    c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
-        t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
-        t.equal('en', res.features[0].language, 'Language returned is English');
-        t.ifError(err, 'no error');
-        t.end();
-    });
-});
+//
+// // check dawg cache
+// tape('invalid data', (t) => {
+//     const dict = new DawgCache();
+//     t.throws(() => { dict.setText(""); });
+//     t.end();
+// });
+//
+// // index contents
+// tape('test index contents for new york', (assert) => {
+//     assert.equal(Array.from(conf.city._dictcache)[0], 'new york', 'test index contents for new york');
+//     assert.end();
+// });
+//
+// tape('test index contents for wallst', (assert) => {
+//     assert.equal(Array.from(conf.street._dictcache)[0], 'wallst', 'test index contents for wallst');
+//     assert.end();
+// });
+//
+// // query in carmen
+// tape('query for "wall st new york"', (assert) => {
+//     c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
+//         assert.end();
+//     });
+// });
+//
+// tape('query for "wallst new york"', (assert) => {
+//     c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
+//         assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+//         assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
+//         assert.end();
+//     });
+// });
+//
+// //landmark search with geocoder_address = 0
+// tape('query for "christ the redeemer, brazil"', (assert) => {
+//     c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
+//         assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
+//         assert.end();
+//     });
+// });
+// tape('test index contents for dict/christtheredeemer', (assert) => {
+//     assert.equal(Array.from(conf.landmark._dictcache)[0], 'christtheredeemer', 'test index contents for christ the redeemer');
+//     assert.end();
+// });
+//
+// //language flag test to trigger during getMatchingText();
+// tape('language fallback query: Wall St', (t) => {
+//     c.geocode('Wall St', { language: 'ar'}, (err, res) => {
+//         t.equal('Wall St', res.features[0].text, 'Fallback to English');
+//         t.equal('en', res.features[0].language, 'Language returned is English');
+//         t.ifError(err, 'no error');
+//         t.end();
+//     });
+// });
+// tape('language fallback query: Christ the Redeemer', (t) => {
+//     c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
+//         t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
+//         t.equal('en', res.features[0].language, 'Language returned is English');
+//         t.ifError(err, 'no error');
+//         t.end();
+//     });
+// });

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -1,6 +1,162 @@
 const tape = require('tape');
 const zlib = require('zlib');
 const DawgCache = require('../lib/util/dawg');
+const termops = require('../lib/util/termops');
+
+const tape = require('tape');
+const Carmen = require('..');
+// const context = require('../lib/context');
+const mem = require('../lib/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+const conf = {
+    country: new mem({
+        maxzoom: 6,
+        geocoder_address: 0,
+        geocoder_languages: ['en'],
+    }, () => {}),
+    city: new mem({
+        maxzoom: 6,
+        geocoder_address: 0,
+        geocoder_languages: ['en'],
+    }, () => {}),
+    street: new mem({
+        maxzoom: 6,
+        geocoder_address: 1,
+        geocoder_languages: ['en'],
+    }, () => {}),
+    landmark: new mem({
+        maxzoom: 6,
+        geocoder_address: 0,
+        geocoder_languages: ['en'],
+    }, () => {}),
+};
+const c = new Carmen(conf);
+tape('index Wall St', (t) => {
+    let street = {
+        "id":1,
+        "properties": {
+            'carmen:text':'Wall St',
+            'carmen:text_en':'Wall St',
+            "carmen:center":  [ -74.01034355163574, 40.706912973264785 ]
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -74.01034355163574,
+                40.706912973264785
+            ]
+        }
+    };
+    queueFeature(conf.street, street, t.end);
+});
+tape('index city', (t) => {
+    let city = {
+        "id":1,
+        "properties": {
+            'carmen:text':'New York',
+            'carmen:text_en': 'New York',
+            "carmen:center":  [ -74.01047229766846, 40.70716509319156 ]
+        },
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        -74.0105152130127,
+                        40.70792146442606
+                    ],
+                    [
+                        -74.01156663894653,
+                        40.707043102014715
+                    ],
+                    [
+                        -74.0103006362915,
+                        40.70640872195707
+                    ],
+                    [
+                        -74.00937795639038,
+                        40.70714069841032
+                    ],
+                    [
+                        -74.0105152130127,
+                        40.70792146442606
+                    ]
+                ]
+            ]
+        }
+    };
+    queueFeature(conf.city, city, t.end);
+});
+tape('index Christ the Redeemer', (t) => {
+    let landmark = {
+        "id":1,
+        "properties": {
+            'carmen:text':'Christ the Redeemer',
+            'carmen:text_en':'Christ the Redeemer',
+            "carmen:center":  [ -50.80078125, -10.444597722834875 ]
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -50.80078125,
+                -10.444597722834875
+
+            ]
+        }
+    };
+    queueFeature(conf.landmark, landmark, t.end);
+});
+tape('index Brazil', (t) => {
+    let country = {
+        "id":1,
+        "properties": {
+            'carmen:text':'Brazil',
+            'carmen:text_en':'Brazil',
+            "carmen:center":  [ -49.9658203125, -10.481333461113326 ]
+        },
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        -55.54687499999999,
+                        -14.647368383896618
+                    ],
+                    [
+                        -44.384765625,
+                        -14.647368383896618
+                    ],
+                    [
+                        -44.384765625,
+                        -6.315298538330033
+                    ],
+                    [
+                        -55.54687499999999,
+                        -6.315298538330033
+                    ],
+                    [
+                        -55.54687499999999,
+                        -14.647368383896618
+                    ]
+                ]
+            ]
+        }
+    };
+    queueFeature(conf.country, country, t.end);
+});
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
 
 tape('create', (t) => {
     const dict = new DawgCache();
@@ -39,3 +195,80 @@ tape('invalid data', (t) => {
     t.throws(() => { dict.setText(""); });
     t.end();
 });
+
+tape('query for "wall st new york"', (assert) => {
+    c.geocode('wall st new york', { limit_verify:1 }, (err, res) => {
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wall st new york" returns "Wall St"');
+        assert.end();
+    });
+});
+
+tape('query for "wallst new york"', (assert) => {
+    c.geocode('wallst new york', { limit_verify:1 }, (err, res) => {
+        assert.equal(res.features.length > 0, true, 'query for "wallst new york" returns any feature');
+        assert.deepEqual(res.features[0].place_name, 'Wall St, New York', 'query for "wallst new york" returns "Wall St"');
+        assert.end();
+    });
+});
+
+tape('test index contents for newyork', (assert) => {
+    assert.equal(Array.from(conf.city._dictcache)[0], 'newyork', 'test index contents for newyork');
+    assert.end();
+});
+
+tape('test index contents for wallst', (assert) => {
+    assert.equal(Array.from(conf.street._dictcache)[0], 'wallst', 'test index contents for wallst');
+    assert.end();
+});
+
+tape('test index contents for grid/newyork', (assert) => {
+    assert.equal(Array.from(conf.city._geocoder.grid.list())[0][0], 'newyork', 'test index contents for newyork');
+    assert.end();
+});
+
+tape('test index contents for grid/wallst', (assert) => {
+    assert.equal(Array.from(conf.street._geocoder.grid.list())[0][0], 'wallst', 'test index contents for wallst');
+    assert.end();
+});
+
+//landmark search with geocoder_address = 0
+tape('query for "christ the redeemer, brazil"', (assert) => {
+    c.geocode('christ the redeemer brazil', { limit_verify:1 }, (err, res) => {
+        assert.deepEqual(res.features[0].place_name, 'Christ the Redeemer, Brazil', 'query for "christ the redeemer brazil" returns "Christ the Redeemer, Brazil"');
+        assert.end();
+    });
+});
+tape('test index contents for dict/christtheredeemer', (assert) => {
+    assert.equal(Array.from(conf.landmark._dictcache)[0], 'christtheredeemer', 'test index contents for christ the redeemer');
+    assert.end();
+});
+tape('test index contents for grid/christtheredeemer', (assert) => {
+    assert.equal(Array.from(conf.landmark._geocoder.grid.list())[0][0], 'christtheredeemer', 'test index contents for christ the redeemer');
+    assert.end();
+});
+//language flag test to trigger during getMatchingText();
+tape('query: Wall St', (t) => {
+    c.geocode('Wall St', { language: 'ar'}, (err, res) => {
+        t.equal('Wall St', res.features[0].text, 'Fallback to English');
+        t.equal('en', res.features[0].language, 'Language returned is English');
+        t.ifError(err, 'no error');
+        t.end();
+    });
+});
+tape('query: Christ the Redeemer', (t) => {
+    c.geocode('Christ the Redeemer', { language: 'ar'}, (err, res) => {
+        t.equal('Christ the Redeemer', res.features[0].text, 'Fallback to English');
+        t.equal('en', res.features[0].language, 'Language returned is English');
+        t.ifError(err, 'no error');
+        t.end();
+    });
+});
+
+tape('removedchar', (assert) => {
+    let charless = termops.removedchar('this has a space');
+    let result = charless.indexOf(' ');
+    assert.deepEqual(charless, 'thishasaspace', 'result and missed character are the same')
+    assert.deepEqual(result, -1, 'dawg-cache removes a char');
+    assert.end();
+});
+

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -182,6 +182,7 @@ tape('dump/load', (t) => {
             t.ifError(err);
             let loaded = new DawgCache(data);
             for (let i = 1; i <= 4; i++) {
+                console.log(loaded.hasPhrase("a1"));
                 t.equal(loaded.hasPhrase("a" + i, false), true, 'has a' + i);
             }
             t.equal(loaded.hasPhrase("a5", false), false, 'not a5');
@@ -268,11 +269,11 @@ tape('query: Christ the Redeemer', (t) => {
     });
 });
 
-tape('removedchar', (assert) => {
-    let charless = termops.removedchar('this has a space');
-    let result = charless.indexOf(' ');
-    assert.deepEqual(charless, 'thishasaspace', 'result and missed character are the same')
-    assert.deepEqual(result, -1, 'dawg-cache removes a char');
-    assert.end();
-});
+// tape('removedchar', (assert) => {
+//     let charless = termops.removedchar('this has a space');
+//     let result = charless.indexOf(' ');
+//     assert.deepEqual(charless, 'thishasaspace', 'result and missed character are the same')
+//     assert.deepEqual(result, -1, 'dawg-cache removes a char');
+//     assert.end();
+// });
 

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -2,16 +2,18 @@ const tape = require('tape');
 const zlib = require('zlib');
 const DawgCache = require('../lib/util/dawg');
 const termops = require('../lib/util/termops');
-
-const tape = require('tape');
 const Carmen = require('..');
-// const context = require('../lib/context');
 const mem = require('../lib/api-mem');
 const queue = require('d3-queue').queue;
+// const context = require('../lib/context');
+
+
+// be able to add a specific feature
 const addFeature = require('../lib/util/addfeature'),
     queueFeature = addFeature.queueFeature,
     buildQueued = addFeature.buildQueued;
 
+// create basic outline for a feature to be searched
 const conf = {
     country: new mem({
         maxzoom: 6,
@@ -34,6 +36,8 @@ const conf = {
         geocoder_languages: ['en'],
     }, () => {}),
 };
+
+
 const c = new Carmen(conf);
 tape('index Wall St', (t) => {
     let street = {

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -1,0 +1,41 @@
+const tape = require('tape');
+const zlib = require('zlib');
+const DawgCache = require('../lib/util/dawg');
+
+tape('create', (t) => {
+    const dict = new DawgCache();
+    t.ok(dict, "dawg created")
+    t.end();
+});
+
+tape('dump/load', (t) => {
+    const dict = new DawgCache();
+    dict.setText("a1");
+    dict.setText("a2");
+    dict.setText("a3");
+    dict.setText("a4");
+
+    zlib.gzip(dict.dump(), (err, zdata) => {
+        t.ifError(err);
+        t.ok(zdata.length < 200e3, 'gzipped dictcache < 200k');
+        zlib.gunzip(zdata, (err, data) => {
+            t.ifError(err);
+            let loaded = new DawgCache(data);
+            for (let i = 1; i <= 4; i++) {
+                t.equal(loaded.hasPhrase("a" + i, false), true, 'has a' + i);
+            }
+            t.equal(loaded.hasPhrase("a5", false), false, 'not a5');
+
+            t.equal(loaded.hasPhrase("a", false), false, 'not a');
+            t.equal(loaded.hasPhrase("a", true), true, 'has a as degen');
+
+            t.end();
+        });
+    });
+});
+
+tape('invalid data', (t) => {
+    const dict = new DawgCache();
+    t.throws(() => { dict.setText(""); });
+    t.end();
+});

--- a/test/fuzzytest.test.js
+++ b/test/fuzzytest.test.js
@@ -185,7 +185,7 @@ tape('dump/load', (t) => {
                 console.log(loaded.hasPhrase("a1"));
                 t.equal(loaded.hasPhrase("a" + i, false), true, 'has a' + i);
             }
-            t.equal(loaded.hasPhrase("a5", false), false, 'not a5');
+            t.equal(loaded.hasPhrase("a45", false, true), false, 'not a45');
 
             t.equal(loaded.hasPhrase("a", false), false, 'not a');
             t.equal(loaded.hasPhrase("a", true), true, 'has a as degen');
@@ -268,12 +268,3 @@ tape('query: Christ the Redeemer', (t) => {
         t.end();
     });
 });
-
-// tape('removedchar', (assert) => {
-//     let charless = termops.removedchar('this has a space');
-//     let result = charless.indexOf(' ');
-//     assert.deepEqual(charless, 'thishasaspace', 'result and missed character are the same')
-//     assert.deepEqual(result, -1, 'dawg-cache removes a char');
-//     assert.end();
-// });
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,9 +574,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dawg-cache@https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35":
+"dawg-cache@https://github.com/mapbox/dawg-cache/tarball/fbe9528a560306bd67a02e53b12762fa46dcc765":
   version "0.5.0"
-  resolved "https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35#a5a01ca68c1c6a7f8be9830f0005b67d2a589d59"
+  resolved "https://github.com/mapbox/dawg-cache/tarball/fbe9528a560306bd67a02e53b12762fa46dcc765#ab1549e570d0bec189df6e3f1a3f5704a6082fed"
   dependencies:
     es6-iterator "2.0.0"
     es6-symbol "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,9 +574,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-dawg-cache@0.5.0:
+"dawg-cache@https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35":
   version "0.5.0"
-  resolved "https://registry.yarnpkg.com/dawg-cache/-/dawg-cache-0.5.0.tgz#7e6e4abf6dbb070250737a6d24a3a8f067082abd"
+  resolved "https://github.com/mapbox/dawg-cache/tarball/ef60027ebc5f0c37c279eaab3688716363e2da35#a5a01ca68c1c6a7f8be9830f0005b67d2a589d59"
   dependencies:
     es6-iterator "2.0.0"
     es6-symbol "3.0.2"


### PR DESCRIPTION
[Context](https://github.com/mapbox/geocoding/issues/158#issuecomment-337028078)
#### Next Steps

- [x] @aarthykc - Uniform places where normalization is being called to change with the uniform API etc. 
- [x] @aarthykc  - Opt into fuzzy matching in phrasematch 
- [x] @aarthykc  - In Phrasematch we will conditionally pass flag extra flag based on contents of the string. 
- [x] @aarthykc - Latin letters checking. 
- [x] @aaaandrea - Look at the response to see if the match string is different from the one we turned in. we will need to pass in the real string and pass into coalesce or the response string and pass that into coalesce. 
- [x] both -Tests

coming soon: check relavence calculations: communicate to carmen-cache or verify match to penalize fuzzy matches. either generic or not so carmen-cache can apply
