### PR TITLE
Reverse routing

### DIFF
--- a/bench/contextVector.js
+++ b/bench/contextVector.js
@@ -34,7 +34,7 @@ var source = {
 suite.add('context vector', {
 	'defer': true,
 	'fn': function(deferred) {
-        context.contextVector(source, -97.4707, 39.4362, false, {}, null, false, false, function(err, data) {
+        context.contextVector(source, -97.4707, 39.4362, false, {}, null, false, false, undefined, function(err, data) {
     	    deferred.resolve();
         });
 	}

--- a/bin/carmen.js
+++ b/bin/carmen.js
@@ -31,6 +31,7 @@ if (argv.help) {
     console.log('  --reverseMode="{mode}"       Sort features in reverse queries by one of `score` or `distance`');
     console.log('  --languageMode="strict"      Only return results with text in a consistent script family');
     console.log('  --bbox="minX,minY,maxX,maxY" Limit results to those within the specified bounding box');
+    console.log(' --routing=true                Return routable points, if possible');
     console.log('  --help                       Print this report');
     process.exit(0);
 }
@@ -103,6 +104,8 @@ if (argv.reverseMode) {
     if (argv.reverseMode !== 'score' && argv.reverseMode !== 'distance') throw new Error('reverseMode must be one of `score` or `distance`');
 }
 
+if (argv.routing) argv.routing = (argv.routing || false); 
+
 let load = +new Date();
 
 carmen.geocode(argv.query, {
@@ -116,7 +119,8 @@ carmen.geocode(argv.query, {
     'indexes': true,
     'reverseMode': argv.reverseMode,
     'languageMode': argv.languageMode,
-    'bbox': argv.bbox
+    'bbox': argv.bbox,
+    'routing': argv.routing
 }, (err, data) => {
     if (err) throw err;
     load = +new Date() - load;

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -580,7 +580,6 @@ function fullFeature(source, feat, query, routing, callback) {
         }
 
         if (source.geocoder_routable) {
-            console.log('calculating routable points');
             loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded);
         }
 

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -74,7 +74,7 @@ module.exports = function(geocoder, position, options, callback) {
                 exclusiveMatched[options.targetFeature[1]] = true;
             }
 
-            q.defer(contextVector, source, lon, lat, full, exclusiveMatched || matched, language, scoreRange, options.reverseMode);
+            q.defer(contextVector, source, lon, lat, full, exclusiveMatched || matched, language, scoreRange, options.reverseMode, options.routing);
         }
     }
 
@@ -381,9 +381,10 @@ function nearestPoints(source, lon, lat, scoreFilter, callback) {
 * @param {Boolean} language - if language option is set, otherwise language=false
 * @param {Number} scoreFilter - filter the results by score
 * @param {String} reverseMode - sort features in reverse queries by one of `score` or `distance`
+* @param {Boolean} routing - whether routing is enabled
 * @param {Function} callback - callback function
 */
-function contextVector(source, lon, lat, full, matched, language, scoreFilter, reverseMode, callback) {
+function contextVector(source, lon, lat, full, matched, language, scoreFilter, reverseMode, routing, callback) {
 
     tileCover(source, lon, lat, query);
 
@@ -491,7 +492,7 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
             // 3. Non-ghost, not a phrasematch
             feat = forwardMatchFeat || ghostMatchFeat || feat;
             if (feat && full) {
-                return fullFeature(source, feat, [lon,lat], callback);
+                return fullFeature(source, feat, [lon,lat], routing, callback);
             } else if (feat) {
                 return lightFeature(source, feat, callback);
             // No matching features found.
@@ -538,7 +539,7 @@ function lightFeature(source, feat, callback) {
 }
 
 // Go from VT query attributes to a fully loaded feature
-function fullFeature(source, feat, query, callback) {
+function fullFeature(source, feat, query, routing, callback) {
     feature.getFeatureById(source, feat.id, (err, loaded) => {
         if (err) return callback(err);
         if (!loaded) return callback();
@@ -579,6 +580,7 @@ function fullFeature(source, feat, query, callback) {
         }
 
         if (source.geocoder_routable) {
+            console.log('calculating routable points');
             loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded);
         }
 

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -579,7 +579,7 @@ function fullFeature(source, feat, query, routing, callback) {
             loaded = addritp;
         }
 
-        if (source.geocoder_routable) {
+        if (source.geocoder_routable && routing) {
             loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded);
         }
 

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -288,7 +288,8 @@ function reverseGeocode(geocoder, tokenized, options, callback) {
             maxidx: maxidx,
             types: options.types,
             stacks: options.stacks,
-            reverseMode: options.reverseMode
+            reverseMode: options.reverseMode,
+            routing: options.routing
         }, (err, context) => {
             if (err) return callback(err);
             // If a single result is being returned, split the context array into

--- a/test/unit/geocoder/context.test.js
+++ b/test/unit/geocoder/context.test.js
@@ -50,7 +50,7 @@ test('contextVector deflate', (t) => {
         id: 'testA',
         idx: 0
     };
-    context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+    context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
         t.ifError(err);
 
         t.deepEqual(data.properties['carmen:vtquerydist'] < 0.0001, true);
@@ -112,7 +112,7 @@ test('contextVector gzip', (t) => {
         id: 'testA',
         idx: 0
     };
-    context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+    context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
         t.ifError(err);
 
         t.deepEqual(data.properties['carmen:vtquerydist'] < 0.0001, true);
@@ -153,7 +153,7 @@ test('contextVector badbuffer', (t) => {
         id: 'testA',
         idx: 0
     };
-    context.contextVector(source, -97.4707, 39.4362, false, {}, null, false, false, (err, data) => {
+    context.contextVector(source, -97.4707, 39.4362, false, {}, null, false, false, undefined, (err, data) => {
         t.equal(err.toString(), 'Error: Could not detect compression of vector tile');
         t.end();
     });
@@ -178,7 +178,7 @@ test('contextVector empty VT buffer', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.end();
         });
@@ -306,7 +306,7 @@ test('contextVector ignores negative score', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data.properties['carmen:text'], 'B');
             t.end();
@@ -342,7 +342,7 @@ test('contextVector only negative score', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data, false);
             t.end();
@@ -378,7 +378,7 @@ test('contextVector matched negative score', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 0, 0, false, { 1:{} }, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, { 1:{} }, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data.properties['carmen:text'], 'A');
             t.end();
@@ -419,7 +419,7 @@ test('contextVector grabbed exclusive ID', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 0, 0, false, { _exclusive: true, 4: true }, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, { _exclusive: true, 4: true }, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data.properties['carmen:text'], 'A');
             t.end();
@@ -462,7 +462,7 @@ test('contextVector restricts distance', (t) => {
             id: 'testA',
             idx: 0
         };
-        context.contextVector(source, 170, 80, false, {}, null, false, false, (err, data) => {
+        context.contextVector(source, 170, 80, false, {}, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data, false);
             t.end();
@@ -518,7 +518,7 @@ test('contextVector restricts distance', (t) => {
                 id: 'testA',
                 idx: 0
             };
-            context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+            context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
                 t.ifError(err);
                 t.equal(data.properties['carmen:text'], 'A');
                 t.end();
@@ -543,7 +543,7 @@ test('contextVector restricts distance', (t) => {
                 id: 'testA',
                 idx: 0
             };
-            context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+            context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
                 t.ifError(err);
                 t.equal(data.properties['carmen:text'], 'A');
                 t.end();
@@ -568,7 +568,7 @@ test('contextVector restricts distance', (t) => {
                 id: 'testA',
                 idx: 0
             };
-            context.contextVector(source, 0, 0, false, { 2:true }, null, false, false, (err, data) => {
+            context.contextVector(source, 0, 0, false, { 2:true }, null, false, false, undefined, (err, data) => {
                 t.ifError(err);
                 t.equal(data.properties['carmen:text'], 'B');
                 t.end();
@@ -608,14 +608,14 @@ test('contextVector caching', (t) => {
         let hit, miss;
         hit = context.getTile.cacheStats.hit;
         miss = context.getTile.cacheStats.miss;
-        context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+        context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
             t.ifError(err);
             t.equal(data.properties['carmen:extid'], 'test.1');
             t.equal(context.getTile.cacheStats.hit - hit, 0, 'hits +0');
             t.equal(context.getTile.cacheStats.miss - miss, 1, 'miss +1');
             hit = context.getTile.cacheStats.hit;
             miss = context.getTile.cacheStats.miss;
-            context.contextVector(source, 0, 0, false, {}, null, false, false, (err, data) => {
+            context.contextVector(source, 0, 0, false, {}, null, false, false, undefined, (err, data) => {
                 t.ifError(err);
                 t.equal(data.properties['carmen:extid'], 'test.1');
                 t.equal(context.getTile.cacheStats.hit - hit, 1, 'hits +1');
@@ -679,6 +679,10 @@ test('Context eliminates correct properties', (t) => {
         });
     });
 });
+
+
+
+
 
 test('teardown', (t) => {
     context.getTile.cache.reset();


### PR DESCRIPTION
### Context
In the previous version, for reverse geocoding, routable points were being calculated for all features marked as `geocoder_routable` in the source in `context.js`, regardless of whether the `routing` option was set. In the final response, `routable_points` wasn't returned because there was a check for `routing` in `ops.js`, but this meant it was doing the work of calculating the points for every reverse request.

This update passes the `routing` option through `context.js` to only calculate the points if `routing` is set to `true`.

### Summary of Changes
- [x] Add `routing` param to `contextVector` and make necessary changes to pass it through
- [x] Add check in `fullFeature` for whether `routing` is enabled before calculating routable points
- [x] Update tests accordingly


### Next Steps
- [ ] Bump carmen version and publish
- [ ] Update api-geocoder and all services that include Carmen as a dependency


cc @mapbox/geocoding-gang
