### PR TITLE
Strip out acute accent character ( ́  ) from all the queries 

### DIFF
--- a/lib/util/termops.js
+++ b/lib/util/termops.js
@@ -110,6 +110,8 @@ function tokenize(query, lonlat) {
         // all other ascii and unicode punctuation except '-' per
         // http://stackoverflow.com/questions/4328500 split terms
         .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#\$%&\(\)\*\+,\.\/:;<=>\?@\[\]\^_`\{\|\}~]/gi, ' ')
+        // removes the acute accent character  ́
+        .replace(/[\u0301]/g,'')
         .split(/[\s+]+/gi);
 
     let pretokens = [];


### PR DESCRIPTION
### Context

Based on user feedback, queries for Moscow in Russian labels doesn't work when `Москва́`(with the accent character) is used instead of `Москва`. Based on discussion,  removing the character from all the queries with this character is a good solution Adding a line to strip out the accent character from all the queries. 

Used [this](https://www.fileformat.info/info/unicode/char/0301/index.htm) to refer for the unicode encoding to replace the accent character with null.


### Summary of Changes
- [ ] Added a `.replace` statement to strip out the character


### Next Steps
- Test
- Review and merge 
- Bump version


cc @mattficke  @mapbox/geocoding-gang
