### PR TITLE
Busted type filtering

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -43,11 +43,9 @@ module.exports = function(geocoder, query, options, callback) {
         for (let type of options.types) {
             if (!acceptableTypes.has(type)) {
                 return callback(errcode('Type "' + type + '" is not a known type. Must be one of: ' + Array.from(acceptableTypes).join(', '), 'EINVALID'));
-            } else {
+            } else if (type.match(/\./) && requestedTypes.has(type.split('.')[0])) {
                 // if we're looking at something like poi.landmark and we also have poi, remove poi.landmark
-                if (type.match(/\./) && requestedTypes.has(type.split('.')[0])) {
-                    requestedTypes.delete(type);
-                }
+                requestedTypes.delete(type);
             }
         }
         options.types = Array.from(requestedTypes).sort();

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -37,20 +37,20 @@ module.exports = function(geocoder, query, options, callback) {
         if (!Array.isArray(options.types) || options.types.length < 1)
             return callback(errcode('options.types must be an array with at least 1 type', 'EINVALID'));
 
-        var l = options.types.length;
-        var acceptableTypes = Object.keys(geocoder.bytype).concat(Object.keys(geocoder.bysubtype));
-        while (l--) {
-            if (acceptableTypes.indexOf(options.types[l]) === -1) {
-                return callback(errcode('Type "' + options.types[l] + '" is not a known type. Must be one of: ' + acceptableTypes.join(', '), 'EINVALID'));
+        let acceptableTypes = new Set([...Object.keys(geocoder.bytype), ...Object.keys(geocoder.bysubtype)]);
+
+        let requestedTypes = new Set(options.types);
+        for (let type of options.types) {
+            if (!acceptableTypes.has(type)) {
+                return callback(errcode('Type "' + type + '" is not a known type. Must be one of: ' + Array.from(acceptableTypes).join(', '), 'EINVALID'));
             } else {
-                //remove any cases like poi and poi.landmark
-                var subtypeAndTypeExist = geocoder.bytype[options.types[l]] && ((options.types).toString().indexOf(options.types[l]) != l);
-                var subtypeIndexWhenTypeExists = subtypeAndTypeExist ? (options.types).toString().indexOf(options.types[l]) : -1;
-                if (subtypeAndTypeExist) {
-                    options.types.splice(subtypeIndexWhenTypeExists, 1);
+                // if we're looking at something like poi.landmark and we also have poi, remove poi.landmark
+                if (type.match(/\./) && requestedTypes.has(type.split('.')[0])) {
+                    requestedTypes.delete(type);
                 }
             }
         }
+        options.types = Array.from(requestedTypes).sort();
     }
 
     // Stacks option

--- a/test/geocode-unit.types.test.js
+++ b/test/geocode-unit.types.test.js
@@ -212,6 +212,20 @@ tape('china', (t) => {
     });
 });
 
+// country wins without type filter
+tape('china', (t) => {
+    c.geocode('china', { types:['poi', 'region', 'place', 'poi.landmark', 'country'] }, (err1, res1) => {
+        t.ifError(err1);
+        c.geocode('china', { types:['region', 'place', 'poi.landmark', 'country', 'poi'] }, (err2, res2) => {
+            t.ifError(err2);
+            t.deepEqual(res1, res2, 'results with type filter and same types are the same regardless of type order');
+            t.deepEqual(res1.features[0].id, 'country.1', 'country wins in response 1');
+            t.deepEqual(res2.features[0].id, 'country.1', 'country wins in response 2');
+            t.end();
+        });
+    });
+});
+
 // types: place
 tape('china', (t) => {
     c.geocode('china', { limit_verify:3, types:['place'] }, (err, res) => {


### PR DESCRIPTION
### Context
Type filter validation is subtly broken. The current code for checking the validity of users' requested type filters look like this:
```
if (options.types) {
    if (!Array.isArray(options.types) || options.types.length < 1)
        return callback(errcode('options.types must be an array with at least 1 type', 'EINVALID'));

    var l = options.types.length;
    var acceptableTypes = Object.keys(geocoder.bytype).concat(Object.keys(geocoder.bysubtype));
    while (l--) {
        if (acceptableTypes.indexOf(options.types[l]) === -1) {
            return callback(errcode('Type "' + options.types[l] + '" is not a known type. Must be one of: ' + acceptableTypes.join(', '), 'EINVALID'));
        } else {
            //remove any cases like poi and poi.landmark
            var subtypeAndTypeExist = geocoder.bytype[options.types[l]] && ((options.types).toString().indexOf(options.types[l]) != l);
            var subtypeIndexWhenTypeExists = subtypeAndTypeExist ? (options.types).toString().indexOf(options.types[l]) : -1;
            if (subtypeAndTypeExist) {
                options.types.splice(subtypeIndexWhenTypeExists, 1);
            }
        }
    }
}
```

Part of it is checking that the types are valid (this part is fine), and the other part is checking for situations where a user has requested both a type (like `poi`) and a child subtype (like `poi.landmark`) with the goal of removing the latter as duplicative. This codepath intermixes values that represent **indexes within the `options.types`** and **indexes with in the `options.types` array cast to a string**. I'm not sure why this is, but as best as I can figure, the `suptypeAndTypeExists` variable is supposed to check whether an entry is the only entry of a given type in the types array by seeing if the position of the entry we're looking at now is the same as the position of the first occurrence of that type within the array; if it's not, we have a duplicate. But it does this by comparing the **array position** of the item we're looking at now with the **string position** of the stringified version of the array, and seeing if they're the same. With the exception of whatever element is in the first position (where both of these will be 0), these will never be the same, so this variable will almost always be true.

If it's true, we then attempt to remove the offending element from the array, but we calculate which element to remove as a **string position** again, and then treat that as an **array position** for performing the removal, so we end up removing an element that has nothing to do with the one we're looking at now, essential at random, and we do this for every type except for the first one in the list. Fortunately, in practice this usually does nothing, because the string position numbers are much larger than the typical array position numbers, so trying to remove the 20th array element doesn't end up doing anything (we don't have that many types). Problems occur, however, if the element in the first position is short and the string offset of the element in the second position is consequently small.

For example, in a list like `['poi', 'region', 'place', 'address', 'country']` (with string representation `poi,region,place,address,country`), the first element is safe (0 == 0), but the second element (`region`) will incorrectly succeed on that first test, and it's in the fifth string position, so we'll then remove the fifth array element (`country`) from the types list. Womp womp.

### Summary of Changes
- [x] add a test confirming the breakage
- [x] the reasoning behind doing all these string operations isn't clear, and we're also doing a bunch of inefficient linear searches over an array, so stop it, and use Sets instead
- [x] the current code also mutates the array while simultaneously iterating over it; instinctively this feels wrong, though I can't pinpoint when exactly it would break; stop that too
- [x] make it all easier to read


### Next Steps
- [x] wait for CI on this project and other related projects
- [ ] merge, cut new version, etc.
<!-- if you're still working on it -->


cc @mapbox/geocoding-gang