### PR TITLE
[WIP] Be explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 /coverage
 /.nyc_output/
 coverage.lcov
+yarn-error.log

--- a/carmen-geojson.md
+++ b/carmen-geojson.md
@@ -58,8 +58,8 @@ key | description
 `address` | Where applicable. Contains the housenumber for the returned feature
 `center` | Array of the form [lon,lat].
 `context` | Array representing a hierarchy of parents. Each parent includes `id`, `text` keys.
-`routable_points` | Optional. Array of coordinate arrays of the form [[lon,lat], [lon,lat]]. Closest point on the relevant road, if the feature has an associated road.
-`routable_points_found` | Optional. Values are `true` or `false` for whether `routable_points` were found. This will only appear if the request was made with `routingMode` enabled.
+`routable_points` | Optional. Closest point on the relevant road, if the feature has an associated road. Will be returned if `routingMode: true` on request.
+`routable_points.points` | Optional. Array of points in the form of `[{ coordinates: [lon, lat] }]` or null if none were found.
 
 For geocodes that include one or more language codes set by `options.language`, the following keys will also be returned for each language requested:
 

--- a/carmen-geojson.md
+++ b/carmen-geojson.md
@@ -59,6 +59,7 @@ key | description
 `center` | Array of the form [lon,lat].
 `context` | Array representing a hierarchy of parents. Each parent includes `id`, `text` keys.
 `routable_points` | Optional. Array of coordinate arrays of the form [[lon,lat], [lon,lat]]. Closest point on the relevant road, if the feature has an associated road.
+`routable_points_found` | Optional. Values are `true` or `false` for whether `routable_points` were found. This will only appear if the request was made with `routingMode` enabled.
 
 For geocodes that include one or more language codes set by `options.language`, the following keys will also be returned for each language requested:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@ Central API elements, used in geocoding and indexing
 
 ### Geocoder
 
-[index.js:55-337](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L55-L337 "Source code on GitHub")
+[index.js:55-337](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L55-L337 "Source code on GitHub")
 
 Geocoder is an interface used to submit a single query to
 multiple indexes, returning a single set of ranked results.
@@ -51,7 +51,7 @@ multiple indexes, returning a single set of ranked results.
 
 #### Geocoder#geocode
 
-[index.js:424-430](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L424-L430 "Source code on GitHub")
+[index.js:424-430](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L424-L430 "Source code on GitHub")
 
 -   **See: [gecode](#geocode) for more details, including
     `options` properties.**
@@ -67,7 +67,7 @@ a given query.
 
 #### Geocoder#index
 
-[index.js:449-455](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L449-L455 "Source code on GitHub")
+[index.js:449-455](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L449-L455 "Source code on GitHub")
 
 -   **See: [index](#index) for more details, including `options` properties.**
 
@@ -85,7 +85,7 @@ Main entry point for indexing. Index a stream of GeoJSON docs.
 
 #### Geocoder#merge
 
-[index.js:471-477](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L471-L477 "Source code on GitHub")
+[index.js:471-477](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L471-L477 "Source code on GitHub")
 
 -   **See: [merge](#merge) for more details, including `options` properties.**
 
@@ -101,7 +101,7 @@ Merge two CarmenSources and output to a third.
 
 #### Geocoder#multimerge
 
-[index.js:492-498](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L492-L498 "Source code on GitHub")
+[index.js:492-498](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L492-L498 "Source code on GitHub")
 
 -   **See: [multimerge](#multimerge) for more details, including `options` properties.**
 
@@ -116,7 +116,7 @@ Merge more than two CarmenSources. Only supports MBTile sources.
 
 ### CarmenSource
 
-[index.js:55-337](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L55-L337 "Source code on GitHub")
+[index.js:55-337](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/index.js#L55-L337 "Source code on GitHub")
 
 An interface to the underlying data that a [Geocoder](#geocoder) instance is indexing and querying. In addition to the properties described below, instances must satisfy interface requirements for `Tilesource` and `Tilesink`. See tilelive [API Docs](https://github.com/mapbox/tilelive/blob/master/API.md) for more info. Currently, carmen supports the following tilelive modules:
 
@@ -135,7 +135,7 @@ Type: [function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 ### MemSource
 
-[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
+[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
 
 An in-memory tilelive source/sink. Used primarily for testing purposes when instantiating a geocoder. Satisfies API constraints documented [here](https://github.com/mapbox/tilelive/blob/master/API.md). If there are three arguments:
 
@@ -147,7 +147,7 @@ An in-memory tilelive source/sink. Used primarily for testing purposes when inst
 
 ### MemSource
 
-[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
+[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
 
 (See above). If there are two arguments:
 
@@ -159,7 +159,7 @@ An in-memory tilelive source/sink. Used primarily for testing purposes when inst
 
 ### PatternReplaceMap
 
-[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
+[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
 
 A mapping from patterns (keys) to replacements (values).
 
@@ -192,7 +192,7 @@ Functions in use when querying indexes. Most commonly used in a production setti
 
 ### geocode
 
-[lib/geocoder/geocode.js:41-161](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/geocode.js#L41-L161 "Source code on GitHub")
+[lib/geocoder/geocode.js:41-161](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/geocoder/geocode.js#L41-L161 "Source code on GitHub")
 
 Main interface for querying an index and returning ranked results.
 
@@ -213,12 +213,12 @@ Main interface for querying an index and returning ranked results.
     -   `options.indexes` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, indexes will be returned as part of the results. (optional, default `false`)
     -   `options.autocomplete` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, indexes will be returned as part of the results. (optional, default `true`)
     -   `options.reverseMode` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built (optional, default `'distance'`)
-    -   `options.routingMode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, routable_points_found will be returned as part of the results, and optionally routable_points. (optional, default `true`)
+    -   `options.routingMode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, routable_points will be returned as part of the results. Currently only forward geocoding of addresses are supported. (optional, default `false`)
 -   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** a callback function
 
 ### phrasematch
 
-[lib/geocoder/phrasematch.js:19-121](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/phrasematch.js#L19-L121 "Source code on GitHub")
+[lib/geocoder/phrasematch.js:19-121](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/geocoder/phrasematch.js#L19-L121 "Source code on GitHub")
 
 phrasematch
 
@@ -232,7 +232,7 @@ phrasematch
 
 ### spatialmatch
 
-[lib/geocoder/spatialmatch.js:27-124](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/spatialmatch.js#L27-L124 "Source code on GitHub")
+[lib/geocoder/spatialmatch.js:27-124](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/geocoder/spatialmatch.js#L27-L124 "Source code on GitHub")
 
 spatialmatch determines whether indexes can be spatially stacked and discards indexes that cannot be stacked together
 
@@ -245,7 +245,7 @@ spatialmatch determines whether indexes can be spatially stacked and discards in
 
 ### verifymatch
 
-[lib/geocoder/verifymatch.js:31-95](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/verifymatch.js#L31-L95 "Source code on GitHub")
+[lib/geocoder/verifymatch.js:31-94](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/geocoder/verifymatch.js#L31-L94 "Source code on GitHub")
 
 verifymatch - results from spatialmatch are now verified by querying real geometries in vector tiles
 
@@ -265,7 +265,7 @@ Functions dedicated toward building and manipulating indexes.
 
 ### index
 
-[lib/indexer/index.js:30-97](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/index.js#L30-L97 "Source code on GitHub")
+[lib/indexer/index.js:30-97](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/indexer/index.js#L30-L97 "Source code on GitHub")
 
 The main interface for building an index
 
@@ -282,7 +282,7 @@ The main interface for building an index
 
 ### analyze
 
-[lib/util/analyze.js:23-55](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/util/analyze.js#L23-L55 "Source code on GitHub")
+[lib/util/analyze.js:23-55](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/util/analyze.js#L23-L55 "Source code on GitHub")
 
 Generate summary statistics about a source. Used by `scripts/carmen-analyze.js`.
 
@@ -303,7 +303,7 @@ Returns **function ([object](https://developer.mozilla.org/docs/Web/JavaScript/R
 
 ### merge
 
-[lib/indexer/merge.js:223-445](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/merge.js#L223-L445 "Source code on GitHub")
+[lib/indexer/merge.js:223-445](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/indexer/merge.js#L223-L445 "Source code on GitHub")
 
 Merge two CarmenSources. The merge happens in three steps
 
@@ -343,7 +343,7 @@ TODO: document how dawg merge works
 
 ### multimerge
 
-[lib/indexer/merge.js:502-586](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/merge.js#L502-L586 "Source code on GitHub")
+[lib/indexer/merge.js:502-586](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/indexer/merge.js#L502-L586 "Source code on GitHub")
 
 Merge more than two CarmenSources. Used by `scripts/carmen-merge.js`. Only supports MBTile sources.
 
@@ -361,7 +361,7 @@ The various utility functions for preparing text while indexing and querying.
 
 ### ReplaceRule
 
-[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
+[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
 
 An individual pattern-based replacement configuration.
 
@@ -375,7 +375,7 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 ### createGlobalReplacer
 
-[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
+[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
 
 Create an array of [ReplaceRule](#replacerule)s from a [PatternReplaceMap](#patternreplacemap).
 
@@ -387,7 +387,7 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 ### createReplacer
 
-[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
+[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/e550b416f2dcd211ec7288333dc6431c8e10946e/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
 
 Create a per-token replacer
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,7 +37,7 @@ Central API elements, used in geocoding and indexing
 
 ### Geocoder
 
-[index.js:55-337](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L55-L337 "Source code on GitHub")
+[index.js:55-337](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L55-L337 "Source code on GitHub")
 
 Geocoder is an interface used to submit a single query to
 multiple indexes, returning a single set of ranked results.
@@ -51,7 +51,7 @@ multiple indexes, returning a single set of ranked results.
 
 #### Geocoder#geocode
 
-[index.js:424-430](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L424-L430 "Source code on GitHub")
+[index.js:424-430](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L424-L430 "Source code on GitHub")
 
 -   **See: [gecode](#geocode) for more details, including
     `options` properties.**
@@ -67,7 +67,7 @@ a given query.
 
 #### Geocoder#index
 
-[index.js:449-455](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L449-L455 "Source code on GitHub")
+[index.js:449-455](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L449-L455 "Source code on GitHub")
 
 -   **See: [index](#index) for more details, including `options` properties.**
 
@@ -85,7 +85,7 @@ Main entry point for indexing. Index a stream of GeoJSON docs.
 
 #### Geocoder#merge
 
-[index.js:471-477](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L471-L477 "Source code on GitHub")
+[index.js:471-477](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L471-L477 "Source code on GitHub")
 
 -   **See: [merge](#merge) for more details, including `options` properties.**
 
@@ -101,7 +101,7 @@ Merge two CarmenSources and output to a third.
 
 #### Geocoder#multimerge
 
-[index.js:492-498](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L492-L498 "Source code on GitHub")
+[index.js:492-498](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L492-L498 "Source code on GitHub")
 
 -   **See: [multimerge](#multimerge) for more details, including `options` properties.**
 
@@ -116,7 +116,7 @@ Merge more than two CarmenSources. Only supports MBTile sources.
 
 ### CarmenSource
 
-[index.js:55-337](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/index.js#L55-L337 "Source code on GitHub")
+[index.js:55-337](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/index.js#L55-L337 "Source code on GitHub")
 
 An interface to the underlying data that a [Geocoder](#geocoder) instance is indexing and querying. In addition to the properties described below, instances must satisfy interface requirements for `Tilesource` and `Tilesink`. See tilelive [API Docs](https://github.com/mapbox/tilelive/blob/master/API.md) for more info. Currently, carmen supports the following tilelive modules:
 
@@ -135,7 +135,7 @@ Type: [function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 ### MemSource
 
-[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
+[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
 
 An in-memory tilelive source/sink. Used primarily for testing purposes when instantiating a geocoder. Satisfies API constraints documented [here](https://github.com/mapbox/tilelive/blob/master/API.md). If there are three arguments:
 
@@ -147,7 +147,7 @@ An in-memory tilelive source/sink. Used primarily for testing purposes when inst
 
 ### MemSource
 
-[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
+[lib/sources/api-mem.js:27-47](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/sources/api-mem.js#L27-L47 "Source code on GitHub")
 
 (See above). If there are two arguments:
 
@@ -159,7 +159,7 @@ An in-memory tilelive source/sink. Used primarily for testing purposes when inst
 
 ### PatternReplaceMap
 
-[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
+[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
 
 A mapping from patterns (keys) to replacements (values).
 
@@ -192,7 +192,7 @@ Functions in use when querying indexes. Most commonly used in a production setti
 
 ### geocode
 
-[lib/geocoder/geocode.js:40-159](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/geocoder/geocode.js#L40-L159 "Source code on GitHub")
+[lib/geocoder/geocode.js:41-161](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/geocode.js#L41-L161 "Source code on GitHub")
 
 Main interface for querying an index and returning ranked results.
 
@@ -213,11 +213,12 @@ Main interface for querying an index and returning ranked results.
     -   `options.indexes` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, indexes will be returned as part of the results. (optional, default `false`)
     -   `options.autocomplete` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, indexes will be returned as part of the results. (optional, default `true`)
     -   `options.reverseMode` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built (optional, default `'distance'`)
+    -   `options.routingMode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** If true, routable_points_found will be returned as part of the results, and optionally routable_points. (optional, default `true`)
 -   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** a callback function
 
 ### phrasematch
 
-[lib/geocoder/phrasematch.js:19-121](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/geocoder/phrasematch.js#L19-L121 "Source code on GitHub")
+[lib/geocoder/phrasematch.js:19-121](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/phrasematch.js#L19-L121 "Source code on GitHub")
 
 phrasematch
 
@@ -231,7 +232,7 @@ phrasematch
 
 ### spatialmatch
 
-[lib/geocoder/spatialmatch.js:27-124](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/geocoder/spatialmatch.js#L27-L124 "Source code on GitHub")
+[lib/geocoder/spatialmatch.js:27-124](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/spatialmatch.js#L27-L124 "Source code on GitHub")
 
 spatialmatch determines whether indexes can be spatially stacked and discards indexes that cannot be stacked together
 
@@ -244,7 +245,7 @@ spatialmatch determines whether indexes can be spatially stacked and discards in
 
 ### verifymatch
 
-[lib/geocoder/verifymatch.js:30-94](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/geocoder/verifymatch.js#L30-L94 "Source code on GitHub")
+[lib/geocoder/verifymatch.js:31-95](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/geocoder/verifymatch.js#L31-L95 "Source code on GitHub")
 
 verifymatch - results from spatialmatch are now verified by querying real geometries in vector tiles
 
@@ -264,7 +265,7 @@ Functions dedicated toward building and manipulating indexes.
 
 ### index
 
-[lib/indexer/index.js:30-97](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/indexer/index.js#L30-L97 "Source code on GitHub")
+[lib/indexer/index.js:30-97](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/index.js#L30-L97 "Source code on GitHub")
 
 The main interface for building an index
 
@@ -281,7 +282,7 @@ The main interface for building an index
 
 ### analyze
 
-[lib/util/analyze.js:23-55](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/util/analyze.js#L23-L55 "Source code on GitHub")
+[lib/util/analyze.js:23-55](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/util/analyze.js#L23-L55 "Source code on GitHub")
 
 Generate summary statistics about a source. Used by `scripts/carmen-analyze.js`.
 
@@ -302,7 +303,7 @@ Returns **function ([object](https://developer.mozilla.org/docs/Web/JavaScript/R
 
 ### merge
 
-[lib/indexer/merge.js:223-445](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/indexer/merge.js#L223-L445 "Source code on GitHub")
+[lib/indexer/merge.js:223-445](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/merge.js#L223-L445 "Source code on GitHub")
 
 Merge two CarmenSources. The merge happens in three steps
 
@@ -342,7 +343,7 @@ TODO: document how dawg merge works
 
 ### multimerge
 
-[lib/indexer/merge.js:502-586](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/indexer/merge.js#L502-L586 "Source code on GitHub")
+[lib/indexer/merge.js:502-586](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/indexer/merge.js#L502-L586 "Source code on GitHub")
 
 Merge more than two CarmenSources. Used by `scripts/carmen-merge.js`. Only supports MBTile sources.
 
@@ -360,7 +361,7 @@ The various utility functions for preparing text while indexing and querying.
 
 ### ReplaceRule
 
-[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
+[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
 
 An individual pattern-based replacement configuration.
 
@@ -374,7 +375,7 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 ### createGlobalReplacer
 
-[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
+[lib/text-processing/token.js:260-275](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L260-L275 "Source code on GitHub")
 
 Create an array of [ReplaceRule](#replacerule)s from a [PatternReplaceMap](#patternreplacemap).
 
@@ -386,7 +387,7 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 ### createReplacer
 
-[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/6e04f0f895b4a37dc21d974e512bb20032e98fa6/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
+[lib/text-processing/token.js:31-137](https://github.com/mapbox/carmen/blob/925a167a1dd59df9a6c2a39e6b8748fe95aec2d8/lib/text-processing/token.js#L31-L137 "Source code on GitHub")
 
 Create a per-token replacer
 

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -35,7 +35,7 @@ const ops = require('./ops'),
  * @param {boolean} [options.indexes=false] - If true, indexes will be returned as part of the results.
  * @param {boolean} [options.autocomplete=true] - If true, indexes will be returned as part of the results.
  * @param {string} [options.reverseMode='distance'] - Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built
- * @param {boolean} [options.routingMode=true] - If true, routable_points will be returned as part of the results.
+ * @param {boolean} [options.routingMode=true] - If true, routable_points_found will be returned as part of the results, and optionally routable_points.
  * @param {function} callback - a callback function
  */
 module.exports = function(geocoder, query, options, callback) {

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -35,7 +35,7 @@ const ops = require('./ops'),
  * @param {boolean} [options.indexes=false] - If true, indexes will be returned as part of the results.
  * @param {boolean} [options.autocomplete=true] - If true, indexes will be returned as part of the results.
  * @param {string} [options.reverseMode='distance'] - Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built
- * @param {boolean} [options.routingMode=true] - If true, routable_points_found will be returned as part of the results, and optionally routable_points.
+ * @param {boolean} [options.routingMode=false] - If true, routable_points_found will be returned as part of the results, and optionally routable_points.
  * @param {function} callback - a callback function
  */
 module.exports = function(geocoder, query, options, callback) {

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -35,7 +35,7 @@ const ops = require('./ops'),
  * @param {boolean} [options.indexes=false] - If true, indexes will be returned as part of the results.
  * @param {boolean} [options.autocomplete=true] - If true, indexes will be returned as part of the results.
  * @param {string} [options.reverseMode='distance'] - Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built
- * @param {boolean} [options.routingMode=false] - If true, routable_points_found will be returned as part of the results, and optionally routable_points.
+ * @param {boolean} [options.routingMode=false] - If true, routable_points will be returned as part of the results. Currently only forward geocoding of addresses are supported.
  * @param {function} callback - a callback function
  */
 module.exports = function(geocoder, query, options, callback) {
@@ -211,7 +211,7 @@ function idGeocode(geocoder, asId, options, callback) {
 *
 * @param {Object} geocoder - instance of the geocoder
 * @param {Object} tokenized - tokenized version of the query
-* @aparm {Object} options - options sent along with the query by the user
+* @param {Object} options - options sent along with the query by the user
 *
 */
 function reverseGeocode(geocoder, tokenized, options, callback) {

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -35,6 +35,7 @@ const ops = require('./ops'),
  * @param {boolean} [options.indexes=false] - If true, indexes will be returned as part of the results.
  * @param {boolean} [options.autocomplete=true] - If true, indexes will be returned as part of the results.
  * @param {string} [options.reverseMode='distance'] - Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built
+ * @param {boolean} [options.routingMode=true] - If true, routable_points will be returned as part of the results.
  * @param {function} callback - a callback function
  */
 module.exports = function(geocoder, query, options, callback) {
@@ -49,6 +50,7 @@ module.exports = function(geocoder, query, options, callback) {
     options.autocomplete = options.autocomplete === undefined ? true : options.autocomplete;
     options.bbox = options.bbox || false;
     options.reverseMode = options.reverseMode || 'distance';
+    options.routingMode = options.routingMode || false;
 
     // Limit query length
     if (query.length > constants.MAX_QUERY_CHARS) {
@@ -464,7 +466,7 @@ function toFeatures(geocoder, contexts, options) {
         if (!filter.featureAllowed(index, context[0], options)) continue;
 
         // Convert this context array to a feature
-        features.push(ops.toFeature(context, index.geocoder_format, options.language, options.languageMode, options.debug, geocoder, options.clipBBox));
+        features.push(ops.toFeature(context, index.geocoder_format, options.language, options.languageMode, options.debug, geocoder, options.clipBBox, options.routingMode));
 
         // Record index usage for this feature
         if (options.indexes) for (let k = 0; k < context.length; k++) {

--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -136,7 +136,6 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
     if (feat.matching_text) feature.matching_text = feat.matching_text;
     if (feat.matching_language) feature.matching_language = feat.matching_language;
     if (feat.routable_points && routingMode) feature.routable_points = feat.routable_points;
-    if (routingMode) feature.routable_points_found = feat.routable_points ? true : false;
 
     languages.reduce((memo, language, i) => {
         const suffix = language ? `_${language}` : '';

--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -136,6 +136,7 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
     if (feat.matching_text) feature.matching_text = feat.matching_text;
     if (feat.matching_language) feature.matching_language = feat.matching_language;
     if (feat.routable_points && routingMode) feature.routable_points = feat.routable_points;
+    if (routingMode) feature.routable_points_found = feat.routable_points ? true : false;
 
     languages.reduce((memo, language, i) => {
         const suffix = language ? `_${language}` : '';

--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -114,9 +114,12 @@ function getPlaceName(context, formatString, language, languageMode, matched) {
  * @param {String} language code to select language/formatting from context array. Undefined defaults to `carmen:text`
  * @param {String} languageMode option that can be set to 'strict' filter resutlts strictly to a specific language. Undefined defaults null.
  * @param {Boolean} debug Enable debug mode to expose internal properties in results
+ * @param {Object} geocoder Geocoder object
+ * @param {boolean} clipBBox Whether or not to clip BBox
+ * @param {boolean} routingMode Whether or not geocoding request was made for routing
  * @return {Object} Carmen GeoJSON feature
  */
-function toFeature(context, format, languages, languageMode, debug, geocoder, clipBBox) {
+function toFeature(context, format, languages, languageMode, debug, geocoder, clipBBox, routingMode) {
     const feat = context[0];
     if (!feat.properties['carmen:center']) throw new Error('Feature has no carmen:center');
     if (!feat.properties['carmen:extid'])  throw new Error('Feature has no carmen:extid');
@@ -132,7 +135,7 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
     };
     if (feat.matching_text) feature.matching_text = feat.matching_text;
     if (feat.matching_language) feature.matching_language = feat.matching_language;
-    if (feat.routable_points) feature.routable_points = feat.routable_points;
+    if (feat.routable_points && routingMode) feature.routable_points = feat.routable_points;
 
     languages.reduce((memo, language, i) => {
         const suffix = language ? `_${language}` : '';

--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -135,7 +135,7 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
     };
     if (feat.matching_text) feature.matching_text = feat.matching_text;
     if (feat.matching_language) feature.matching_language = feat.matching_language;
-    if (feat.routable_points && routingMode) feature.routable_points = feat.routable_points;
+    if (routingMode) feature.routable_points = feat.routable_points || { points: null };
 
     languages.reduce((memo, language, i) => {
         const suffix = language ? `_${language}` : '';

--- a/lib/geocoder/routablepoint.js
+++ b/lib/geocoder/routablepoint.js
@@ -1,7 +1,7 @@
 'use strict';
 const nearestPointOnLine = require('@turf/nearest-point-on-line');
 
-module.exports = routablePoint;
+module.exports = routablePoints;
 
 // TODO: get this from a config instead?
 const ALLOWED_TYPES = new Set();
@@ -15,29 +15,45 @@ ALLOWED_TYPES.add('address');
  * @param {!Object} feature Address feature with GeometryCollection of MultiPoint and LineStrings
  * @return {Array|null} Lon,lat coordinate array of the routable point
  */
-function routablePoint(point, feature) {
+function routablePoints(point, feature) {
+    const routPoints = {
+        found: false,
+        supported_type: false,
+        points: null
+    };
 
     // TODO: Should this accept both arrays and objects?
-    if (!Object.keys(point).length || !feature || !Object.keys(feature).length) {
+    if (!point || !Object.keys(point).length || !feature || !Object.keys(feature).length) {
         return null;
     }
 
     // Skip if routable_points is not already set, and the addressPoint isn't interpolated
     // TODO: Revisit what routable_points already being set will actually look like.
     // For now this assumes it's in properties['carmen:routable_points'] to signify that it was added at index time
-    // This is also redundant for now, since we're checking before we even call routablePoint
+    // This is also redundant for now, since we're checking before we even call routablePoints
     if (feature.properties['carmen:routable_points']) {
-        return null;
+        return {
+            found: true,
+            supported_type: true, // TODO is there ever a case where this wouldnt be true? We haven't checked for allowed types yet, but if there are existing routable_points, does that mean this feature's type is supported?
+            points: feature.properties['carmen:routable_points']
+        };
     }
 
     // If the point is interpolated, return the existing point coordinates
     if (point.interpolated) {
-        return point.coordinates;
+        return {
+            found: true,
+            supported_type: true,
+            points: [{ coordinates: point.coordinates }]
+        };
     }
 
-    // Check if feature is an address
+    // Check if feature is an allowed type
     if (!_isAllowedType(feature)) {
-        return null;
+        // Return initialized routPoint with all false/null values
+        return routPoints;
+    } else {
+        routPoints.supported_type = true;
     }
 
     // Get LineString from feature geometry
@@ -46,7 +62,9 @@ function routablePoint(point, feature) {
     const nearestPoint = featureLineString ? nearestPointOnLine(featureLineString, point) : null;
 
     if (!nearestPoint) {
-        return null;
+        return routPoints;
+    } else {
+        routPoints.found = true;
     }
 
     // Round coordinates to 6 decimal places
@@ -54,7 +72,9 @@ function routablePoint(point, feature) {
         (coord) => Math.round(coord * Math.pow(10, 6)) / Math.pow(10, 6)
     );
 
-    return nearestPointCoords;
+    routPoints.points = [{ coordinates: nearestPointCoords }];
+
+    return routPoints;
 }
 
 

--- a/lib/geocoder/routablepoint.js
+++ b/lib/geocoder/routablepoint.js
@@ -3,9 +3,6 @@ const nearestPointOnLine = require('@turf/nearest-point-on-line');
 
 module.exports = routablePoints;
 
-// TODO: get this from a config instead?
-const ALLOWED_TYPES = new Set();
-ALLOWED_TYPES.add('address');
 
 /**
  * Takes a point of origin and a feature, and returns the nearest point
@@ -16,13 +13,10 @@ ALLOWED_TYPES.add('address');
  * @return {Array|null} Lon,lat coordinate array of the routable point
  */
 function routablePoints(point, feature) {
-    const routPoints = {
-        found: false,
-        supported_type: false,
+    const defaultResult = {
         points: null
     };
 
-    // TODO: Should this accept both arrays and objects?
     if (!point || !Object.keys(point).length || !feature || !Object.keys(feature).length) {
         return null;
     }
@@ -30,11 +24,8 @@ function routablePoints(point, feature) {
     // Skip if routable_points is not already set, and the addressPoint isn't interpolated
     // TODO: Revisit what routable_points already being set will actually look like.
     // For now this assumes it's in properties['carmen:routable_points'] to signify that it was added at index time
-    // This is also redundant for now, since we're checking before we even call routablePoints
     if (feature.properties['carmen:routable_points']) {
         return {
-            found: true,
-            supported_type: true, // TODO is there ever a case where this wouldnt be true? We haven't checked for allowed types yet, but if there are existing routable_points, does that mean this feature's type is supported?
             points: feature.properties['carmen:routable_points']
         };
     }
@@ -42,29 +33,18 @@ function routablePoints(point, feature) {
     // If the point is interpolated, return the existing point coordinates
     if (point.interpolated) {
         return {
-            found: true,
-            supported_type: true,
             points: [{ coordinates: point.coordinates }]
         };
-    }
-
-    // Check if feature is an allowed type
-    if (!_isAllowedType(feature)) {
-        // Return initialized routPoint with all false/null values
-        return routPoints;
-    } else {
-        routPoints.supported_type = true;
     }
 
     // Get LineString from feature geometry
     const featureLineString = _findLineString(feature);
 
+
     const nearestPoint = featureLineString ? nearestPointOnLine(featureLineString, point) : null;
 
     if (!nearestPoint) {
-        return routPoints;
-    } else {
-        routPoints.found = true;
+        return defaultResult;
     }
 
     // Round coordinates to 6 decimal places
@@ -72,9 +52,9 @@ function routablePoints(point, feature) {
         (coord) => Math.round(coord * Math.pow(10, 6)) / Math.pow(10, 6)
     );
 
-    routPoints.points = [{ coordinates: nearestPointCoords }];
-
-    return routPoints;
+    return {
+        points: [{ coordinates: nearestPointCoords }]
+    };
 }
 
 
@@ -103,17 +83,3 @@ function _findLineString(feature) {
     }
 }
 
-/**
- * Checks if at least one of the feature types is in the allowed types for routable points
- *
- * @param {Object} feature GeoJSON feature
- * @return {bool} whether the feature is of an allowed type
- */
-function _isAllowedType(feature) {
-    if (!feature.properties['carmen:types']) {
-        return false;
-    }
-    if (feature.properties['carmen:types'].find((type) => ALLOWED_TYPES.has(type))) {
-        return true;
-    }
-}

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -142,12 +142,14 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                 if (addressPoints.length) {
                     const newFeats = addressPoints.slice(0,10).map((addressPoint) => {
                         const feat = JSON.parse(JSON.stringify(feats[0]));
-                        const routPoint = routablePoint(addressPoint, feat);
-                        if (routPoint) {
-                            // For now, return nearestPointCoords as an object in an array
-                            // to support multiple routable points, with other meta info
-                            // TODO: eventually figure out how to identify and add multiple routable points.
-                            feat.routable_points = [{ coordinates: routPoint }];
+                        if (options.routingMode) {
+                            const routPoint = routablePoint(addressPoint, feat);
+                            if (routPoint) {
+                                // For now, return nearestPointCoords as an object in an array
+                                // to support multiple routable points, with other meta info
+                                // TODO: eventually figure out how to identify and add multiple routable points.
+                                feat.routable_points = [{ coordinates: routPoint }];
+                            }
                         }
                         feat.geometry = addressPoint;
                         feat.properties['carmen:center'] = feat.geometry && feat.geometry.coordinates;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -10,7 +10,7 @@ const closestLang = require('../text-processing/closest-lang');
 const bbox = require('../util/bbox');
 const filter = require('./filter-sources');
 const constants = require('../constants');
-const routablePoint = require('./routablepoint');
+const routablePoints = require('./routablepoint');
 
 module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
@@ -89,7 +89,6 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         }
         // Limit verify results before loading contexts
         verified = verified.slice(0, options.limit_verify);
-
         loadContexts(geocoder, verified, sets, options, callback);
     }
 }
@@ -143,12 +142,12 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                     const newFeats = addressPoints.slice(0,10).map((addressPoint) => {
                         const feat = JSON.parse(JSON.stringify(feats[0]));
                         if (options.routingMode) {
-                            const routPoint = routablePoint(addressPoint, feat);
-                            if (routPoint) {
+                            const routPoints = routablePoints(addressPoint, feat);
+                            if (routPoints) {
                                 // For now, return nearestPointCoords as an object in an array
                                 // to support multiple routable points, with other meta info
                                 // TODO: eventually figure out how to identify and add multiple routable points.
-                                feat.routable_points = [{ coordinates: routPoint }];
+                                feat.routable_points = routPoints;
                             }
                         }
                         feat.geometry = addressPoint;
@@ -164,6 +163,11 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             } else {
                 feats[0].properties['carmen:address'] = null;
             }
+        } else if (options.routingMode) {
+            feats.forEach((feat) => {
+                const routPoints = routablePoints(feat.properties['carmen:center'], feat);
+                feat.routable_points = routPoints;
+            });
         }
 
         for (const feat of feats) {

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -47,10 +47,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for non-interpolated address and return routable points', (t) => {
         c.geocode('9 fake street', { debug: true, routingMode: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points_found,
+            t.deepEquals(res.features[0].routable_points.found,
                 true,
-                'Forward geocode of non-interpolated address sets the routable_points_found flag to true');
-            t.deepEquals(res.features[0].routable_points,
+                'Forward geocode of non-interpolated address sets the routable_points.found flag to true');
+            t.deepEquals(res.features[0].routable_points.points,
                 [{ coordinates: [1.111, 1.11] }],
                 'Forward geocode of non-interpolated address result has correct routable_point');
             t.end();
@@ -60,13 +60,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Geocode for non-interpolated address without routingMode', (t) => {
         c.geocode('9 fake street', {}, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points_found,
-                undefined,
-                'Forward geocode witout routingMode: true does not set routable_points_found flag'
-            );
             t.deepEquals(res.features[0].routable_points,
                 undefined,
-                'Forward geocode without routingMode: true does not return routable_points');
+                'Forward geocode witout routingMode: true does not set routable_points on response'
+            );
             t.end();
         });
     });
@@ -113,11 +110,11 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for interpolated address', (t) => {
         c.geocode('150 Main Street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points_found,
+            t.deepEquals(res.features[0].routable_points.found,
                 true,
-                'Forward geocode of interpolated address result should set routable_points_found to true'
+                'Forward geocode of interpolated address result should set routable_points.found to true'
             );
-            t.deepEquals(res.features[0].routable_points,
+            t.deepEquals(res.features[0].routable_points.points,
                 [{ coordinates: res.features[0].geometry.coordinates }],
                 'Forward geocode of interpolated address result should return existing coordinates'
             );
@@ -152,12 +149,12 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for address with no LineString data', (t) => {
         c.geocode('9 fake street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points_found,
+            t.deepEquals(res.features[0].routable_points.found,
                 false,
-                'Forward geocode of address with no LineString data sets routable_points_found to false'
+                'Forward geocode of address with no LineString data sets routable_points.found to false'
             );
-            t.deepEquals(res.features[0].routable_points,
-                undefined,
+            t.deepEquals(res.features[0].routable_points.points,
+                null,
                 'Forward geocode of address with no LineString data returns no routable_points');
             t.end();
         });
@@ -197,16 +194,31 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         queueFeature(conf.poi, poi, () => { buildQueued(conf.poi, t.end); });
     });
 
-    tape('Forward search for POI', (t) => {
-        c.geocode('Oakland International Airport', { routingMode: true, debug: true, full: true }, (err, res) => {
+    tape('Forward search for POI with routingMode', (t) => {
+        c.geocode('Oakland International Airport', { routingMode: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points_found,
+            t.deepEquals(res.features[0].routable_points.found,
                 false,
-                'Forward search for POI in routingMode sets routable_points_found to false'
+                'Forward search for POI in routingMode sets routable_points.found to false'
             );
+            t.deepEquals(res.features[0].routable_points.supported_type,
+                false,
+                'Forward search for POI in routingMode sets routable_points.supported_type to false'
+            );
+            t.deepEquals(res.features[0].routable_points.points,
+                null,
+                'Forward search for POI returns found: false, supported_type: false, and points: null'
+            );
+            t.end();
+        });
+    });
+
+    tape('Forward search for POI without routingMode', (t) => {
+        c.geocode('Oakland International Airport', {}, (err, res) => {
+            t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 undefined,
-                'Forward search for POI returns no routable_points'
+                'Forward search for POI without routingMode does not return routable_points'
             );
             t.end();
         });

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -2,6 +2,7 @@
 'use strict';
 const tape = require('tape');
 const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
 const mem = require('../../lib/sources/api-mem');
 const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
@@ -66,6 +67,11 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.end();
         });
     });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 
@@ -116,6 +122,11 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.end();
         });
     });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 
@@ -149,6 +160,11 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'Forward geocode of address with no LineString data returns no routable_points');
             t.end();
         });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
     });
 
 })();
@@ -205,6 +221,11 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             );
             t.end();
         });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
     });
 })();
 
@@ -269,7 +290,12 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             );
             t.end();
         });
-    })
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
 
 // Test where limit is > 1, all address features should have routable_points
@@ -347,22 +373,31 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
     tape('build address index', (t) => {
         buildQueued(conf.address, t.end);
-    })
+    });
 
     tape('Forward search for address with multiple results', (t) => {
         c.geocode('9 fake street', { routingMode: true, types: ['address'], limit: 5, allow_dupes: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(
                 res.features[0].routable_points,
-                { points: [{ coordinates: [1.111, 1.11] }]},
+                { points: [{ coordinates: [1.111, 1.11] }] },
                 'First address should have correct routable points'
             );
             t.deepEquals(
                 res.features[1].routable_points,
-                { points: [{ coordinates: [2.111, 2.11] }]},
+                { points: [{ coordinates: [2.111, 2.11] }] },
                 'Second address should have correct routable points'
             );
-            t.end(); 
+            t.end();
         });
     });
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
 })();
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -47,6 +47,9 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for non-interpolated address and return routable points', (t) => {
         c.geocode('9 fake street', { debug: true, routingMode: true }, (err, res) => {
             t.ifError(err);
+            t.deepEquals(res.features[0].routable_points_found,
+                true,
+                'Forward geocode of non-interpolated address sets the routable_points_found flag to true');
             t.deepEquals(res.features[0].routable_points,
                 [{ coordinates: [1.111, 1.11] }],
                 'Forward geocode of non-interpolated address result has correct routable_point');
@@ -57,6 +60,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Geocode for non-interpolated address without routingMode', (t) => {
         c.geocode('9 fake street', {}, (err, res) => {
             t.ifError(err);
+            t.deepEquals(res.features[0].routable_points_found,
+                undefined,
+                'Forward geocode witout routingMode: true does not set routable_points_found flag'
+            );
             t.deepEquals(res.features[0].routable_points,
                 undefined,
                 'Forward geocode without routingMode: true does not return routable_points');
@@ -106,9 +113,14 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for interpolated address', (t) => {
         c.geocode('150 Main Street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
+            t.deepEquals(res.features[0].routable_points_found,
+                true,
+                'Forward geocode of interpolated address result should set routable_points_found to true'
+            );
             t.deepEquals(res.features[0].routable_points,
                 [{ coordinates: res.features[0].geometry.coordinates }],
-                'Forward geocode of interpolated address result should return existing coordinates');
+                'Forward geocode of interpolated address result should return existing coordinates'
+            );
             t.end();
         });
     });
@@ -140,6 +152,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for address with no LineString data', (t) => {
         c.geocode('9 fake street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
+            t.deepEquals(res.features[0].routable_points_found,
+                false,
+                'Forward geocode of address with no LineString data sets routable_points_found to false'
+            );
             t.deepEquals(res.features[0].routable_points,
                 undefined,
                 'Forward geocode of address with no LineString data returns no routable_points');
@@ -151,7 +167,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
 
 // Test POI
-(()=> {
+(() => {
     const conf = {
         poi : new mem({ maxzoom: 6 }, () => {})
     };
@@ -184,6 +200,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for POI', (t) => {
         c.geocode('Oakland International Airport', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
+            t.deepEquals(res.features[0].routable_points_found,
+                false,
+                'Forward search for POI in routingMode sets routable_points_found to false'
+            );
             t.deepEquals(res.features[0].routable_points,
                 undefined,
                 'Forward search for POI returns no routable_points'

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -45,7 +45,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('Forward search for non-interpolated address and return routable points', (t) => {
-        c.geocode('9 fake street', { debug: true, full: true, routingMode: true }, (err, res) => {
+        c.geocode('9 fake street', { debug: true, routingMode: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 [{ coordinates: [1.111, 1.11] }],
@@ -54,15 +54,15 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         });
     });
 
-    tape('Geocode for non-interpolated address without routingMode', ((t) => {
+    tape('Geocode for non-interpolated address without routingMode', (t) => {
         c.geocode('9 fake street', {}, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
-            undefined,
-            'Forward geocode without routingMode: true does not return routable_points');
-            t.end()
+                undefined,
+                'Forward geocode without routingMode: true does not return routable_points');
+            t.end();
         });
-    }))
+    });
 })();
 
 

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -207,3 +207,67 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         });
     });
 })();
+
+
+// Test reverse geocoding
+(() => {
+    const conf = {
+        address: new mem({ maxzoom: 6,  geocoder_address:1, geocoder_format: '{address._number} {address._name} {place._name}, {region._name} {postcode._name}, {country._name}' }, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index address', (t) => {
+        const address = {
+            id:1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0], // not used
+                'carmen:addressnumber': [null, ['9','11','13']],
+                'carmen:types': ['address']
+            },
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [
+                    {
+                        type: 'MultiLineString',
+                        coordinates: [
+                            [
+                                [1.111, 1.11],
+                                [1.112, 1.11],
+                                [1.114, 1.11],
+                                [1.115, 1.11]
+                            ]
+                        ]
+                    },
+                    {
+                        type: 'MultiPoint',
+                        coordinates: [[1.111, 1.111], [1.113, 1.111], [1.115, 1.111]]
+                    }
+                ]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+
+    tape('Reverse geocode with routingMode', (t) => {
+        c.geocode('1.111, 1.111', { routingMode: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+                {
+                    points: null
+                },
+                'Reverse geocode with routingMode sets routable_points.points to false'
+            );
+            t.end();
+        });
+    });
+    tape('Reverse geocode without routingMode', (t) => {
+        c.geocode('1.111, 1.111', {}, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+                undefined,
+                'Reverse geocode without routingMode does not set routable_points'
+            );
+            t.end();
+        });
+    })
+})();

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -45,7 +45,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('Forward search for non-interpolated address and return routable points', (t) => {
-        c.geocode('9 fake street', { limit_verify: 1, debug: true, full: true }, (err, res) => {
+        c.geocode('9 fake street', { debug: true, full: true, routingMode: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 [{ coordinates: [1.111, 1.11] }],
@@ -53,6 +53,16 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.end();
         });
     });
+
+    tape('Geocode for non-interpolated address without routingMode', ((t) => {
+        c.geocode('9 fake street', {}, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+            undefined,
+            'Forward geocode without routingMode: true does not return routable_points');
+            t.end()
+        });
+    }))
 })();
 
 
@@ -94,7 +104,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('Forward search for interpolated address', (t) => {
-        c.geocode('150 Main Street', { debug: true, full: true }, (err, res) => {
+        c.geocode('150 Main Street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 [{ coordinates: res.features[0].geometry.coordinates }],
@@ -128,7 +138,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('Forward search for address with no LineString data', (t) => {
-        c.geocode('9 fake street', { debug: true, full: true }, (err, res) => {
+        c.geocode('9 fake street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 undefined,
@@ -172,7 +182,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('Forward search for POI', (t) => {
-        c.geocode('Oakland International Airport', { debug: true, full: true }, (err, res) => {
+        c.geocode('Oakland International Airport', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 undefined,

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -47,11 +47,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for non-interpolated address and return routable points', (t) => {
         c.geocode('9 fake street', { debug: true, routingMode: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points.found,
-                true,
-                'Forward geocode of non-interpolated address sets the routable_points.found flag to true');
-            t.deepEquals(res.features[0].routable_points.points,
-                [{ coordinates: [1.111, 1.11] }],
+            t.deepEquals(res.features[0].routable_points,
+                {
+                    points: [{ coordinates: [1.111, 1.11] }]
+                },
                 'Forward geocode of non-interpolated address result has correct routable_point');
             t.end();
         });
@@ -62,7 +61,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 undefined,
-                'Forward geocode witout routingMode: true does not set routable_points on response'
+                'Forward geocode without routingMode: true does not set routable_points on response'
             );
             t.end();
         });
@@ -110,10 +109,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for interpolated address', (t) => {
         c.geocode('150 Main Street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points.found,
-                true,
-                'Forward geocode of interpolated address result should set routable_points.found to true'
-            );
             t.deepEquals(res.features[0].routable_points.points,
                 [{ coordinates: res.features[0].geometry.coordinates }],
                 'Forward geocode of interpolated address result should return existing coordinates'
@@ -149,10 +144,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for address with no LineString data', (t) => {
         c.geocode('9 fake street', { routingMode: true, debug: true, full: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points.found,
-                false,
-                'Forward geocode of address with no LineString data sets routable_points.found to false'
-            );
             t.deepEquals(res.features[0].routable_points.points,
                 null,
                 'Forward geocode of address with no LineString data returns no routable_points');
@@ -197,14 +188,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('Forward search for POI with routingMode', (t) => {
         c.geocode('Oakland International Airport', { routingMode: true }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res.features[0].routable_points.found,
-                false,
-                'Forward search for POI in routingMode sets routable_points.found to false'
-            );
-            t.deepEquals(res.features[0].routable_points.supported_type,
-                false,
-                'Forward search for POI in routingMode sets routable_points.supported_type to false'
-            );
             t.deepEquals(res.features[0].routable_points.points,
                 null,
                 'Forward search for POI returns found: false, supported_type: false, and points: null'
@@ -224,4 +207,3 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         });
     });
 })();
-

--- a/test/unit/geocoder/routablepoint.test.js
+++ b/test/unit/geocoder/routablepoint.test.js
@@ -47,8 +47,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.113, 1.111], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.113, 1.11] }]
             },
             'Actual address point on feature with interpolation linestring should find routable points'
@@ -66,8 +64,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.111, 1.11], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.111, 1.11] }]
             },
             'Point that is already on linestring should return itself'
@@ -87,8 +83,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.113, 1.115], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.113, 1.11] }]
             },
             'Point in between linestring coords should return midpoint between coords on linestring'
@@ -108,8 +102,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.115, 1.115], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.115, 1.11] }]
             },
             'Point not in the linestring should find routable point'
@@ -165,8 +157,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.116, 1.113], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.1168, 1.1114] }]
             },
             'Point should be projected onto the diagonal linestring'
@@ -223,8 +213,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.1115, 1.1115], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.111, 1.1115] }]
             },
             'Point projected to left side of the cul de sac line'
@@ -245,8 +233,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.1118, 1.1115], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.112, 1.1115] }]
             },
             'point projected to the closer side of the cul de sac line'
@@ -268,8 +254,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([1.1118, 1.1112], feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1.112, 1.1112] }]
             },
             'point projected to the side of the cul de sac line it is closest to'
@@ -317,19 +301,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         }
     };
 
-    const featureNoTypes = {
-        type: 'Feature',
-        properties: {},
-        geometry: {
-            type: 'GeometryCollection',
-            geometries: [
-                {
-                    type: 'LineString',
-                    coordinates: [[1, 1.11], [1, 1.13]]
-                }
-            ]
-        }
-    };
 
     const featureNoLinestring = {
         type: 'Feature',
@@ -422,7 +393,7 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         );
         assert.ok(
             routablePoints([0, 0], feature),
-            '[0,0] should not necessarily return null'
+            '[0,0] should not necessarily return points: null'
         );
         assert.end();
     });
@@ -431,45 +402,30 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints(pointObject),
             null, // TODO should this return the whole routable_points object?
-            'Missing feature input should return null'
+            'Missing feature input should return points: null'
         );
         assert.deepEquals(
             routablePoints(pointObject, {}),
             null, // TODO should this return the whole routable_points object?
-            'Empty feature input should return null'
-        );
-        assert.deepEquals(
-            routablePoints(pointObject, featureNoTypes),
-            {
-                found: false,
-                supported_type: false,
-                points: null // TODO null or []?
-            },
-            'Features with no types specified should return supported_type false and routable_points null'
+            'Empty feature input should return points: null'
         );
         assert.deepEquals(
             routablePoints(pointObject, featureNoGeometry),
             {
-                found: false,
-                supported_type: true,
                 points: null
             },
-            'Features with no geometry should return null'
+            'Features with no geometry should return points: null'
         );
         assert.deepEquals(
             routablePoints(pointObject, featureNoLinestring),
             {
-                found: false,
-                supported_type: true,
                 points: null
             },
-            'Features with no linestrings should return null'
+            'Features with no linestrings should return points: null'
         );
         assert.deepEqual(
             routablePoints(pointObject, featureLineString),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1, 1.11] }]
             },
             'Features with LineStrings, instead of MultiLineStrings, should also work'
@@ -477,8 +433,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints(pointObject, featureSingleGeomLineString),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1, 1.11] }]
             },
             'Features with single geometry, instead of geometry collections, with LineString, should work'
@@ -486,8 +440,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints(pointObject, featureSingleGeomMultiLineString),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [1, 1.11] }]
             },
             'Features with single geometry, instead of geometry collections, with MultiLineString, should work'
@@ -541,8 +493,6 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints(pointInterpolated, feature),
             {
-                found: true,
-                supported_type: true,
                 points: [{ coordinates: [-97.2, 37.3] }]
             },
             'Interpolated point inputs should return routable_point response with original coordinates as points'
@@ -552,10 +502,8 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
 })();
 
 // Test feature that already has routable_points
-// This is slightly redundant since it would also return null because this feature is a POI,
-// but the realistic case is that routable_points will only be added for POIs
 (() => {
-    const featureroutablePointss = {
+    const featureroutablePoints = {
         id: 6666777777982370,
         type: 'Feature',
         properties: {
@@ -584,11 +532,9 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
     // and the expected result of routablePoints if so.
     tape('routablePoints input validation: feature containing routable_points', (assert) => {
         assert.deepEquals(
-            routablePoints([-122, 37], featureroutablePointss),
+            routablePoints([-122, 37], featureroutablePoints),
             {
-                found: true,
-                supported_type: true, // TODO: confirm assumption
-                points: featureroutablePointss.properties['carmen:routable_points']
+                points: featureroutablePoints.properties['carmen:routable_points']
             },
             'features that already have routable_points should return existing routable points'
         );
@@ -628,11 +574,9 @@ tape('routablePoints input validation: POI feature', (assert) => {
         routablePoints(
             feature.properties['carmen:center'], feature),
         {
-            found: false,
-            supported_type: false,
-            points: null // TODO null or []?
+            points: null
         },
-        'non-addresses should return supported_type false, and no routable points'
+        'non-addresses should return null routable points'
     );
     assert.end();
 });

--- a/test/unit/geocoder/routablepoint.test.js
+++ b/test/unit/geocoder/routablepoint.test.js
@@ -1,11 +1,11 @@
 'use strict';
 const tape = require('tape');
-const routablePoint = require('../../../lib/geocoder/routablepoint.js');
+const routablePoints = require('../../../lib/geocoder/routablepoint.js');
 
 
 // straight line
 (() => {
-    const testPrefix = 'routablePoint on straight line: ';
+    const testPrefix = 'routablePoints address on straight line: ';
     const feature = {
         id: 1,
         type: 'Feature',
@@ -36,7 +36,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
         }
     };
 
-    tape(testPrefix + 'with actual feature point', (assert) => {
+    tape(testPrefix + 'with actual address point', (assert) => {
 
         /**
          * Example point (x) feature point coords (.) and linestring coords (-) looks like:
@@ -45,9 +45,13 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          * - - - - -
          */
         assert.deepEquals(
-            routablePoint([1.113, 1.111], feature),
-            [1.113, 1.11],
-            'Point that is same as input'
+            routablePoints([1.113, 1.111], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.113, 1.11] }]
+            },
+            'Actual address point on feature with interpolation linestring should find routable points'
         );
         assert.end();
     });
@@ -60,8 +64,12 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          * - - x - -
          */
         assert.deepEquals(
-            routablePoint([1.111, 1.11], feature),
-            [1.111, 1.11],
+            routablePoints([1.111, 1.11], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.111, 1.11] }]
+            },
             'Point that is already on linestring should return itself'
         );
         assert.end();
@@ -77,8 +85,12 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          * - -   - -
          */
         assert.deepEquals(
-            routablePoint([1.113, 1.115], feature),
-            [1.113, 1.11],
+            routablePoints([1.113, 1.115], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.113, 1.11] }]
+            },
             'Point in between linestring coords should return midpoint between coords on linestring'
         );
         assert.end();
@@ -94,9 +106,13 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          * - - - - - - -
          */
         assert.deepEquals(
-            routablePoint([1.115, 1.115], feature),
-            [1.115, 1.11],
-            'Point not in the linestring'
+            routablePoints([1.115, 1.115], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.115, 1.11] }]
+            },
+            'Point not in the linestring should find routable point'
         );
         assert.end();
     });
@@ -104,7 +120,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 
 // zigzag line
 (() => {
-    const testPrefix = 'routablePoint on ZigZag Line: ';
+    const testPrefix = 'routablePoints address on ZigZag Line: ';
     const feature = {
         type: 'Feature',
         properties: {
@@ -147,9 +163,13 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          */
 
         assert.deepEquals(
-            routablePoint([1.116, 1.113], feature),
-            [1.1168, 1.1114],
-            'point projected onto the diagonal'
+            routablePoints([1.116, 1.113], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.1168, 1.1114] }]
+            },
+            'Point should be projected onto the diagonal linestring'
         );
         assert.end();
     });
@@ -157,7 +177,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 
 // |_| cul de sac street
 (() => {
-    const testPrefix = 'routablePoint in cul de sac: ';
+    const testPrefix = 'routablePoints address in cul de sac: ';
     const feature = {
         type: 'Feature',
         properties: {
@@ -201,8 +221,12 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
         // in a case like this where either side of the cul de sac is equal distance from the point
         // expecting the projection to be on the side closest to the beginning of the line
         assert.deepEquals(
-            routablePoint([1.1115, 1.1115], feature),
-            [1.111, 1.1115],
+            routablePoints([1.1115, 1.1115], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.111, 1.1115] }]
+            },
             'Point projected to left side of the cul de sac line'
         );
         assert.end();
@@ -219,8 +243,12 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          */
 
         assert.deepEquals(
-            routablePoint([1.1118, 1.1115], feature),
-            [1.112, 1.1115],
+            routablePoints([1.1118, 1.1115], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.112, 1.1115] }]
+            },
             'point projected to the closer side of the cul de sac line'
         );
         assert.end();
@@ -238,8 +266,12 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
          */
 
         assert.deepEquals(
-            routablePoint([1.1118, 1.1112], feature),
-            [1.112, 1.1112],
+            routablePoints([1.1118, 1.1112], feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1.112, 1.1112] }]
+            },
             'point projected to the side of the cul de sac line it is closest to'
         );
         assert.end();
@@ -249,7 +281,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 
 // Input validation
 (()=> {
-    const testPrefix = 'routablePoint input validation: ';
+    const testPrefix = 'routablePoints input validation: ';
 
     const pointObject = {
         type: 'Point',
@@ -316,7 +348,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
     };
 
     // TODO: revisit if this test case is necessary. It's not valid GeoJSON without geometry,
-    // but there is a check for geometry in routablePoint anyway to avoid throwing an error on geometry.geometries
+    // but there is a check for geometry in routablePoints anyway to avoid throwing an error on geometry.geometries
     const featureNoGeometry = {
         type: 'Feature',
         properties: {
@@ -370,26 +402,26 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 
     tape(testPrefix + 'point inputs', (assert) => {
         assert.deepEquals(
-            routablePoint([], feature),
-            null,
+            routablePoints([], feature),
+            null, // TODO should this return the whole routable_points object?
             'Empty point arrays should return null'
         );
         assert.deepEquals(
-            routablePoint({}, feature),
-            null,
+            routablePoints({}, feature),
+            null, // TODO should this return the whole routable_points object?
             'Empty point objects should return null'
         );
         assert.ok(
-            routablePoint(pointObject, feature),
+            routablePoints(pointObject, feature),
             'Point objects should be accepted'
         );
 
         assert.ok(
-            routablePoint([1, 1], feature),
+            routablePoints([1, 1], feature),
             'Point arrays should be accepted'
         );
         assert.ok(
-            routablePoint([0, 0], feature),
+            routablePoints([0, 0], feature),
             '[0,0] should not necessarily return null'
         );
         assert.end();
@@ -397,43 +429,67 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 
     tape(testPrefix + 'feature inputs', (assert) => {
         assert.deepEquals(
-            routablePoint(pointObject),
-            null,
+            routablePoints(pointObject),
+            null, // TODO should this return the whole routable_points object?
             'Missing feature input should return null'
         );
         assert.deepEquals(
-            routablePoint(pointObject, {}),
-            null,
+            routablePoints(pointObject, {}),
+            null, // TODO should this return the whole routable_points object?
             'Empty feature input should return null'
         );
         assert.deepEquals(
-            routablePoint(pointObject, featureNoTypes),
-            null,
-            'Features with no types specified should return null'
+            routablePoints(pointObject, featureNoTypes),
+            {
+                found: false,
+                supported_type: false,
+                points: null // TODO null or []?
+            },
+            'Features with no types specified should return supported_type false and routable_points null'
         );
         assert.deepEquals(
-            routablePoint(pointObject, featureNoGeometry),
-            null,
+            routablePoints(pointObject, featureNoGeometry),
+            {
+                found: false,
+                supported_type: true,
+                points: null
+            },
             'Features with no geometry should return null'
         );
         assert.deepEquals(
-            routablePoint(pointObject, featureNoLinestring),
-            null,
+            routablePoints(pointObject, featureNoLinestring),
+            {
+                found: false,
+                supported_type: true,
+                points: null
+            },
             'Features with no linestrings should return null'
         );
         assert.deepEqual(
-            routablePoint(pointObject, featureLineString),
-            [1, 1.11],
+            routablePoints(pointObject, featureLineString),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1, 1.11] }]
+            },
             'Features with LineStrings, instead of MultiLineStrings, should also work'
         );
         assert.deepEquals(
-            routablePoint(pointObject, featureSingleGeomLineString),
-            [1, 1.11],
+            routablePoints(pointObject, featureSingleGeomLineString),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1, 1.11] }]
+            },
             'Features with single geometry, instead of geometry collections, with LineString, should work'
         );
         assert.deepEquals(
-            routablePoint(pointObject, featureSingleGeomMultiLineString),
-            [1, 1.11],
+            routablePoints(pointObject, featureSingleGeomMultiLineString),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [1, 1.11] }]
+            },
             'Features with single geometry, instead of geometry collections, with MultiLineString, should work'
         );
         assert.end();
@@ -481,11 +537,15 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
         coordinates: [-97.2, 37.3],
         interpolated: true
     };
-    tape('routablePoint input validation: interpolated point', (assert) => {
+    tape('routablePoints input validation: interpolated point', (assert) => {
         assert.deepEquals(
-            routablePoint(pointInterpolated, feature),
-            [-97.2, 37.3],
-            'Interpolated point inputs should return null'
+            routablePoints(pointInterpolated, feature),
+            {
+                found: true,
+                supported_type: true,
+                points: [{ coordinates: [-97.2, 37.3] }]
+            },
+            'Interpolated point inputs should return routable_point response with original coordinates as points'
         );
         assert.end();
     });
@@ -495,7 +555,7 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
 // This is slightly redundant since it would also return null because this feature is a POI,
 // but the realistic case is that routable_points will only be added for POIs
 (() => {
-    const featureRoutablePoints = {
+    const featureroutablePointss = {
         id: 6666777777982370,
         type: 'Feature',
         properties: {
@@ -521,19 +581,23 @@ const routablePoint = require('../../../lib/geocoder/routablepoint.js');
         }
     };
     // TODO: Confirm these assumpitons - Both what routable_points looks like on the feature,
-    // and the expected result of routablePoint if so.
-    tape('routablePoint input validation: feature containing routable_points', (assert) => {
+    // and the expected result of routablePoints if so.
+    tape('routablePoints input validation: feature containing routable_points', (assert) => {
         assert.deepEquals(
-            routablePoint([-122, 37], featureRoutablePoints),
-            null,
-            'features that already have routable_points should return null'
+            routablePoints([-122, 37], featureroutablePointss),
+            {
+                found: true,
+                supported_type: true, // TODO: confirm assumption
+                points: featureroutablePointss.properties['carmen:routable_points']
+            },
+            'features that already have routable_points should return existing routable points'
         );
         assert.end();
     });
 })();
 
-// Test routablePoint with POI
-tape('routablePoint input validation: POI feature', (assert) => {
+// Test routablePoints with POI
+tape('routablePoints input validation: POI feature', (assert) => {
     const feature = {
         id: 6666777777982370,
         type: 'Feature',
@@ -561,10 +625,14 @@ tape('routablePoint input validation: POI feature', (assert) => {
     };
 
     assert.deepEquals(
-        routablePoint(
+        routablePoints(
             feature.properties['carmen:center'], feature),
-        null,
-        'non-addresses should not return routable Points'
+        {
+            found: false,
+            supported_type: false,
+            points: null // TODO null or []?
+        },
+        'non-addresses should return supported_type false, and no routable points'
     );
     assert.end();
 });


### PR DESCRIPTION
### Context
The intention of this PR is to add an option to enable routable point functionality to release in beta without disturbing existing API users, and to make the response more explicit (return `null` for the points instead of returning nothing at all, if routable points are requested

### Summary of Changes
- [x] Adds routingMode option to geocode, and only returns routable_points if true
- [x] Update signature of response to allow for adding more info in the future
- [x] Update documention


### Next Steps
- [ ] Update api-geocoder to handle new option

cc @mapbox/geocoding-gang
