### PR TITLE
update copyright year and add license name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-carmen copyright (c) 2017, Mapbox.
+BSD 2-clause "Simplified" license
+
+carmen copyright (c) 2018, Mapbox.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
The copyright year is old (happy 2018!) and the license name isn't explicitly called out.

### Summary of Changes
- [ ] update 2017 to 2018
- [ ] add `BSD 2-clause "Simplified" license` to get the fancy badge to show up


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/geocoding-gang
