### PR TITLE
Update test and coverage scripts to test everything in test directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 npm-debug.log
 /coverage
 /.nyc_output/
-ccoverage.lcov
+coverage.lcov

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "main": "./index.js",
   "scripts": {
     "lint": "eslint index.js lib test scripts",
-    "test": "yarn run lint && (retire -n || echo 'WARNING: retire found insecure packages') && TESTING=true tape ./test/*.js && yarn run bench",
-    "coverage": "TESTING=true nyc tape test/*.js && nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "test": "yarn run lint && (retire -n || echo 'WARNING: retire found insecure packages') && TESTING=true tape './test**/*.js' && yarn run bench",
+    "coverage": "TESTING=true nyc tape 'test/**/*.js' && nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "bench": "./test/run_all_benchmarks.sh",
     "build-docs": " $(yarn bin)/documentation build --config docs/documentation.yml --access public --github --format md --output docs/api.md index.js lib/**"
   },


### PR DESCRIPTION
### Context
I noticed that the `yarn run test` and `yarn run coverage` scripts only ran 42 tests, since it was only running test files that were directly in the /test directory (specifically `bin.test.js`). Now that the tests have been refactored and organized (yay! 🎉 ), they're nested. This PR updates the scripts to run all of the nested tests.


### Summary of Changes
- [x] Change `test` and `coverage` scripts in package.json to use npm globs to get all the files
- [x] Add quotes to protect the script from getting expanded ([see explanation here](https://stackoverflow.com/questions/32017169/npm-glob-pattern-not-matching-subdirectories)
- [x] Fix typo in gitignore from my other PR #698 so that coverage.lcov _actually_ gets ignored (oops!)


### Next Steps
None, that's it!

cc @mapbox/geocoding-gang
