### PR TITLE
[security] upgrade node-mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "^6.0.1",
     "geojson-rewind": "^0.3.1",
     "iter-tools": "^4.1.1",
-    "mapnik": "^3.7.2",
+    "mapnik": "^4.0.1",
     "minimist": "1.2.0",
     "model-un": "0.0.3",
     "split": "^1.0.1",


### PR DESCRIPTION
This will solve this security warning, seen on circle:

```
deep-extend 0.4.2 has known vulnerabilities:  severity: low; summary: Prototype pollution attack, CVE: CVE-2018-3750; https://hackerone.com/reports/311333
@mapbox/carmen 24.5.1
↳ mapnik 3.7.2
 ↳ node-pre-gyp 0.6.39
  ↳ rc 1.2.6
   ↳ deep-extend 0.4.2
```

### Context

An old version of node-mapnik was being used.


### Summary of Changes
- [ ] Upgrades to node-mapnik@4.0.1: https://github.com/mapnik/node-mapnik/blob/master/CHANGELOG.md#401


### Next Steps
- [ ] Someone on @mapbox/geocoding merge once 🍏


cc @mapbox/geocoding-gang
