### PR TITLE
Add documentation for routable_point for Carmen GeoJSON

### DIFF
--- a/carmen-geojson.md
+++ b/carmen-geojson.md
@@ -58,6 +58,7 @@ key | description
 `address` | Where applicable. Contains the housenumber for the returned feature
 `center` | Array of the form [lon,lat].
 `context` | Array representing a hierarchy of parents. Each parent includes `id`, `text` keys.
+`routable_point` | Optional. Array of the form [lon,lat]. Closest point on the relevant road, if the feature has an associated road.
 
 For geocodes that include one or more language codes set by `options.language`, the following keys will also be returned for each language requested:
 


### PR DESCRIPTION
### Context
Proposed new spec for routable_point feature as described in #674 

### Summary of Changes
- [ ] Add routable_point as a top-level key on the Carmen GeoJSON spec


### Next Steps
I have a few open questions:
1. Not sure if it makes sense for routable_point to be a top-level key with the other carmen keys (in addition to standard GeoJSON), or if it should be nested under properties. I have it here as a top-level key because it seems to be the most consistent with the way things are done now.  It seems that as it is now, relevant, standardized location data is all top-level (center, bbox, etc), and properties seem to be non-standardized byproducts of data sources. Adding it top-level will mean a bigger change to the Carmen spec (and more deviation from standard GeoJSON), but hopefully adding properties shouldn't break any existing functionality. Also, are there other use-cases where information like this that will be consumed by API users is nested in properties? If not, adding to the properties would mean accessing a new nested field that API consumers may not be currently accessing.

2. Does the order matter? I've added it to the end, but if there's a reason it should be in a different order, let me know!


cc @mapbox/geocoding-gang
