### PR TITLE
Fix bbox in scripts/carmen.js

### DIFF
--- a/scripts/carmen.js
+++ b/scripts/carmen.js
@@ -75,13 +75,13 @@ if (argv.proximity) {
 }
 
 if (argv.bbox) {
-    if (argv.bbox.split(',') !== 4)
+    if (argv.bbox.split(',').length !== 4)
         throw new Error("bbox must be minX,minY,maxX,maxY");
     argv.bbox = [
-        Number(argv.proximity.split(',')[0]),
-        Number(argv.proximity.split(',')[1]),
-        Number(argv.proximity.split(',')[2]),
-        Number(argv.proximity.split(',')[3])
+        Number(argv.bbox.split(',')[0]),
+        Number(argv.bbox.split(',')[1]),
+        Number(argv.bbox.split(',')[2]),
+        Number(argv.bbox.split(',')[3])
     ];
 }
 

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -217,6 +217,19 @@ tape('bin/carmen query language=es,en', (t) => {
         t.end();
     });
 });
+tape('bin/carmen query bbox', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --bbox="-78.828,-34.465,9.830,21.913"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+tape('bin/carmen query invalid bbox', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --bbox="-78.828,-34.465"', (err, stdout, stderr) => {
+        t.ok(err, 'bbox must be minX,minY,maxX,maxY');
+        t.end();
+    });
+});
 tape('bin/carmen-copy noargs', (t) => {
     exec(bin + '/carmen-copy.js', (err, stdout, stderr) => {
         t.equal(1, err.code);


### PR DESCRIPTION
### Context
https://github.com/mapbox/carmen/pull/681 added support for `bbox` arguments from the carmen CLI. This fixes error handling for that change and adds tests to confirm it works as expected.

### Summary of Changes
- [x] check the length of the `bbox` arg and parse `bbox` rather than `proximity` parameter
- [x] add unit tests for cli runs with valid and invalid bboxes

### Next Steps
- [ ] review
- [ ] merge & release new carmen version

cc @mapbox/geocoding-gang
