### PR TITLE
Token concat

### DIFF
--- a/lib/util/token.js
+++ b/lib/util/token.js
@@ -49,12 +49,12 @@ module.exports.createReplacer = function(tokens, inverseOpts) {
     }
     for (var token in tokens) {
         var from = token; // normalize expanded
-        var to = tokens[token];
+        var orig_to = tokens[token];
 
         var replacementOpts = {};
-        if (typeof to == 'object' && to.text) {
-            replacementOpts = to;
-            to = to.text;
+        if (typeof orig_to == 'object' && orig_to.text) {
+            replacementOpts = orig_to;
+            orig_to = orig_to.text;
         }
 
         let inverse = !!isInverse[from];
@@ -76,14 +76,14 @@ module.exports.createReplacer = function(tokens, inverseOpts) {
             entry.named = (parsedFrom.xregexp.captureNames !== null);
 
             // ensure that named groups are all or nothing; otherwise we have order problems
-            if (entry.named && parsedFrom.xregexp.captureNames.some(function(captureName) { return captureName === null; }))
+            if (entry.named && parsedFrom.xregexp.captureNames.some(function(captureName) { return captureName === null; })) {
                 throw new Error('Cannot process \'%s\'; must use either named or numbered capture groups, not both', from);
+            }
 
             if (entry.named) {
                 entry.from = new XRegExp('(?<tokenBeginning>' + WORD_BOUNDARY + '|^)' + from.replace(".", "\\.") + '(?<tokenEnding>' + WORD_BOUNDARY + '|$)', 'gi');
-                entry.to = typeof to == "string" ? '${tokenBeginning}' + to + '${tokenEnding}' : to;
-            }
-            else {
+                entry.to = typeof orig_to == "string" ? '${tokenBeginning}' + orig_to + '${tokenEnding}' : orig_to;
+            } else {
                 entry.from = new RegExp(
                     (replacementOpts.skipBoundaries ? '' : '(' + WORD_BOUNDARY + '|^)') +
                     from.replace(".", "\\.") +
@@ -94,11 +94,14 @@ module.exports.createReplacer = function(tokens, inverseOpts) {
                 let count = new RegExp(from + "|").exec('').length - 1;
 
                 // increment replacements indexes in `to`
-                if (typeof to == "string" && !replacementOpts.skipBoundaries) {
-                    to = to.replace(/\$(\d+)/g, function(str, index) { return '$' + (parseInt(index)+1).toString();});
-                    entry.to = '$1' + to + '$' + (count + 2).toString(); // normalize abbrev
+                if (typeof orig_to == "string" && !replacementOpts.skipBoundaries) {
+                    let new_to = orig_to.replace(/\$(\d+)/g, (str, index) => {
+                        return '$' + (parseInt(index) + 1).toString();
+                    });
+
+                    entry.to = '$1' + new_to + '$' + (count + 2).toString(); // normalize abbrev
                 } else {
-                    entry.to = to; // normalize abbrev
+                    entry.to = orig_to; // normalize abbrev
                 }
             }
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -37,6 +37,25 @@ tape.test('token#concatenated single token', t => {
     t.end();
 });
 
+tape.test('token#concatenated single token - diacritics', t => {
+    let tokens = {
+        '([a-z]+)vägen': {
+            'text': '$1v'
+        }
+    }
+    let tokenReplacer = tokenize.createReplacer(tokens)
+    let expected = [
+        { from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)([a-z]+)vägen([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, inverse: false, named: false, to: '$1$2v$3' },
+        { from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)([a-z]+)vagen([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, inverse: false, named: false, to: '$1$2v$3' }
+    ]
+
+    t.deepEquals(tokenReplacer, expected, 'created a regex')
+
+    t.equals(tokenize.replaceToken(tokenReplacer, 'Samuelsvägen'), 'Samuelsv', 'replaced token');
+    t.equals(tokenize.replaceToken(tokenReplacer, 'Samuelsvagen'), 'Samuelsv', 'replaced token');
+    t.end();
+});
+
 tape.test('token#test global tokens - talstrasse', (t) => {
     let tokens = {
         '\\b(.+)(strasse|str|straße)\\b': "$1 str"

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -1,57 +1,51 @@
 const tokenize = require('../lib/util/token.js');
 const tape = require('tape');
 
-(() => {
-    tape('test tokens', (t) => {
-        let tokens = {
-            'Street': 'st'
-        }
-        let tokenReplacer = tokenize.createReplacer(tokens)
-        let expected = [ { named: false, from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)Street([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, to: '$1st$2', inverse: false } ];
-        t.deepEquals(tokenReplacer, expected, 'okay, created a regex')
-        t.end();
-    });
-})();
+tape.test('token# test tokens', t => {
+    let tokens = {
+        'Street': 'st'
+    }
+    let tokenReplacer = tokenize.createReplacer(tokens)
+    let expected = [ { named: false, from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)Street([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, to: '$1st$2', inverse: false } ];
+    t.deepEquals(tokenReplacer, expected, 'okay, created a regex')
+    t.end();
+});
 
-(() => {
-    tape('test tokens', (t) => {
-        let tokens = {
-            'Street': 'st'
-        }
-        let query = 'fake street';
-        let tokensRegex = tokenize.createReplacer(tokens)
+tape.test('token#test tokens', (t) => {
+    let tokens = {
+        'Street': 'st'
+    }
+    let query = 'fake street';
+    let tokensRegex = tokenize.createReplacer(tokens)
+    let replace = tokenize.replaceToken(tokensRegex, query);
+    t.deepEquals('fake st', replace, 'okay, replaced the token')
+    t.end();
+});
+
+tape.test('token#test global tokens - talstrasse', (t) => {
+    let tokens = {
+        '\\b(.+)(strasse|str|straße)\\b': "$1 str"
+    };
+    tape.test('talstrasse', (q) => {
+        let query = 'talstrasse';
+        let tokensRegex = tokenize.createGlobalReplacer(tokens)
         let replace = tokenize.replaceToken(tokensRegex, query);
-        t.deepEquals('fake st', replace, 'okay, replaced the token')
-        t.end();
+        q.deepEquals('tal str', replace, 'okay, talstrasse')
+        q.end();
     });
-})();
-
-(() => {
-    tape('test global tokens - talstrasse', (t) => {
-        let tokens = {
-            '\\b(.+)(strasse|str|straße)\\b': "$1 str"
-        };
-        tape.test('talstrasse', (q) => {
-            let query = 'talstrasse';
-            let tokensRegex = tokenize.createGlobalReplacer(tokens)
-            let replace = tokenize.replaceToken(tokensRegex, query);
-            q.deepEquals('tal str', replace, 'okay, talstrasse')
-            q.end();
-        });
-        tape.test('talstraße', (q) => {
-            let query = 'talstraße';
-            let tokensRegex = tokenize.createGlobalReplacer(tokens)
-            let replace = tokenize.replaceToken(tokensRegex, query);
-            q.deepEquals('tal str', replace, 'okay, talstraße')
-            q.end();
-        });
-        tape.test('talstr', (q) => {
-            let query = 'talstr';
-            let tokensRegex = tokenize.createGlobalReplacer(tokens)
-            let replace = tokenize.replaceToken(tokensRegex, query);
-            q.deepEquals('tal str', replace, 'okay, talstr')
-            q.end();
-        });
-        t.end();
+    tape.test('talstraße', (q) => {
+        let query = 'talstraße';
+        let tokensRegex = tokenize.createGlobalReplacer(tokens)
+        let replace = tokenize.replaceToken(tokensRegex, query);
+        q.deepEquals('tal str', replace, 'okay, talstraße')
+        q.end();
     });
-})();
+    tape.test('talstr', (q) => {
+        let query = 'talstr';
+        let tokensRegex = tokenize.createGlobalReplacer(tokens)
+        let replace = tokenize.replaceToken(tokensRegex, query);
+        q.deepEquals('tal str', replace, 'okay, talstr')
+        q.end();
+    });
+    t.end();
+});

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -20,9 +20,7 @@ tape.test('token#street=>st', t => {
 
 tape.test('token#concatenated single token', t => {
     let tokens = {
-        '([a-z]+)gatan': {
-            'text': '$1g'
-        }
+        '([a-z]+)gatan': '$1g'
     }
     let tokenReplacer = tokenize.createReplacer(tokens)
     let expected = [ { from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)([a-z]+)gatan([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, inverse: false, named: false, to: '$1$2g$3' } ];

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -1,24 +1,39 @@
 const tokenize = require('../lib/util/token.js');
 const tape = require('tape');
 
-tape.test('token# test tokens', t => {
-    let tokens = {
+tape.test('token#street=>st', t => {
+    const tokens = {
         'Street': 'st'
     }
-    let tokenReplacer = tokenize.createReplacer(tokens)
-    let expected = [ { named: false, from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)Street([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, to: '$1st$2', inverse: false } ];
-    t.deepEquals(tokenReplacer, expected, 'okay, created a regex')
+
+    const tokenReplacer = tokenize.createReplacer(tokens)
+    const expected = [ { named: false, from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)Street([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, to: '$1st$2', inverse: false } ];
+
+    t.deepEquals(tokenReplacer, expected, 'created a regex')
+
+    const query = 'fake street';
+    const replace = tokenize.replaceToken(tokenReplacer, query);
+
+    t.deepEquals(replace, 'fake st', 'replaced the token')
     t.end();
 });
 
-tape.test('token#test tokens', (t) => {
+tape.test('token#concatenated single token', t => {
     let tokens = {
-        'Street': 'st'
+        '([a-z]+)gatan': {
+            'text': '$1g'
+        }
     }
-    let query = 'fake street';
-    let tokensRegex = tokenize.createReplacer(tokens)
-    let replace = tokenize.replaceToken(tokensRegex, query);
-    t.deepEquals('fake st', replace, 'okay, replaced the token')
+    let tokenReplacer = tokenize.createReplacer(tokens)
+    let expected = [ { from: /([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|^)([a-z]+)gatan([\s\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]|$)/gi, inverse: false, named: false, to: '$1$2g$3' } ];
+
+    t.deepEquals(tokenReplacer, expected, 'created a regex')
+
+    const query = 'Mäster Samuelsgatan';
+
+    const replace = tokenize.replaceToken(tokenReplacer, query);
+
+    t.deepEquals(replace, 'Mäster Samuelsg', 'replaced the token')
     t.end();
 });
 
@@ -26,25 +41,25 @@ tape.test('token#test global tokens - talstrasse', (t) => {
     let tokens = {
         '\\b(.+)(strasse|str|straße)\\b': "$1 str"
     };
-    tape.test('talstrasse', (q) => {
+    t.test('talstrasse', (q) => {
         let query = 'talstrasse';
         let tokensRegex = tokenize.createGlobalReplacer(tokens)
         let replace = tokenize.replaceToken(tokensRegex, query);
-        q.deepEquals('tal str', replace, 'okay, talstrasse')
+        q.deepEquals(replace, 'tal str', 'talstrasse')
         q.end();
     });
-    tape.test('talstraße', (q) => {
+    t.test('talstraße', (q) => {
         let query = 'talstraße';
         let tokensRegex = tokenize.createGlobalReplacer(tokens)
         let replace = tokenize.replaceToken(tokensRegex, query);
-        q.deepEquals('tal str', replace, 'okay, talstraße')
+        q.deepEquals(replace, 'tal str', 'talstraße')
         q.end();
     });
-    tape.test('talstr', (q) => {
+    t.test('talstr', (q) => {
         let query = 'talstr';
         let tokensRegex = tokenize.createGlobalReplacer(tokens)
         let replace = tokenize.replaceToken(tokensRegex, query);
-        q.deepEquals('tal str', replace, 'okay, talstr')
+        q.deepEquals(replace, 'tal str', 'talstr')
         q.end();
     });
     t.end();


### PR DESCRIPTION
### Context

- Updates to token tests
    - Refactor to avoid use of anon fxn
    - Ensure all assertions are `result, expected`
    - Add tests around per-index regex tokens (sweden)

*Bug Fix*
On the first pass of generating a `from:to` pair, the original `to` string would be mutated to include the numbered replacement groups referencing the word boundaries.

So `$1something` would be mutated to become `$1$2something$3`

If the diacritic removal code was run it then removed the diacritics from the `from` replacer and ran the `to` creator again. Since the `to` had been mutated by the first pass it would then incorrectly calculate the numbered replace groups. 

Fix: Avoid mutating the original `to` text, instead cloning on write.

cc @mapbox/geocoding-gang
