### PR TITLE
Fuzzy relevance

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -49,6 +49,7 @@ module.exports = function phrasematch(source, query, options, callback) {
         const windowMatches = phraseSet.fuzzyMatchWindows(tokenized, maxDistance, maxDistance, options.autocomplete);
         subqueries = windowMatches.map((match) => {
             const subquery = match.phrase;
+            subquery.original_phrase = tokenized.slice(match.start_position, match.phrase.length);
             subquery.ender = match.ends_in_prefix;
 
             let mask = 0;
@@ -89,6 +90,7 @@ module.exports = function phrasematch(source, query, options, callback) {
 
             for (let i = 0; i < phraseSetMatches.length; i++) {
                 const sq = phraseSetMatches[i].phrase;
+                sq.original_phrase = subquery;
                 sq.ender = scanPrefix;
                 sq.mask = subquery.mask;
                 sq.edit_distance = phraseSetMatches[i].edit_distance;
@@ -126,17 +128,29 @@ module.exports = function phrasematch(source, query, options, callback) {
     const phrasematches = [];
 
     for (const subquery of subqueries) {
+        const phrase = subquery.join(' ');
         // Augment permutations with matched grids,
         // index position and weight relative to input query.
         // use the original subquery to calculate weight, in case the variant has a different cardinality
-        const weight = subquery.length / tokenized.length;
+        let weight = subquery.length / tokenized.length;
+        let editMultiplier = 1;
+        if (subquery.edit_distance != 0) {
+            // approximate a levenshtein ratio -- this is usually defined as
+            // ratio(a, b) = ((len(a) + len(b)) - distance(a, b)) / (len(a) + len(b))
+            // except in this instance we're just going to base it on the query text,
+            // so that different matches that are the same distance from the query
+            // text can be disambiguated by score even if they have different lengths
+            const original = subquery.original_phrase.join(' ');
+            editMultiplier = Math.max(
+                (original.length - (subquery.edit_distance / 2)) / original.length,
+                .75
+            );
+            weight *= editMultiplier;
+        }
 
         const prefix = (subquery.ender && !(source.geocoder_address && termops.isAddressNumber(subquery)));
 
-        // TODO: need to add data to Phrasematch to be used in
-        // relevance rankings. could be edit distance, or maybe the
-        // distance adjusted by overall length of query <27-06-18, boblannon> //
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, subquery.join(' '), scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages, editMultiplier));
     }
 
     return callback(null, new PhrasematchResult(phrasematches, source));
@@ -160,7 +174,7 @@ function PhrasematchResult(phrasematches, source) {
 * Attributes used by carmen-cache, all phrasematches from the same source have the same values for idx, cache, zoom
 **/
 module.exports.Phrasematch = Phrasematch;
-function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages) {
+function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages, editMultiplier) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -171,8 +185,9 @@ function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zo
     this.idx = idx;
     this.cache = cache;
     this.zoom = zoom;
+    this.editMultiplier = editMultiplier || 1;
 }
 
 Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages);
+    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages, this.editMultiplier);
 };

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -134,7 +134,7 @@ module.exports = function phrasematch(source, query, options, callback) {
         // use the original subquery to calculate weight, in case the variant has a different cardinality
         let weight = subquery.length / tokenized.length;
         let editMultiplier = 1;
-        if (subquery.edit_distance != 0) {
+        if (subquery.edit_distance !== 0) {
             // approximate a levenshtein ratio -- this is usually defined as
             // ratio(a, b) = ((len(a) + len(b)) - distance(a, b)) / (len(a) + len(b))
             // except in this instance we're just going to base it on the query text,

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -305,17 +305,18 @@ function rebalance(query, stack) {
     }
 
     const garbage = (query.length === (stackMask.toString(2).split(1).length - 1)) ? 0 : 1;
-    const weight = 1 / (garbage + stack.length);
-
-    // recompute total relevance from scratch
-    stackClone.relev = weight * stack.length;
+    const weightPerMatch = 1 / (garbage + stack.length);
 
     // shallow copy stack into stackClone to prevent cases where a stack's
     // index gets overwritten in deep copies.
+    let totalWeight = 0;
     for (let k = 0; k < stack.length; k++) {
         stackClone[k] = stack[k].clone();
-        stackClone[k].weight = weight;
+        stackClone[k].weight = weightPerMatch * stack[k].editMultiplier;
+        totalWeight += stackClone[k].weight;
     }
+
+    stackClone.relev = totalWeight;
 
     return stackClone;
 }

--- a/test/acceptance/geocode-unit.fuzzy.test.js
+++ b/test/acceptance/geocode-unit.fuzzy.test.js
@@ -46,7 +46,7 @@ tape('parlor - without fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
         t.deepEqual(res.features[0].id, 'place.2');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
         t.equal(res.features.length, 1, 'Parlor is only result');
         t.end();
     });
@@ -56,11 +56,11 @@ tape('parlor - with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins on relevance');
         t.deepEqual(res.features[0].id, 'place.2');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
 
         t.deepEqual(res.features[1].place_name, 'Pinball Parlour Arcade', 'Parlour is in second place');
         t.deepEqual(res.features[1].id, 'place.1');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
         t.end();
     });
@@ -70,13 +70,13 @@ tape('parloar - with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Tied on relevance; parlour wins on score');
         t.deepEqual(res.features[0].id, 'place.1');
-        t.assert(res.features[0].relevance < 1, "relevance < 1");
+        t.assert(res.features[0].relevance < 1, 'relevance < 1');
 
         t.deepEqual(res.features[1].place_name, 'Pinball Parlor Arcade', 'Parlor is in second place');
         t.deepEqual(res.features[1].id, 'place.2');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
-        t.equal(res.features[0].relevance, res.features[1].relevance, "Relevances are equal");
+        t.equal(res.features[0].relevance, res.features[1].relevance, 'Relevances are equal');
         t.end();
     });
 });
@@ -86,7 +86,7 @@ tape('parlor - prefix without fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
         t.deepEqual(res.features[0].id, 'place.2');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
         t.equal(res.features.length, 1, 'Parlor is only result');
         t.end();
     });
@@ -96,11 +96,11 @@ tape('parlor - prefix with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins on relevance');
         t.deepEqual(res.features[0].id, 'place.2');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
 
         t.deepEqual(res.features[1].place_name, 'Pinball Parlour Arcade', 'Parlour is in second place');
         t.deepEqual(res.features[1].id, 'place.1');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
         t.end();
     });
@@ -110,13 +110,13 @@ tape('parloar - prefix with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Tied on relevance; parlour wins on score');
         t.deepEqual(res.features[0].id, 'place.1');
-        t.assert(res.features[0].relevance < 1, "relevance < 1");
+        t.assert(res.features[0].relevance < 1, 'relevance < 1');
 
         t.deepEqual(res.features[1].place_name, 'Pinball Parlor Arcade', 'Parlor is in second place');
         t.deepEqual(res.features[1].id, 'place.2');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
-        t.equal(res.features[0].relevance, res.features[1].relevance, "Relevances are equal");
+        t.equal(res.features[0].relevance, res.features[1].relevance, 'Relevances are equal');
         t.end();
     });
 });
@@ -213,8 +213,8 @@ tape('100 main st washington dc - without fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
         t.deepEqual(res.features[0].id, 'address.100');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
-        t.assert(res.features.length == 1, "1 feature returned")
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
+        t.assert(res.features.length === 1, '1 feature returned');
         t.end();
     });
 });
@@ -225,13 +225,13 @@ tape('100 main st washington dc - with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
         t.deepEqual(res.features[0].id, 'address.100');
-        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features[0].relevance === 1, 'relevance = 1');
 
         t.deepEqual(res.features[1].place_name, '100 Maine St, Washington, DC', '101 Maine St');
         t.deepEqual(res.features[1].id, 'address.101');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
-        t.assert(res.features.length == 2, "2 features returned")
+        t.assert(res.features.length === 2, '2 features returned');
         t.end();
     });
 });
@@ -241,14 +241,14 @@ tape('100 main st warshington dc - with fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
         t.deepEqual(res.features[0].id, 'address.100');
-        t.assert(res.features[0].relevance < 1, "relevance < 1");
+        t.assert(res.features[0].relevance < 1, 'relevance < 1');
 
         t.deepEqual(res.features[1].place_name, '100 Maine St, Washington, DC', '101 Maine St');
         t.deepEqual(res.features[1].id, 'address.101');
-        t.assert(res.features[1].relevance < 1, "relevance < 1");
+        t.assert(res.features[1].relevance < 1, 'relevance < 1');
 
-        t.assert(res.features[1].relevance < res.features[0].relevance, "more typos = worse relevance");
-        t.assert(res.features.length == 2, "2 features returned")
+        t.assert(res.features[1].relevance < res.features[0].relevance, 'more typos = worse relevance');
+        t.assert(res.features.length === 2, '2 features returned');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.fuzzy.test.js
+++ b/test/acceptance/geocode-unit.fuzzy.test.js
@@ -5,71 +5,255 @@ const tape = require('tape');
 const Carmen = require('../..');
 const context = require('../../lib/geocoder/context');
 const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
 const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
-// Confirm that disabling autocomplete works, and that in situations where an autocomplete
+// simpleConfirm that disabling autocomplete works, and that in situations where an autocomplete
 // result scores highest, the winner changes depending on whether or not autocomplete is enabled
-const conf = { place: new mem(null, () => {}) };
-const c = new Carmen(conf);
-const places = [
+const simpleConf = { place: new mem(null, () => {}) };
+const simple = new Carmen(simpleConf);
+const pois = [
     {
         id:1,
         properties: {
             'carmen:score': 100,
-            'carmen:text':'Pinball Parlour Arcade',
-            'carmen:zxy':['6/32/32'],
-            'carmen:center':[0,0]
+            'carmen:text': 'Pinball Parlour Arcade',
+            'carmen:zxy': ['6/32/32'],
+            'carmen:center': [0,0]
         }
     },
     {
         id:2,
         properties: {
             'carmen:score': 10,
-            'carmen:text':'Pinball Parlor Arcade',
-            'carmen:zxy':['6/32/32'],
-            'carmen:center':[0,0]
+            'carmen:text': 'Pinball Parlor Arcade',
+            'carmen:zxy': ['6/32/32'],
+            'carmen:center': [0,0]
         }
     }
 ];
-queueFeature(conf.place, places, (err) => {
-    buildQueued(conf.place, () => {
-        tape('parlor - with fuzzy', (t) => {
-            c.geocode('pinball parlor arcade', { limit_verify:1, autocomplete: 0, fuzzyMatch: 1 }, (err, res) => {
-                t.ifError(err);
-                t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Parlour wins with fuzzy');
-                t.deepEqual(res.features[0].id, 'place.1');
-                t.end();
-            });
-        });
-        tape('parlor - without fuzzy', (t) => {
-            c.geocode('pinball parlor arcade', { limit_verify:1, autocomplete: 0, fuzzyMatch: 0 }, (err, res) => {
-                t.ifError(err);
-                t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
-                t.deepEqual(res.features[0].id, 'place.2');
-                t.end();
-            });
-        });
-        tape('parlor - prefix with fuzzy', (t) => {
-            c.geocode('pinball parlor', { limit_verify:1, autocomplete: 1, fuzzyMatch: 1 }, (err, res) => {
-                t.ifError(err);
-                t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Parlour wins with fuzzy');
-                t.deepEqual(res.features[0].id, 'place.1');
-                t.end();
-            });
-        });
-        tape('parlor - prefix without fuzzy', (t) => {
-            c.geocode('pinball parlor', { limit_verify:1, autocomplete: 1, fuzzyMatch: 0 }, (err, res) => {
-                t.ifError(err);
-                t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
-                t.deepEqual(res.features[0].id, 'place.2');
-                t.end();
-            });
-        });
-        tape('teardown', (t) => {
-            context.getTile.cache.reset();
+
+tape('simple indexing', (t) => {
+    queueFeature(simpleConf.place, pois, (err) => {
+        buildQueued(simpleConf.place, () => {
             t.end();
         });
     });
 });
 
+tape('parlor - without fuzzy', (t) => {
+    simple.geocode('pinball parlor arcade', { limit_verify: 2, autocomplete: false, fuzzyMatch: false }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.equal(res.features.length, 1, 'Parlor is only result');
+        t.end();
+    });
+});
+tape('parlor - with fuzzy', (t) => {
+    simple.geocode('pinball parlor arcade', { limit_verify: 2, autocomplete: false, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins on relevance');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
 
+        t.deepEqual(res.features[1].place_name, 'Pinball Parlour Arcade', 'Parlour is in second place');
+        t.deepEqual(res.features[1].id, 'place.1');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.end();
+    });
+});
+tape('parloar - with fuzzy', (t) => {
+    simple.geocode('pinball parloar arcade', { limit_verify: 2, autocomplete: false, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Tied on relevance; parlour wins on score');
+        t.deepEqual(res.features[0].id, 'place.1');
+        t.assert(res.features[0].relevance < 1, "relevance < 1");
+
+        t.deepEqual(res.features[1].place_name, 'Pinball Parlor Arcade', 'Parlor is in second place');
+        t.deepEqual(res.features[1].id, 'place.2');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.equal(res.features[0].relevance, res.features[1].relevance, "Relevances are equal");
+        t.end();
+    });
+});
+
+tape('parlor - prefix without fuzzy', (t) => {
+    simple.geocode('pinball parlor', { limit_verify: 2, autocomplete: true, fuzzyMatch: false }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins without fuzzy');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.equal(res.features.length, 1, 'Parlor is only result');
+        t.end();
+    });
+});
+tape('parlor - prefix with fuzzy', (t) => {
+    simple.geocode('pinball parlor', { limit_verify: 2, autocomplete: true, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlor Arcade', 'Parlor wins on relevance');
+        t.deepEqual(res.features[0].id, 'place.2');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
+
+        t.deepEqual(res.features[1].place_name, 'Pinball Parlour Arcade', 'Parlour is in second place');
+        t.deepEqual(res.features[1].id, 'place.1');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.end();
+    });
+});
+tape('parloar - prefix with fuzzy', (t) => {
+    simple.geocode('pinball parloar arcade', { limit_verify: 2, autocomplete: true, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Pinball Parlour Arcade', 'Tied on relevance; parlour wins on score');
+        t.deepEqual(res.features[0].id, 'place.1');
+        t.assert(res.features[0].relevance < 1, "relevance < 1");
+
+        t.deepEqual(res.features[1].place_name, 'Pinball Parlor Arcade', 'Parlor is in second place');
+        t.deepEqual(res.features[1].id, 'place.2');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.equal(res.features[0].relevance, res.features[1].relevance, "Relevances are equal");
+        t.end();
+    });
+});
+
+const complexConf = {
+    region: new mem({ maxzoom: 6 }, () => {}),
+    place: new mem({ maxzoom: 6 }, () => {}),
+    address: new mem({ maxzoom: 6, geocoder_address: 1, geocoder_name:'address' }, () => {})
+};
+const complex = new Carmen(complexConf);
+
+// Place
+tape('index place "Washington"', (t) => {
+    const place = {
+        id:105,
+        properties: {
+            'carmen:text': 'Washington',
+            'carmen:zxy': ['6/32/32'],
+            'carmen:center': [0,0]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        }
+    };
+    queueFeature(complexConf.place, place, t.end);
+});
+
+// Address 1
+tape('index address "Main St" in "Washington"', (t) => {
+    const address = {
+        id: 100,
+        properties: {
+            'carmen:text': 'Main St',
+            'carmen:center': [0,0],
+            'carmen:zxy': ['6/32/32'],
+            'carmen:addressnumber': ['100']
+        },
+        geometry: {
+            type: 'MultiPoint',
+            coordinates: [[0,0]]
+        }
+    };
+    queueFeature(complexConf.address, address, t.end);
+});
+
+// Address 2
+tape('index address "Maine St" in "Washington"', (t) => {
+    const address = {
+        id: 101,
+        properties: {
+            'carmen:text': 'Maine St',
+            'carmen:center': [0,0],
+            'carmen:zxy': ['6/32/32'],
+            'carmen:addressnumber': ['100']
+        },
+        geometry: {
+            type: 'MultiPoint',
+            coordinates: [[0,0]]
+        }
+    };
+    queueFeature(complexConf.address, address, t.end);
+});
+
+// Place 2: Seattle
+tape('index region DC', (t) => {
+    const region = {
+        id: 110,
+        properties: {
+            'carmen:text': 'DC',
+            'carmen:zxy': ['6/32/32'],
+            'carmen:center': [0,0]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        }
+    };
+    queueFeature(complexConf.region, region, t.end);
+});
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(complexConf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(complexConf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('100 main st washington dc - without fuzzy', (t) => {
+    complex.geocode('100 Main St washington dc', { limit_verify: 2, autocomplete: true, fuzzyMatch: false }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
+        t.deepEqual(res.features[0].id, 'address.100');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
+        t.assert(res.features.length == 1, "1 feature returned")
+        t.end();
+    });
+});
+
+
+tape('100 main st washington dc - with fuzzy', (t) => {
+    complex.geocode('100 Main St washington dc', { limit_verify: 2, autocomplete: true, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
+        t.deepEqual(res.features[0].id, 'address.100');
+        t.assert(res.features[0].relevance == 1, "relevance = 1");
+
+        t.deepEqual(res.features[1].place_name, '100 Maine St, Washington, DC', '101 Maine St');
+        t.deepEqual(res.features[1].id, 'address.101');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.assert(res.features.length == 2, "2 features returned")
+        t.end();
+    });
+});
+
+tape('100 main st warshington dc - with fuzzy', (t) => {
+    complex.geocode('100 Main St warshington dc', { limit_verify: 2, autocomplete: true, fuzzyMatch: true }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
+        t.deepEqual(res.features[0].id, 'address.100');
+        t.assert(res.features[0].relevance < 1, "relevance < 1");
+
+        t.deepEqual(res.features[1].place_name, '100 Maine St, Washington, DC', '101 Maine St');
+        t.deepEqual(res.features[1].id, 'address.101');
+        t.assert(res.features[1].relevance < 1, "relevance < 1");
+
+        t.assert(res.features[1].relevance < res.features[0].relevance, "more typos = worse relevance");
+        t.assert(res.features.length == 2, "2 features returned")
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});


### PR DESCRIPTION
### Context
This PR builds on #722 to add a mechanism for penalizing relevance for inexact matches when fuzzy match is enabled. It does this by calculating something like a Levenshtein ratio (inspired by, but not exactly the same as, the `ratio` operation as defined in python-levenshtein; see inline comments for specifics), and then reducing the weight of the match in the phrasematch object by multiplying it by this ratio. It repeats this multiplication operation after stacks have been rebalanced in spatialmatch.

I've also rewritten the existing fuzzy match tests as their results have now changed in light of the new relevances, and added some address-specific tests as they use a different codepath and need to be tested separately.

### Summary of Changes
- [x] add relevance penalty for fuzzy matches
- [x] rewrite/augment fuzzy match tests


### Next Steps
Nope

cc @mapbox/geocoding-gang
