### PR TITLE
Add support for dashes in format string

### DIFF
--- a/lib/util/ops.js
+++ b/lib/util/ops.js
@@ -54,7 +54,7 @@ function getPlaceName(context, formatString, language, languageMode, matched) {
         ).trim();
     } else {
         // Create template object that lists what we want to know
-        const template = formatString.replace(/ /g,'').replace(/,/g,'').trim().replace(/^{/,'').replace(/}$/,'').split('}{');
+        const template = formatString.replace(/ /g,'').replace(/,/g,'').trim().replace(/^{/,'').replace(/}$/,'').split(/}{|}-{/);
 
         // Go through template object one-by-one & check to see if context is available for this template property
         for (let i = 0; i < template.length; i++) {
@@ -100,7 +100,7 @@ function getPlaceName(context, formatString, language, languageMode, matched) {
             }
         }
         // Handle any cases where context wasn't available by getting rid of curly braces, awkwards spaces/commas
-        formatString = formatString.replace(/\{.+?\}/g, '').replace(/ , /g,', ').replace(/ {2}/g,' ').replace(/, ,/g,'').replace(/^,/,'').replace(/,,/,',').trim().replace(/,$/,'');
+        formatString = formatString.replace(/\{.+?\}/g, '').replace(/ , /g,', ').replace(/ {2}/g,' ').replace(/, -/,',').replace(/, ,/g,'').replace(/^,/,'').replace(/,,/,',').trim().replace(/,$/,'');
         place_name = formatString;
     }
     return place_name;

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -434,6 +434,148 @@ const addFeature = require('../lib/util/addfeature'),
     });
 })();
 
+// Test dashes in format string
+(() => {
+    const conf = {
+        region: new mem({ maxzoom: 6,  geocoder_format: '{region._name}' }, () => {}),
+        place: new mem({ maxzoom: 6,  geocoder_format: '{place._name} - {region._name}' }, () => {}),
+        locality: new mem({ maxzoom: 6,  geocoder_format: '{locality._name}, {place._name} - {region._name}' }, () => {}),
+        neighborhood: new mem({ maxzoom: 6,  geocoder_format: '{neighborhood._name}, {place._name} - {region._name}' }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('index region:', (t) => {
+        const region = {
+            id:1,
+            properties: {
+                'carmen:text': 'Region A',
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32']
+            }
+        };
+        queueFeature(conf.region, region, t.end);
+    });
+    tape('index region:', (t) => {
+        const region = {
+            id:2,
+            properties: {
+                'carmen:text': 'Region B',
+                'carmen:center': [-1,-1],
+                'carmen:zxy': ['6/31/32']
+            }
+        };
+        queueFeature(conf.region, region, t.end);
+    });
+    tape('index region:', (t) => {
+        const region = {
+            id:3,
+            properties: {
+                'carmen:text': 'Region C',
+                'carmen:center': [-1,1],
+                'carmen:zxy': ['6/31/31']
+            }
+        };
+        queueFeature(conf.region, region, t.end);
+    });
+    tape('index place', (t) => {
+        const place = {
+            id:1,
+            properties: {
+                'carmen:text': 'Place A',
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32']
+            }
+        };
+        queueFeature(conf.place, place, t.end);
+    });
+    tape('index locality', (t) => {
+        const locality = {
+            id:1,
+            properties: {
+                'carmen:text': 'Locality C',
+                'carmen:center': [-1,1],
+                'carmen:zxy': ['6/31/31']
+            }
+        };
+        queueFeature(conf.locality, locality, t.end);
+    });
+    tape('index neighborhood', (t) => {
+        const neighborhood = {
+            id:1,
+            properties: {
+                'carmen:text': 'Neighborhood A',
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32']
+            }
+        };
+        queueFeature(conf.neighborhood, neighborhood, t.end);
+    });
+    tape('index neighborhood', (t) => {
+        const neighborhood = {
+            id:2,
+            properties: {
+                'carmen:text': 'Neighborhood B',
+                'carmen:center': [-1,-1],
+                'carmen:zxy': ['6/31/32']
+            }
+        };
+        queueFeature(conf.neighborhood, neighborhood, t.end);
+    });
+    tape('index neighborhood', (t) => {
+        const neighborhood = {
+            id:3,
+            properties: {
+                'carmen:text': 'Neighborhood C',
+                'carmen:center': [-1,1],
+                'carmen:zxy': ['6/31/31']
+            }
+        };
+        queueFeature(conf.neighborhood, neighborhood, t.end);
+    });
+    tape('build queued features', (t) => {
+        const q = queue();
+        Object.keys(conf).forEach((c) => {
+            q.defer((cb) => {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
+    tape('Place A', (t) => {
+        c.geocode('Place A', { }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Place A - Region A');
+            t.end();
+        });
+    });
+    tape('Locality C', (t) => {
+        c.geocode('Locality C', { }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Locality C, Region C');
+            t.end();
+        });
+    });
+    tape('Neighborhood A', (t) => {
+        c.geocode('Neighborhood A', { }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Neighborhood A, Place A - Region A');
+            t.end();
+        });
+    });
+    tape('Neighborhood C', (t) => {
+        c.geocode('Neighborhood C', { }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, 'Neighborhood C, Region C');
+            t.end();
+        });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
+})();
+
 tape('teardown', (t) => {
     context.getTile.cache.reset();
     t.end();

--- a/test/geocode-unit.address-format.test.js
+++ b/test/geocode-unit.address-format.test.js
@@ -48,6 +48,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.end();
         });
     });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 // Test geocoder_address formatting with multiple formats by language
@@ -105,6 +110,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.equals(res.features[0].place_name, '9 fake street');
             t.end();
         });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
     });
 })();
 
@@ -251,6 +261,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.end();
         });
     });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 (() => {
@@ -308,6 +323,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.end();
         });
     });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 // If the layer does not have geocoder_address do not take house number into account
@@ -337,6 +357,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.equals(res.features[0].relevance, 0.50);
             t.end();
         });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
     });
 })();
 
@@ -401,6 +426,11 @@ const addFeature = require('../lib/util/addfeature'),
             t.equals(res.features[0].place_name, 'snowball II, springfield');
             t.end();
         });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
     });
 })();
 


### PR DESCRIPTION
### Context
Dashes are used as a postal address delimiter in some countries (such as
Brazil, where it is used to separate the city and region components).
This adds display support for dash-separted address formats in the
place_name property.

This also fixes a pre-existing bug in geocode-unit.address-format.test.js that could cause features to persist across test closures.

### Summary of Changes
- Allow dashes as format string delimiter
- add teardown within each test closure in geocode-unit.address-format.test.js

cc @mapbox/geocoding-gang
