### PR TITLE
Skip irrelevant indexes earlier when using country param

### DIFF
--- a/lib/phrasematch.js
+++ b/lib/phrasematch.js
@@ -2,6 +2,7 @@ var termops = require('./util/termops');
 var token = require('./util/token');
 var bb = require('./util/bbox');
 var cl = require('./util/closest-lang');
+var filter = require('./util/filter');
 
 /**
 * phrasematch
@@ -15,6 +16,12 @@ module.exports = function phrasematch(source, query, options, callback) {
     options.autocomplete = options.autocomplete || false;
     options.bbox = options.bbox || false;
     var tokenized = termops.tokenize(token.replaceToken(source.token_replacer, query));
+
+    // if requested country isn't included, skip
+    if (options.stacks) {
+        let stackAllowed = filter.sourceMatchesStacks(source, options);
+        if (!stackAllowed) return callback(null, new PhrasematchResult([], source));
+    }
 
     // if not in bbox, skip
     if (options.bbox) {

--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -89,6 +89,8 @@ if (argv.types) {
     argv.types = argv.types.split(',');
 }
 
+if (argv.country) argv.stacks = argv.country;
+
 if (argv.stacks) {
     argv.stacks = argv.stacks.split(',');
 }

--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -17,19 +17,21 @@ var argv = require('minimist')(process.argv, {
 if (argv.help) {
     console.log('carmen.js --query="<query>" [options]');
     console.log('[options]:');
-    console.log('  --version               Print the carmen version');
-    console.log('  --tokens=<tokens.json>  Load global token file');
-    console.log('  --config=<file.js>      Load index config from js (module)');
-    console.log('  --limit="{limit}"       Customize the number of results returned');
-    console.log('  --proximity="lat,lng"   Favour results by proximity');
-    console.log('  --types="{type},..."    Only return results of a given type');
-    console.log('  --stacks="{stack},..."  Only return results of a given stack');
-    console.log('  --geojson               Return a geojson object');
-    console.log('  --language={ISO code}   Return responses in specified language (if available in index)');
-    console.log('  --stats                 Generate Stats on the query');
-    console.log('  --debug="feat id"       Follows a feature through geocode"');
-    console.log('  --reverseMode="{mode}"  Sort features in reverse queries by one of `score` or `distance`');
-    console.log('  --help                  Print this report');
+    console.log('  --version                    Print the carmen version');
+    console.log('  --tokens=<tokens.json>       Load global token file');
+    console.log('  --config=<file.js>           Load index config from js (module)');
+    console.log('  --limit="{limit}"            Customize the number of results returned');
+    console.log('  --proximity="lng,lat"        Favour results by proximity');
+    console.log('  --types="{type},..."         Only return results of a given type');
+    console.log('  --stacks="{stack},..."       Only return results of a given stack');
+    console.log('  --geojson                    Return a geojson object');
+    console.log('  --language={ISO code}        Return responses in specified language (if available in index)');
+    console.log('  --stats                      Generate Stats on the query');
+    console.log('  --debug="feat id"            Follows a feature through geocode"');
+    console.log('  --reverseMode="{mode}"       Sort features in reverse queries by one of `score` or `distance`');
+    console.log('  --languageMode="strict"      Only return results with text in a consistent script family');
+    console.log('  --bbox="minX,minY,maxX,maxY" Limit results to those within the specified bounding box');
+    console.log('  --help                       Print this report');
     process.exit(0);
 }
 
@@ -72,6 +74,17 @@ if (argv.proximity) {
     argv.proximity = [ Number(argv.proximity.split(',')[0]), Number(argv.proximity.split(',')[1]) ];
 }
 
+if (argv.bbox) {
+    if (argv.bbox.split(',') !== 4)
+        throw new Error("bbox must be minX,minY,maxX,maxY");
+    argv.bbox = [
+        Number(argv.proximity.split(',')[0]),
+        Number(argv.proximity.split(',')[1]),
+        Number(argv.proximity.split(',')[2]),
+        Number(argv.proximity.split(',')[3])
+    ];
+}
+
 if (argv.types) {
     argv.types = argv.types.split(',');
 }
@@ -99,7 +112,9 @@ carmen.geocode(argv.query, {
     'stats': true,
     'language': argv.language,
     'indexes': true,
-    'reverseMode': argv.reverseMode
+    'reverseMode': argv.reverseMode,
+    'languageMode': argv.languageMode,
+    'bbox': argv.bbox
 }, function(err, data) {
     if (err) throw err;
     load = +new Date() - load;


### PR DESCRIPTION
### Context
Currently, the country param only filters out features that are not in the requested country or countries relatively late in the process, in verifymatch. We end up doing a fair amount of work finding and sorting results from indexes that will have all their results thrown away at the end.

We can skip indexes that don't contain any features in the requested country earlier in the process in phrasematch to improve performance.

### Summary of Changes
* When using the country param, don't consider phrasematch results from indexes that don't contain features in the requested country.

cc @mapbox/geocoding-gang
