### PR TITLE
fix license name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-BSD 2-clause "Simplified" license
+BSD 2-Clause License
 
 carmen copyright (c) 2018, Mapbox.
 


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
Badge not appearing after adding `BSD 2-Clause "Simplified" License`.
### Summary of Changes
- [ ] change from BSD 2-Clause "Simplified" License to BSD 2-Clause License to try and get the license auto-detected


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/geocoding-gang
