### PR TITLE
[security] upgrade node-mbtiles & node-sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@mapbox/carmen-cache": "0.21.1",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
-    "@mapbox/mbtiles": "^0.9.0",
+    "@mapbox/mbtiles": "^0.10.0",
     "@mapbox/sphericalmercator": "^1.1.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",


### PR DESCRIPTION
This should avoid the security warning being seen in tests:

```
@mapbox/carmen 24.5.1
↳ @mapbox/mbtiles 0.9.0
 ↳ sqlite3 3.1.13
  ↳ node-pre-gyp 0.6.38
   ↳ hawk 3.1.3
    ↳ cryptiles 2.0.5
     ↳ boom 2.10.1
      ↳ hoek 2.16.3
```

### Context

An old version of node-sqlite3 was being used.


### Summary of Changes
- [ ] Upgrades to the most recent mbtiles release: https://github.com/mapbox/node-mbtiles/blob/master/CHANGELOG.md#0100


### Next Steps

- [ ] Someone on @mapbox/geocoding merge once 🍏 


cc @mapbox/geocoding-gang
