### PR TITLE
Handle strange dawg phrase insertion bug

### DIFF
--- a/lib/indexer/dawg.js
+++ b/lib/indexer/dawg.js
@@ -71,10 +71,10 @@ WriteCache.prototype.dump = function() {
         let lastInserted = null;
         for (let j = 0; j < phrases.length; j++) {
             const phraseString = phrases[j].toString();
-            if (phraseString === lastInserted) {
-                continue;
-            }
+
+            if (phraseString === lastInserted) continue;
             lastInserted = phraseString;
+
             dawg.insert(phraseString);
         }
     }
@@ -107,10 +107,10 @@ WriteCache.prototype.dumpWithNormalizations = function(normalizationCachePath) {
         let lastInserted = null;
         for (let j = 0; j < phrases.length; j++) {
             const phraseString = phrases[j].toString();
-            if (phraseString === lastInserted) {
-                continue;
-            }
+
+            if (phraseString === lastInserted) continue;
             lastInserted = phraseString;
+
             dawg.insert(phraseString);
 
             if (this.normalizationMap.has(phraseString) || this.normalizationTargets.has(phraseString)) {

--- a/lib/indexer/dawg.js
+++ b/lib/indexer/dawg.js
@@ -67,8 +67,15 @@ WriteCache.prototype.dump = function() {
             phrases.push(new Buffer(k));
         }
         phrases.sort(Buffer.compare);
+
+        let lastInserted = null;
         for (let j = 0; j < phrases.length; j++) {
-            dawg.insert(phrases[j].toString());
+            const phraseString = phrases[j].toString();
+            if (phraseString === lastInserted) {
+                continue;
+            }
+            lastInserted = phraseString;
+            dawg.insert(phraseString);
         }
     }
     dawg.finish();
@@ -96,8 +103,14 @@ WriteCache.prototype.dumpWithNormalizations = function(normalizationCachePath) {
             phrases.push(new Buffer(k));
         }
         phrases.sort(Buffer.compare);
+
+        let lastInserted = null;
         for (let j = 0; j < phrases.length; j++) {
             const phraseString = phrases[j].toString();
+            if (phraseString === lastInserted) {
+                continue;
+            }
+            lastInserted = phraseString;
             dawg.insert(phraseString);
 
             if (this.normalizationMap.has(phraseString) || this.normalizationTargets.has(phraseString)) {


### PR DESCRIPTION
### Context
In the DAWG utility functions `dump` and `dumpWithNormalizations`, there's a stage where we take all the phrases (which have been unique-ified by being turned into keys in a `Map`), sort them, and then insert them one by one lexicographically into the underlying DAWG builder structure. The DAWG requires that the entries by in order byte-wise, rather than character-wise, and we get them in that order by iterating over the map, converting them all into `Buffer`s (which can be sorted byte-wise) and adding them to an array, sorting the array, and then looping over it and converting them back to strings again for insertion.

Apparently, though, there are situations where this string -> buffer -> string transformation sequence is lossy, I think maybe because the input string is somehow invalid. It seems that in rare circumstances, two nonequal strings can exist such that if one or both of them is affected by this transformation, they can end up equal afterwards, so our already-deduplicated list can end up with duplicates in it, that appear together once sorted.

It turns out that whatever breakage produces these strings gets corrected by Node (thanks, Node) if you try and apply any encoding or other transformation necessary to, say, print it to the screen, write it to a file, encode it as hex, etc. In other words, in the context of the running indexer I can see that these two strings are nonequal, but under any means of inspection I can come up with, they appear equal to me. As such, I've been able to observe and correct this behavior in the context of live data, but have been unsuccessful in producing an isolated test case. The good news, though, is that all current tests pass, all of this code is going away anyway once [fuzzy-phrase](https://github.com/mapbox/fuzzy-phrase) lands, and this fix does fix the production data issue that brought the problem to light.


### Summary of Changes
- [x] before each insertion, check if it's equal to the last-inserted string, and if so, skip it

cc @mapbox/geocoding-gang
