### PR TITLE
You wouldn't believe this address format!

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -184,7 +184,7 @@ function address(token) {
             /^\d+[a-z]?$/.test(token) //10 or 10a Style
             || /^(\d+)-(\d+)[a-z]?$/.test(token) // 10-19 or 10-19a Style
             || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token) // 6N23 Style (ie Kane County, IL)
-            || /^([nesw])(\d+)([nesw])(\d+)$/.test(token) //W350N5337 Style (ie Waukesha County, WI)
+            || /^([nesw])(\d+)([nesw]\d+)?$/.test(token) //W350N5337 or N453 Style (ie Waukesha County, WI)
         )
     ) {
         return token;

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -184,7 +184,7 @@ function address(token) {
             /^\d+[a-z]?$/.test(token) //10 or 10a Style
             || /^(\d+)-(\d+)[a-z]?$/.test(token) // 10-19 or 10-19a Style
             || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token) // 6N23 Style (ie Kane County, IL)
-            || /^([nesw])(\d+)([nesw])(\d+)$/ //W350N5337 Style (ie Waukesha County, WI)
+            || /^([nesw])(\d+)([nesw])(\d+)$/.test(token) //W350N5337 Style (ie Waukesha County, WI)
         )
     ) {
         return token;

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -178,8 +178,15 @@ function maskAddress(query, coverText, mask) {
  * @return {String}       Returns a string of the address or null
  */
 function address(token) {
-    //                                  10 or 10a Style               10-19 or 10-19a Style              6N23 Style (ie Kane County, IL)
-    if (typeof token === 'string' && (/^\d+[a-z]?$/.test(token) || /^(\d+)-(\d+)[a-z]?$/.test(token) || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token))) {
+    if (
+        typeof token === 'string'
+        && (
+            /^\d+[a-z]?$/.test(token) //10 or 10a Style
+            || /^(\d+)-(\d+)[a-z]?$/.test(token) // 10-19 or 10-19a Style
+            || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token) // 6N23 Style (ie Kane County, IL)
+            || /^([nesw])(\d+)([nesw])(\d+)$/ //W350N5337 Style (ie Waukesha County, WI)
+        )
+    ) {
         return token;
     } else {
         return null;

--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -181,10 +181,10 @@ function address(token) {
     if (
         typeof token === 'string'
         && (
-            /^\d+[a-z]?$/.test(token) //10 or 10a Style
+            /^\d+[a-z]?$/.test(token) // 10 or 10a Style
             || /^(\d+)-(\d+)[a-z]?$/.test(token) // 10-19 or 10-19a Style
             || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token) // 6N23 Style (ie Kane County, IL)
-            || /^([nesw])(\d+)([nesw]\d+)?$/.test(token) //W350N5337 or N453 Style (ie Waukesha County, WI)
+            || /^([nesw])(\d+)([nesw]\d+)?$/.test(token) // W350N5337 or N453 Style (ie Waukesha County, WI)
         )
     ) {
         return token;

--- a/test/termops.maskAddress.test.js
+++ b/test/termops.maskAddress.test.js
@@ -8,13 +8,13 @@ test('maskAddress', (q) => {
     q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100b'], 'fake street ###', parseInt('1110',2)), { addr: '100b', pos: 3 });
     q.deepEqual(termops.maskAddress(['100b', '1', 'fake', 'street'], '', parseInt('1111',2)), { addr: '100b', pos: 0 });
 
-    //Kane IL Style Addresses
+    // Kane IL Style Addresses
     q.deepEqual(termops.maskAddress(['1s13', 'fake', 'street'], '## fake street', parseInt('111',2)), { addr: '1s13', pos: 0 });
     q.deepEqual(termops.maskAddress(['6n486', 'fake', 'street'], '### fake street', parseInt('111',2)), { addr: '6n486', pos: 0 });
     q.deepEqual(termops.maskAddress(['54w32', 'fake', 'street'], '## fake street', parseInt('111',2)), { addr: '54w32', pos: 0 });
     q.deepEqual(termops.maskAddress(['8e234', 'fake', 'street'], '### fake street', parseInt('111',2)), { addr: '8e234', pos: 0 });
 
-    //Waukesha, WI Style Addresses
+    // Waukesha, WI Style Addresses
     q.deepEqual(termops.maskAddress(['w350n5337', 'road', 'c'], '## road c', parseInt('111',2)), { addr: 'w350n5337', pos: 0 });
     q.deepEqual(termops.maskAddress(['n60w35415', 'bayshore', 'circle'], '## bayshore circle', parseInt('111',2)), { addr: 'n60w35415', pos: 0 });
     q.deepEqual(termops.maskAddress(['w35295', 'coastal', 'avenue'], '## coastal avenue', parseInt('111',2)), { addr: 'w35295', pos: 0 });

--- a/test/termops.maskAddress.test.js
+++ b/test/termops.maskAddress.test.js
@@ -7,10 +7,19 @@ test('maskAddress', (q) => {
     q.deepEqual(termops.maskAddress(['100', '1', 'fake', 'street'], '### 1 fake street', parseInt('1111',2)), { addr: '100', pos: 0 });
     q.deepEqual(termops.maskAddress(['1', 'fake', 'street', '100b'], 'fake street ###', parseInt('1110',2)), { addr: '100b', pos: 3 });
     q.deepEqual(termops.maskAddress(['100b', '1', 'fake', 'street'], '', parseInt('1111',2)), { addr: '100b', pos: 0 });
+
+    //Kane IL Style Addresses
     q.deepEqual(termops.maskAddress(['1s13', 'fake', 'street'], '## fake street', parseInt('111',2)), { addr: '1s13', pos: 0 });
     q.deepEqual(termops.maskAddress(['6n486', 'fake', 'street'], '### fake street', parseInt('111',2)), { addr: '6n486', pos: 0 });
     q.deepEqual(termops.maskAddress(['54w32', 'fake', 'street'], '## fake street', parseInt('111',2)), { addr: '54w32', pos: 0 });
     q.deepEqual(termops.maskAddress(['8e234', 'fake', 'street'], '### fake street', parseInt('111',2)), { addr: '8e234', pos: 0 });
+
+    //Waukesha, WI Style Addresses
+    q.deepEqual(termops.maskAddress(['w350n5337', 'road', 'c'], '## road c', parseInt('111',2)), { addr: 'w350n5337', pos: 0 });
+    q.deepEqual(termops.maskAddress(['n60w35415', 'bayshore', 'circle'], '## bayshore circle', parseInt('111',2)), { addr: 'n60w35415', pos: 0 });
+    q.deepEqual(termops.maskAddress(['w35295', 'coastal', 'avenue'], '## coastal avenue', parseInt('111',2)), { addr: 'w35295', pos: 0 });
+    q.deepEqual(termops.maskAddress(['n35295', 'lakeshore', 'drive'], '## lakeshore drive', parseInt('111',2)), { addr: 'n35295', pos: 0 });
+
     q.deepEqual(termops.maskAddress(['115', '37'], '## 115', parseInt('11',2)), { addr: '37', pos: 1 });
     q.deepEqual(termops.maskAddress(['115', '115'], '## 115', parseInt('11',2)), { addr: '115', pos: 1 });
     q.end();


### PR DESCRIPTION
### Context

A customer has reported that addresses for the Town of Oconomowoc, WI fail to geocode.

Per the town code: https://ecode360.com/15607678

```
§ 85-5 Numbering system.
A. One hundred numbers shall be assigned to each invisible block, regardless of discrepancies in block sizes. Properties on the north and east sides of streets shall bear even numbers, and properties on the south and west sides of streets shall bear odd numbers.
B. The number assigned to each property shall be composed of two parts. The first part, or street designation, shall be composed of a directional letter, "N," "S," "W," followed by the number of the appropriate block line.
C. The second part of the property number, the block and house designation, shall be composed of a directional letter followed by the number of the appropriate block line plus two additional digits indicating the relative position of the property in the block.
D. For a block which lies south of the east-west baseline, the designation of the block shall be by the block line numbers of its north and its east boundaries. For a block which lies north of the east-west baseline, the designation of the block shall be by the block line numbers of its south and its east boundaries.
E. Properties and street intersections contained within any block shall bear numbers and directional letters related to the point of intersection of the block boundary lines stipulated in the subsection next above.
```

This PR introduces support for this address type.

### Next Steps

- Add Support to https://github.com/ingalls/pt2itp/

cc @mapbox/geocoding-gang
