### PR TITLE
carmen-cache@0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.21.0",
+    "@mapbox/carmen-cache": "0.21.1",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@mapbox/carmen-cache@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.21.0.tgz#f775bdf959ca4e570a034f6618c299e256b11aaf"
+"@mapbox/carmen-cache@0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.21.1.tgz#554e4dfc73a046a16bf151fcf89a6d5757ec744d"
   dependencies:
     nan "~2.5.1"
     node-pre-gyp "~0.6.32"


### PR DESCRIPTION
### Context
The new version excludes unnecessary build tools which were
previously included in the published package.

Refs https://github.com/mapbox/carmen-cache/pull/121
### Summary of Changes
- bump carmen-cache

cc @mapbox/geocoding-gang
