### PR TITLE
Routablequest tests and functionality

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -293,6 +293,7 @@ function tileCover(source, lon, lat, cb) {
 // For a source return an array of nearest feature hit points/center points as
 // a flat array of lon,lat coordinates.
 function nearestPoints(source, lon, lat, scoreFilter, callback) {
+    console.log('|||||||||||| INSIDE NEAREST POINTS')
     tileCover(source, lon, lat, query);
 
     function query(err, vt) {
@@ -350,7 +351,7 @@ function nearestPoints(source, lon, lat, scoreFilter, callback) {
 // in imaginary z-space (country, town, place, etc). When there are no more
 // to do, return that array, filtered of nulls and reversed.
 function contextVector(source, lon, lat, full, matched, language, scoreFilter, reverseMode, callback) {
-
+    console.log('========= inside contextVector')
     tileCover(source, lon, lat, query);
 
     // For a loaded vector tile, query for features at the lon,lat.
@@ -489,6 +490,7 @@ function lightFeature(source, feat, callback) {
 
 // Go from VT query attributes to a fully loaded feature
 function fullFeature(source, feat, query, callback) {
+    console.log(' $$$$$ inside full feature $$$$$$')
     feature.getFeatureById(source, feat.id, function(err, loaded) {
         if (err) return callback(err);
         if (!loaded) return callback();

--- a/lib/context.js
+++ b/lib/context.js
@@ -293,7 +293,6 @@ function tileCover(source, lon, lat, cb) {
 // For a source return an array of nearest feature hit points/center points as
 // a flat array of lon,lat coordinates.
 function nearestPoints(source, lon, lat, scoreFilter, callback) {
-    console.log('|||||||||||| INSIDE NEAREST POINTS')
     tileCover(source, lon, lat, query);
 
     function query(err, vt) {
@@ -351,7 +350,6 @@ function nearestPoints(source, lon, lat, scoreFilter, callback) {
 // in imaginary z-space (country, town, place, etc). When there are no more
 // to do, return that array, filtered of nulls and reversed.
 function contextVector(source, lon, lat, full, matched, language, scoreFilter, reverseMode, callback) {
-    console.log('========= inside contextVector')
     tileCover(source, lon, lat, query);
 
     // For a loaded vector tile, query for features at the lon,lat.
@@ -490,7 +488,6 @@ function lightFeature(source, feat, callback) {
 
 // Go from VT query attributes to a fully loaded feature
 function fullFeature(source, feat, query, callback) {
-    console.log(' $$$$$ inside full feature $$$$$$')
     feature.getFeatureById(source, feat.id, function(err, loaded) {
         if (err) return callback(err);
         if (!loaded) return callback();

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -1,20 +1,34 @@
+const nearestPointOnLine = require("@turf/nearest-point-on-line");
+const turfPoint = require("@turf/helpers").point;
+
 module.exports = routablePoint;
 
 /**
- * Takes a point of origin and a feature, and returns the nearest point 
+ * Takes a point of origin and a feature, and returns the nearest point
  * on the associated LineString
- * 
+ *
  * @param {Array} point Lon,lat coordinate array
  * @param {Object} feature Address feature with GeometryCollection of MultiPoint and LineStrings
  * @return {Array} Lon,lat coordinate array of the routable point
  */
 function routablePoint(point, feature) {
-    // TODO: Handle unexpected inputs
-    // if (!point) {
-    //     throw new Error('routablePoint requires a point');
-    // } else if (!feature) {
-    //     throw new Error('routablePoint requires a feature');
-    // }
+    // TODO: determine if this should throw error or if should just return empty array
+    if (!point || !feature) {
+        return [];
+    }
+    const addressLineString = feature.geometry.geometries.find(
+        geom => geom.type === "MultiLineString"
+    );
+    if (!addressLineString) {
+        return [];
+    }
+    const pt = turfPoint(point);
 
-    return [];
+    const nearestPoint = addressLineString ? nearestPointOnLine(addressLineString, pt): [];
+
+    // Round coordinates to 6 decimal places
+    const nearestPointCoords = nearestPoint.geometry.coordinates.map(
+        coord => Math.round(coord * Math.pow(10, 6)) / Math.pow(10, 6)
+    );
+    return nearestPointCoords;
 }

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -17,8 +17,6 @@ function routablePoint(point, feature) {
         return null;
     }
 
-    console.warn('FEATURE PASSED IN', feature)
-
     const addressLineString = feature.geometry.geometries.find(
         geom => geom.type === "MultiLineString"
     );

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -1,3 +1,20 @@
 module.exports = routablePoint;
 
-function routablePoint(point, feature) {}
+/**
+ * Takes a point of origin and a feature, and returns the nearest point 
+ * on the associated LineString
+ * 
+ * @param {Array} point Lon,lat coordinate array
+ * @param {Object} feature Address feature with GeometryCollection of MultiPoint and LineStrings
+ * @return {Array} Lon,lat coordinate array of the routable point
+ */
+function routablePoint(point, feature) {
+    // TODO: Handle unexpected inputs
+    // if (!point) {
+    //     throw new Error('routablePoint requires a point');
+    // } else if (!feature) {
+    //     throw new Error('routablePoint requires a feature');
+    // }
+
+    return [];
+}

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -14,13 +14,16 @@ module.exports = routablePoint;
 function routablePoint(point, feature) {
     // TODO: determine if this should throw error or if should just return empty array
     if (!point || !feature) {
-        return [];
+        return null;
     }
+
+    console.warn('FEATURE PASSED IN', feature)
+
     const addressLineString = feature.geometry.geometries.find(
         geom => geom.type === "MultiLineString"
     );
     if (!addressLineString) {
-        return [];
+        return null;
     }
     const pt = turfPoint(point);
 

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -1,0 +1,3 @@
+module.exports = routablePoint;
+
+function routablePoint(point, feature) {}

--- a/lib/pure/routablepoint.js
+++ b/lib/pure/routablepoint.js
@@ -12,7 +12,7 @@ module.exports = routablePoint;
  * @return {Array} Lon,lat coordinate array of the routable point
  */
 function routablePoint(point, feature) {
-    // TODO: determine if this should throw error or if should just return empty array
+    // TODO: determine if this should throw error or if should just return null
     if (!point || !feature) {
         return null;
     }

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -3,7 +3,6 @@ var closestLang = require('./closest-lang');
 var featureMatchesLanguage = require('./filter').featureMatchesLanguage;
 var termops = require('./termops');
 var bbox = require('./bbox');
-var routablePoint = require('../pure/routablepoint');
 
 /**
  * getFormatString - get a `place_name` template string from a format object

--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -3,6 +3,7 @@ var closestLang = require('./closest-lang');
 var featureMatchesLanguage = require('./filter').featureMatchesLanguage;
 var termops = require('./termops');
 var bbox = require('./bbox');
+var routablePoint = require('../pure/routablepoint');
 
 /**
  * getFormatString - get a `place_name` template string from a format object
@@ -130,6 +131,7 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
     };
     if (feat.matching_text) feature.matching_text = feat.matching_text;
     if (feat.matching_language) feature.matching_language = feat.matching_language;
+    if (feat.routable_point) feature.routable_point = feat.routable_point;
 
     languages.reduce(function(memo, language, i) {
         var suffix = language ? `_${language}` : '';

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -9,6 +9,7 @@ var closestLang = require('./util/closest-lang');
 var bbox = require('./util/bbox');
 var filter = require('./util/filter');
 var constants = require('./constants');
+var routablePoint = require('./pure/routablepoint');
 
 module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
@@ -115,6 +116,15 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                 if (addressPoints.length) {
                     let newFeats = addressPoints.slice(0,10).map(function(addressPoint) {
                         let feat = JSON.parse(JSON.stringify(feats[0]));
+
+                        // Run routablePoint on multilinestring and addresspoint
+                        console.log('^^^^ RUNNING ROUTABLEPOINT');
+                        const routPoint = routablePoint(addressPoint.coordinates, feat);
+                        console.warn('####### ROUTABLE POINT ', routPoint);
+                        // Add routable_point attribute to feat
+                        if (routPoint) {
+                            feat.routable_point = routPoint;
+                        }
                         feat.geometry = addressPoint;
                         feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;
                         return feat;

--- a/lib/verifymatch.js
+++ b/lib/verifymatch.js
@@ -118,10 +118,9 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                         let feat = JSON.parse(JSON.stringify(feats[0]));
 
                         // Run routablePoint on multilinestring and addresspoint
-                        console.log('^^^^ RUNNING ROUTABLEPOINT');
+                        // TODO: only run routablePoint if address is not interpolated,
+                        // otherwise, either skip it or set routable_point as addressPoint
                         const routPoint = routablePoint(addressPoint.coordinates, feat);
-                        console.warn('####### ROUTABLE POINT ', routPoint);
-                        // Add routable_point attribute to feat
                         if (routPoint) {
                             feat.routable_point = routPoint;
                         }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@turf/distance": "^5.1.5",
     "@turf/helpers": "^5.1.5",
     "@turf/length": "^5.1.5",
+    "@turf/nearest-point-on-line": "^5.1.5",
     "@turf/point-on-feature": "^5.1.5",
     "d3-queue": "3.0.x",
     "dawg-cache": "0.5.0",

--- a/test/geocode-unit.address-routable-point.test.js
+++ b/test/geocode-unit.address-routable-point.test.js
@@ -22,7 +22,7 @@ const addFeature = require('../lib/util/addfeature'),
             properties: {
                 'carmen:text': 'fake street',
                 'carmen:center': [0,0],
-                'carmen:addressnumber': [null, ['9','10','7']]
+                'carmen:addressnumber': [null, ['9','11','13']]
             },
             geometry: {
                 type: "GeometryCollection",
@@ -48,9 +48,13 @@ const addFeature = require('../lib/util/addfeature'),
         queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end) });
     });
 
-    tape('Search for us style address, return with german formatting', (t) => {
-        c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
+    tape('Search for interpolated address and return routable point', (t) => {
+        c.geocode('9 fake street', { limit_verify: 1, debug: true, full: true }, (err, res) => {
             t.ifError(err);
+            // routable_point property exists, ok
+            console.warn('res', res);
+            // console.warn('geometry', res.features[0].geometry);
+            t.ok(res.features[0].routable_point, 'routable_point exists');
             t.end();
         });
     });

--- a/test/geocode-unit.address-routable-point.test.js
+++ b/test/geocode-unit.address-routable-point.test.js
@@ -1,0 +1,63 @@
+// Ensures that relev takes into house number into consideration
+// Also ensure relev is applied to US & Non-US Style addresses
+
+const tape = require('tape');
+const Carmen = require('..');
+const context = require('../lib/context');
+const mem = require('../lib/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+// Test geocoder_address formatting + return place_name as germany style address (address number follows name)
+(() => {
+    const conf = {
+        address: new mem({maxzoom: 6,  geocoder_address:1, geocoder_format: '{address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}'}, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index address', (t) => {
+        let address = {
+            id:1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0],
+                'carmen:addressnumber': [null, ['9','10','7']]
+            },
+            geometry: {
+                type: "GeometryCollection",
+                geometries: [
+                    {
+                        type: "MultiLineString",
+                        coordinates: [
+                            [
+                                [1.111, 1.11],
+                                [1.112, 1.11],
+                                [1.114, 1.11],
+                                [1.115, 1.11]
+                            ]
+                        ]
+                    },
+                    {
+                        type: "MultiPoint",
+                        coordinates: [[1.111, 1.111], [1.113, 1.111], [1.115, 1.111]]
+                    }
+                ]
+            }
+        }
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end) });
+    });
+
+    tape('Search for us style address, return with german formatting', (t) => {
+        c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.end();
+        });
+    });
+})();
+
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});

--- a/test/geocode-unit.address-routable-point.test.js
+++ b/test/geocode-unit.address-routable-point.test.js
@@ -1,5 +1,4 @@
-// Ensures that relev takes into house number into consideration
-// Also ensure relev is applied to US & Non-US Style addresses
+// Tests whether routable_point is added to geocoding results
 
 const tape = require('tape');
 const Carmen = require('..');
@@ -51,9 +50,6 @@ const addFeature = require('../lib/util/addfeature'),
     tape('Search for interpolated address and return routable point', (t) => {
         c.geocode('9 fake street', { limit_verify: 1, debug: true, full: true }, (err, res) => {
             t.ifError(err);
-            // routable_point property exists, ok
-            console.warn('res', res);
-            // console.warn('geometry', res.features[0].geometry);
             t.ok(res.features[0].routable_point, 'routable_point exists');
             t.end();
         });

--- a/test/geocode-unit.address-routable-point.test.js
+++ b/test/geocode-unit.address-routable-point.test.js
@@ -4,7 +4,6 @@ const tape = require('tape');
 const Carmen = require('..');
 const context = require('../lib/context');
 const mem = require('../lib/api-mem');
-const queue = require('d3-queue').queue;
 const addFeature = require('../lib/util/addfeature'),
     queueFeature = addFeature.queueFeature,
     buildQueued = addFeature.buildQueued;

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -7,8 +7,6 @@ tape('call routablePoint with valid inputs', function(assert) {
         type: "Feature",
         properties: {
             "carmen:addressnumber": [null, ["110", "112", "114"]],
-            "carmen:text": "Main street",
-            "carmen:geocoder_stack": "us",
             "carmen:center": [1.111, 1.113]
         },
         geometry: {
@@ -83,6 +81,9 @@ tape('call routablePoint with valid inputs', function(assert) {
 
     assert.end();
 });
+
+
+
 
 /**
  * TODO: Test non-straight linestring

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -2,7 +2,7 @@ var tape = require('tape');
 var routablePoint = require('../lib/pure/routablepoint.js');
 
 tape('call routablePoint with valid inputs', function(assert) {
-    var point = [1.11, 1.1];
+    var point = [1.111, 1.11];
     var feature = {
         type: "Feature",
         properties: {
@@ -76,8 +76,8 @@ tape('call routablePoint with valid inputs', function(assert) {
      * - -   - -
      */
     assert.deepEquals(
-        routablePoint([1.13, 1.115], feature),
-        [1.13, 1.1],
+        routablePoint([1.113, 1.115], feature),
+        [1.113, 1.11],
         "Point in between linestring coords should return midpoint between coords on linestring"
     );
 

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -1,0 +1,12 @@
+var tape = require('tape');
+var routablePoint = require('../lib/pure/routablepoint.js');
+
+tape('call routablepoint with valid inputs', function(assert) {
+  var point = [1, 1]; // define a test point here
+  var feature = {}; // define a test feature here
+  var result = routablePoint(point, feature);
+  // assert some things that you expect about the result here
+  // then end the test
+  assert.equals(1, 1, 'dummy test');
+  assert.end();
+});

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -1,12 +1,152 @@
 var tape = require('tape');
 var routablePoint = require('../lib/pure/routablepoint.js');
 
-tape('call routablepoint with valid inputs', function(assert) {
-  var point = [1, 1]; // define a test point here
-  var feature = {}; // define a test feature here
-  var result = routablePoint(point, feature);
-  // assert some things that you expect about the result here
-  // then end the test
-  assert.equals(1, 1, 'dummy test');
-  assert.end();
+tape('call routablePoint with valid inputs', function(assert) {
+    var point = [1.11, 1.1];
+    var feature = {
+        type: "Feature",
+        properties: {
+            "carmen:addressnumber": [null, ["110", "112", "114"]],
+            "carmen:text": "Main street",
+            "carmen:geocoder_stack": "us",
+            "carmen:center": [1.111, 1.113]
+        },
+        geometry: {
+            type: "GeometryCollection",
+            geometries: [
+                {
+                    type: "MultiLineString",
+                    coordinates: [
+                        [
+                            [1.111, 1.11],
+                            [1.112, 1.11],
+                            [1.114, 1.11],
+                            [1.115, 1.11]
+                        ]
+                    ]
+                },
+                {
+                    type: "MultiPoint",
+                    coordinates: [[1.11, 1.111], [1.113, 1.111], [1.115, 1.111]]
+                }
+            ]
+        },
+        id: 1
+    };
+
+    var featureNoLinestring = {
+        type: "Feature",
+        properties: {},
+        geometry: {
+            type: "GeometryCollection",
+            geometries: [
+                {
+                    type: "MultiPoint",
+                    coordinates: [[1, 1]]
+                }
+            ]
+        }
+    };
+
+    var result = routablePoint(point, feature);
+
+    assert.deepEquals(
+        routablePoint(point, featureNoLinestring),
+        [],
+        "Features with no linestrings should return empty array"
+    );
+
+    /**
+     * Example point (x) feature point coords (.) and linestring coords (-) looks like:
+     *
+     * .   .   .
+     * - - x - -
+     */
+    assert.deepEquals(
+        result,
+        point,
+        "Point that is already on linestring should return itself"
+    );
+
+    /**
+     * Example point (x) feature point coords (.) and linestring coords (-) looks like:
+     *
+     *     x
+     * .   .   .
+     * - -   - -
+     */
+    assert.deepEquals(
+        routablePoint([1.13, 1.115], feature),
+        [1.13, 1.1],
+        "Point in between linestring coords should return midpoint between coords on linestring"
+    );
+
+    assert.end();
 });
+
+/**
+ * TODO: Test non-straight linestring
+ * TODO: Test linestring and point with 2 equidistant closest points (and determine expected behavior)
+ * TODO: Test case where point is entirely offset from linestring, e.g.:
+ *       x
+ *              -------------------
+ * TODO: Test invalid inputs
+ * TODO: Test not interpolated feature?
+ * TODO: Integration tests for reverse geocoding?
+ */
+
+
+// TODO: Test invalidinputs
+// tape('call routablePoint with invalid inputs', function(assert) {
+//     var point = {};
+//     var malformedPoint = "1, 1";
+//     var feature = {
+//         type: "Feature",
+//         properties: {
+//             "carmen:addressnumber": [null, ["110", "112", "114"]],
+//             "carmen:text": "Main street",
+//             "carmen:geocoder_stack": "us",
+//             "carmen:center": [1.11, 1.13]
+//         },
+//         geometry: {
+//             type: "GeometryCollection",
+//             geometries: [
+//                 {
+//                     type: "MultiLineString",
+//                     coordinates: [
+//                         [
+//                             [1.11, 1.111],
+//                             [1.11, 1.112],
+//                             [1.11, 1.113],
+//                             [1.11, 1.114],
+//                             [1.11, 1.115]
+//                         ]
+//                     ]
+//                 },
+//                 {
+//                     type: "MultiPoint",
+//                     coordinates: [
+//                         [1.111, 1.111],
+//                         [1.111, 1.113],
+//                         [1.111, 1.115]
+//                     ]
+//                 }
+//             ]
+//         },
+//         id: 1
+//     };
+
+//     assert.throws(
+//         routablePoint(),
+//         Error,
+//         "Missing point and feature params throws error"
+//     );
+//     assert.throws(routablePoint(point), Error, "Missing feature throws error");
+//     assert.throws(
+//         routablePoint(malformedPoint, feature),
+//         Error,
+//         "Malformed point throws error"
+//     );
+
+//     assert.end();
+// });

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -50,8 +50,8 @@ tape('call routablePoint with valid inputs', function(assert) {
 
     assert.deepEquals(
         routablePoint(point, featureNoLinestring),
-        [],
-        "Features with no linestrings should return empty array"
+        null,
+        "Features with no linestrings should return null"
     );
 
     /**

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -83,9 +83,8 @@ tape('call routablePoint with valid inputs', function(assert) {
 });
 
 
-
-
 /**
+ * TODO: Test invalidinputs
  * TODO: Test non-straight linestring
  * TODO: Test linestring and point with 2 equidistant closest points (and determine expected behavior)
  * TODO: Test case where point is entirely offset from linestring, e.g.:
@@ -94,61 +93,7 @@ tape('call routablePoint with valid inputs', function(assert) {
  * TODO: Test invalid inputs
  * TODO: Test not interpolated feature?
  * TODO: Integration tests for reverse geocoding?
- * TODO: Test cases crossing dateline
+ * TODO: Test cases crossing dateline?
  */
 
 
-// TODO: Test invalidinputs
-// tape('call routablePoint with invalid inputs', function(assert) {
-//     var point = {};
-//     var malformedPoint = "1, 1";
-//     var feature = {
-//         type: "Feature",
-//         properties: {
-//             "carmen:addressnumber": [null, ["110", "112", "114"]],
-//             "carmen:text": "Main street",
-//             "carmen:geocoder_stack": "us",
-//             "carmen:center": [1.11, 1.13]
-//         },
-//         geometry: {
-//             type: "GeometryCollection",
-//             geometries: [
-//                 {
-//                     type: "MultiLineString",
-//                     coordinates: [
-//                         [
-//                             [1.11, 1.111],
-//                             [1.11, 1.112],
-//                             [1.11, 1.113],
-//                             [1.11, 1.114],
-//                             [1.11, 1.115]
-//                         ]
-//                     ]
-//                 },
-//                 {
-//                     type: "MultiPoint",
-//                     coordinates: [
-//                         [1.111, 1.111],
-//                         [1.111, 1.113],
-//                         [1.111, 1.115]
-//                     ]
-//                 }
-//             ]
-//         },
-//         id: 1
-//     };
-
-//     assert.throws(
-//         routablePoint(),
-//         Error,
-//         "Missing point and feature params throws error"
-//     );
-//     assert.throws(routablePoint(point), Error, "Missing feature throws error");
-//     assert.throws(
-//         routablePoint(malformedPoint, feature),
-//         Error,
-//         "Malformed point throws error"
-//     );
-
-//     assert.end();
-// });

--- a/test/routablepoint.test.js
+++ b/test/routablepoint.test.js
@@ -27,7 +27,7 @@ tape('call routablePoint with valid inputs', function(assert) {
                 },
                 {
                     type: "MultiPoint",
-                    coordinates: [[1.11, 1.111], [1.113, 1.111], [1.115, 1.111]]
+                    coordinates: [[1.111, 1.111], [1.113, 1.111], [1.115, 1.111]]
                 }
             ]
         },
@@ -93,6 +93,7 @@ tape('call routablePoint with valid inputs', function(assert) {
  * TODO: Test invalid inputs
  * TODO: Test not interpolated feature?
  * TODO: Integration tests for reverse geocoding?
+ * TODO: Test cases crossing dateline
  */
 
 


### PR DESCRIPTION
### Context
Starts adding routable point functionality to geocoding results and tests, as outlined in #676 and #675.
This implements it for forward geocoding only, and is still in progress towards creating a fully production-ready feature.

### Summary of Changes
- Use Turf.js [nearest-point-on-line](https://github.com/Turfjs/turf/tree/master/packages/turf-nearest-point-on-line) to find the routable point
- Add routable_point attribute to geocoding results for forward geocoding
- Add unit tests and integration test for routable point functionality

### Next Steps
- [ ] More robust test cases (see TODO's in [test/routablepoint.test.js](https://github.com/mapbox/carmen/blob/d3a23252893d7e90062e24b28c403ae5f6a64042/test/routablepoint.test.js))
- [ ] More robust handling of inputs so routablePoint does not cause unexpected errors (either explicit error handling, or failing silently and returning null if inputs are not as expected)
- [ ] Handling some of the other test cases described in the TODO's (in particular the 2 equidistant points case and dateline. The non-straight linestring and point entirely offset from linestring _should_ be handled. But we can't be sure without tests!)
- [ ] Add reverse geocoding functionality (see discussion [here](https://github.com/mapbox/carmen/issues/674#issuecomment-354865992))
- [ ] Only run routablePoint if address is not interpolated. Otherwise, determine if routable_point should be set to the interpolated point, which is already on the linestring, or if routable_point should not be added at all in this case.
- [ ] Revisit signature of routablePoint. Does it still make sense to pass in an array and a feature, or would it make sense to pass in a point object and feature, or coordinate array and linestring?


cc @mapbox/geocoding-gang

  