### PR TITLE
Combining diacritics

### DIFF
--- a/bin/carmen-index.js
+++ b/bin/carmen-index.js
@@ -12,7 +12,7 @@ argv = require('minimist')(process.argv, {
 const settings = require('../package.json');
 
 function help() {
-    console.log('carmen-copy.js --config=<path> --index=<path> [options]');
+    console.log('carmen-index.js --config=<path> --index=<path> [options]');
     console.log('[options]:');
     console.log('  --help                  Prints this message');
     console.log('  --version               Print the carmen version');

--- a/lib/text-processing/remove-diacritics.js
+++ b/lib/text-processing/remove-diacritics.js
@@ -32,7 +32,7 @@ const diaRegex = new RegExp('([' + Array.from(diaMap.keys()).map(unicodeEscape).
 const removeDiacritics = function(str) {
     return str.replace(diaRegex, (match) => {
         return diaMap.get(match) || match;
-    });
+    }).replace(/(\S)([\u0300-\u036F]+)/g, '$1');
 };
 
 module.exports = removeDiacritics;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "bin": {
     "carmen": "./bin/carmen.js",
     "carmen-analyze": "./bin/carmen-analyze.js",
-    "carmen-copy": "./bin/carmen-copy.js",
     "carmen-index": "./bin/carmen-index.js",
     "carmen-merge": "./bin/carmen-merge.js"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "main": "./index.js",
   "scripts": {
     "lint": "eslint index.js lib test scripts",
-    "test": "yarn run lint && (retire -n || echo 'WARNING: retire found insecure packages') && TESTING=true tape './test**/*.js' && yarn run bench",
+    "test": "yarn run lint && (retire -n || echo 'WARNING: retire found insecure packages') && TESTING=true tape './test/**/*.js' && yarn run bench",
     "coverage": "TESTING=true nyc tape 'test/**/*.js' && nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "bench": "./test/run_all_benchmarks.sh",
     "build-docs": " $(yarn bin)/documentation build --config docs/documentation.yml --access public --github --format md --output docs/api.md index.js lib/**"

--- a/test/acceptance/geocode-unit.unicode.test.js
+++ b/test/acceptance/geocode-unit.unicode.test.js
@@ -98,6 +98,12 @@ tape('москва => москва', (t) => {
         t.end();
     });
 });
+tape('Москва́ => москва', (t) => {
+    c.geocode('Москва́', { limit_verify:1 }, (err, res) => {
+        t.deepEqual(res.features[0].place_name, 'москва');
+        t.end();
+    });
+});
 tape('m => москва', (t) => {
     c.geocode('m', { limit_verify:1 }, (err, res) => {
         t.equal(res.features.length, 0, 'm (no results)');

--- a/test/unit/text-processing/diacritics.test.js
+++ b/test/unit/text-processing/diacritics.test.js
@@ -24,8 +24,8 @@ tape('removeDiacritics', (t) => {
     // (which can have weird tokenization results)
     t.assert(removeDiacritics('\u0300').length > 0, 'bare combining diacritics are left alone');
     t.assert(removeDiacritics('\u0300\u0311').length > 0, 'bare combining diacritics are left alone');
-    t.assert(removeDiacritics('asdf \u0300').split(' ').filter((t) => t.length > 0).length == 2, 'tokens consisting of bare combining diacritics are left alone');
-    t.assert(removeDiacritics('asdf \u0300\u0311').split(' ').filter((t) => t.length > 0).length == 2, 'tokens consisting of bare combining diacritics are left alone');
+    t.assert(removeDiacritics('asdf \u0300').split(' ').filter((t) => t.length > 0).length === 2, 'tokens consisting of bare combining diacritics are left alone');
+    t.assert(removeDiacritics('asdf \u0300\u0311').split(' ').filter((t) => t.length > 0).length === 2, 'tokens consisting of bare combining diacritics are left alone');
 
     t.end();
 });

--- a/test/unit/text-processing/diacritics.test.js
+++ b/test/unit/text-processing/diacritics.test.js
@@ -3,6 +3,7 @@ const tape = require('tape');
 const removeDiacritics = require('../../../lib/text-processing/remove-diacritics');
 
 tape('removeDiacritics', (t) => {
+    // precomosed diacritics
     t.equal(removeDiacritics('Hérê àrë søme wöřdš, including diacritics and puncatuation!'), 'Here are some words, including diacritics and puncatuation!', 'diacritics are removed from latin text');
     t.equal(removeDiacritics('Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)'), 'Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)', 'nothing happens to latin text with no diacritic marks');
     t.equal(removeDiacritics('堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》'), '堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》', 'nothing happens to Japanese text');
@@ -10,6 +11,21 @@ tape('removeDiacritics', (t) => {
     t.equal(removeDiacritics('άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ'), 'αΑεΕηΗιΙοΟυΥ αΑεΕηΗιΙοΟυΥ', 'greek diacritics are removed and other characters stay the same');
     t.equal(removeDiacritics('ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ'), 'уУеЕеЕгГиИ уУеЕеЕгГиИ', 'cyrillic diacritics are removed and other characters stay the same');
     t.equal(removeDiacritics('ي,ی ى'), 'ى,ى ى', 'arabic diacritics are removed and other characters stay the same');
+
+    // combining diacritics
+    t.equal(removeDiacritics('a\u0300'), 'a', 'diacritic removal from latin letter works');
+    t.equal(removeDiacritics('Москва́'), 'Москва', 'diacritic removal from Cyrillic works');
+    t.equal(removeDiacritics('asdf Москва́'), 'asdf Москва', 'diacritic removal from Cyrillic with mutliple words works');
+    t.equal(removeDiacritics('a\u0300\u0301'), 'a', 'removal of multiple combining diacritics from a single letter works');
+    t.equal(removeDiacritics('é\u0311'), 'e', 'removal of a combining diacritic and a precomposed diacritic applied to the same letter works');
+
+    // combining diacritics alone are nonsensical and we won't expect good search results here
+    // so we don't really care what the results are here as long as they're of nonzero length
+    // (which can have weird tokenization results)
+    t.assert(removeDiacritics('\u0300').length > 0, 'bare combining diacritics are left alone');
+    t.assert(removeDiacritics('\u0300\u0311').length > 0, 'bare combining diacritics are left alone');
+    t.assert(removeDiacritics('asdf \u0300').split(' ').filter((t) => t.length > 0).length == 2, 'tokens consisting of bare combining diacritics are left alone');
+    t.assert(removeDiacritics('asdf \u0300\u0311').split(' ').filter((t) => t.length > 0).length == 2, 'tokens consisting of bare combining diacritics are left alone');
 
     t.end();
 });


### PR DESCRIPTION
### Context
Carmen's current diacritical mark handling handles precomposed diacritical marks (those where a single unicode codepoint represents a letter with a diacritical mark) but not combining diacritics (those where the diacritical mark is a separate codepoint that follows an unmarked stand-alone letter). This PR adds a mechanism to strip combining marks to the diacritical mark stripper, but only applies it in circumstances where the diacritical mark is applied to an existing character, and not to ones where the mark stands alone in a query or token, to avoid unexpected behavior potentially resulting from the diacritical mark remover rendering a query, label, or token empty.


### Summary of Changes
- [x] enhance diacritical mark remover to make it remove combining marks
- [x] add tests

cc @mapbox/geocoding-gang
