### PR TITLE
Prefer non-ghost features when building context

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -365,6 +365,8 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
         }, function(err, results) {
             if (err) return callback(err);
             if (!results || !results.length) return callback(null, false);
+            var forwardMatchFeat;
+            var ghostMatchFeat;
             var feat;
             var dist = Infinity;
             var mapped;
@@ -429,6 +431,11 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
                 var score = attr["carmen:score"] || (attr.properties && attr.properties["carmen:score"]);
                 if (score === undefined) score = 0;
                 if (score < 0 && !matched[tmpid]) continue;
+                // Store first ghost feature for possible later use.
+                if (score < 0 && !ghostMatchFeat) {
+                    ghostMatchFeat = attr;
+                    continue;
+                }
 
                 // scorefilter, if set
                 if (scoreFilter && (score <= scoreFilter[0] || score > scoreFilter[1])) continue;
@@ -438,8 +445,16 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
 
                 feat = attr;
                 dist = results[i].distance;
-                if (matched[tmpid]) break;
+                if (matched[tmpid]) {
+                    forwardMatchFeat = feat;
+                    break;
+                }
             }
+            // Priority order:
+            // 1. Non-ghost, forward phrasematch
+            // 2. Ghost, forward phrasematch
+            // 3. Non-ghost, not a phrasematch
+            feat = forwardMatchFeat || ghostMatchFeat || feat;
             if (feat && full) {
                 return fullFeature(source, feat, [lon,lat], callback);
             } else if (feat) {

--- a/test/geocode-unit.ghost.test.js
+++ b/test/geocode-unit.ghost.test.js
@@ -1,0 +1,106 @@
+const tape = require('tape');
+const Carmen = require('..');
+const context = require('../lib/context');
+const mem = require('../lib/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../lib/util/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+(() => {
+    const conf = {
+        region: new mem(null, () => {}),
+        city: new mem(null, () => {}),
+        neighborhood: new mem(null, () => {}),
+        poi: new mem(null, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index region', (t) => {
+        let region = {
+            id:1,
+            properties: {
+                'carmen:text':'Outer Rim',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0]
+            }
+        };
+        queueFeature(conf.region, region, t.end);
+    });
+
+    tape('index city 1', (t) => {
+        let city = {
+            id:2,
+            properties: {
+                'carmen:text':'Mos Eisley',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0],
+                'carmen:score': -1
+            }
+        };
+        queueFeature(conf.city, city, t.end);
+    });
+
+    tape('index city 2', (t) => {
+        let city = {
+            id:3,
+            properties: {
+                'carmen:text':'Tatooine',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0],
+                'carmen:score': 1000
+            }
+        };
+        queueFeature(conf.city, city, t.end);
+    });
+
+    tape('index neighborhood', (t) => {
+        let neighborhood = {
+            id:5,
+            properties: {
+                'carmen:text':'Mos Eisley',
+                'carmen:zxy':['6/32/32'],
+                'carmen:center':[0,0],
+                'carmen:score': 10
+            }
+        };
+        queueFeature(conf.neighborhood, neighborhood, t.end);
+    });
+
+    tape('index poi', (t) => {
+        let poi = {
+            id:5,
+            properties: {
+                'carmen:text':'Tatooine Community College',
+                'carmen:center':[0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        queueFeature(conf.poi, poi, t.end);
+    });
+
+    tape('build queued features', (t) => {
+        const q = queue();
+        Object.keys(conf).forEach((c) => {
+            q.defer((cb) => {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
+    tape('Mos Eisley', (t) => {
+        c.geocode('Mos Eisley Tatooine', {}, (err, res) => {
+            t.ifError(err);
+            t.deepEqual(res.features[0].place_name, 'Mos Eisley, Tatooine, Outer Rim');
+            t.deepEqual(res.features[0].relevance, 1);
+            t.end();
+        });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
+})();


### PR DESCRIPTION
### Context
"Ghost" features (typically alternate place names, denoted by a score of
-1) are excluded from a feature's context array unless they were
included in the original query. This allows an alternate place name to
returned if it was explicitly requested, but otherwise the default place
name will be used.

However, in situations where a query token matches both a ghost and a
non-ghost feature (for instance, a POI with the same name as a ghost
place within which it is located), we will return the first feature that
happens to be returned when querying the vector tile, which is
arbitrary and non-deterministic between indexer runs.

### Summary of Changes

This adjusts the context builder to use a priority order:

1. Non-ghost features that match a query token
2. Ghost features that match a query token
3. Non-ghost features that do not match a query token


### Next Steps
There is still some non-determinism when matching ghost features, since
this preserves a portion of the old behavior and returns only the first
ghost feature that is also a forward phrasematch. However, this is a
smaller problem than the prior status quo, and doesn't have as obvious a
solution since all features in this category are identically scored.

cc @mapbox/geocoding-gang
