### PR TITLE
Simplifications to text processing for indexing

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -442,10 +442,10 @@ function generateFrequency(docs, replacer, globalTokens, maxScore) {
         // set max score
         freq['__MAX__'][0] = maxScore || Math.max(freq['__MAX__'][0], docs[i].properties['carmen:score'] || 0);
 
-        const texts = termops.getIndexableText(replacer, globalTokens, docs[i]);
+        const texts = termops.getMinimalIndexableText(replacer, globalTokens, docs[i]);
 
         for (let x = 0; x < texts.length; x++) {
-            const terms = texts[x].tokens;
+            const terms = texts[x];
 
             for (let k = 0; k < terms.length; k++) {
                 const id = terms[k];

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -258,6 +258,7 @@ function getIndexableText(replacer, globalTokens, doc) {
     }
 
     const texts = doc.properties['carmen:text'].split(',');
+    const housenumRange = getHousenumRangeV3(doc);
 
     // get tokens for default text
     getTokens(texts, 'default');
@@ -285,11 +286,10 @@ function getIndexableText(replacer, globalTokens, doc) {
                 if (!tokens.length) continue;
 
                 // push tokens with housenum range token if applicable
-                const range = getHousenumRangeV3(doc);
-                if (range) {
-                    let l = range.length;
+                if (housenumRange) {
+                    let l = housenumRange.length;
                     while (l--) {
-                        const withHousenums = [range[l]].concat(tokens);
+                        const withHousenums = [housenumRange[l]].concat(tokens);
                         add(withHousenums, language);
                     }
                 }
@@ -314,6 +314,49 @@ function getIndexableText(replacer, globalTokens, doc) {
     });
 
     return output;
+}
+
+// Takes a geocoder_tokens token mapping and a text string and returns
+// an array of one or more arrays of tokens that should be indexed.
+module.exports.getMinimalIndexableText = getMinimalIndexableText;
+function getMinimalIndexableText(replacer, globalTokens, doc) {
+    const uniqTexts = new Set();
+    const indexableText = [];
+    const housenumRange = getHousenumRangeV3(doc);
+
+    let texts = doc.properties['carmen:text'].split(',');
+
+    for (const key of Object.keys(doc.properties)) {
+        if (key.match(/text_(.+)/) && doc.properties[key]) {
+            texts = texts.concat(doc.properties[key].split(','));
+        }
+    }
+
+    for (let x = 0; x < texts.length; x++) {
+        if (globalTokens) {
+            texts[x] = token.replaceToken(globalTokens, texts[x]);
+        }
+        const tokens = tokenize(token.replaceToken(replacer, texts[x]));
+        if (!tokens.length) continue;
+
+        if (housenumRange) {
+            let l = housenumRange.length;
+            while (l--) {
+                const withHousenums = [housenumRange[l]].concat(tokens);
+                add(withHousenums);
+            }
+        } else {
+            add(tokens);
+        }
+    }
+
+    function add(tokens) {
+        const key = tokens.join(' ');
+        if (!tokens.length || uniqTexts.has(key)) return;
+        uniqTexts.add(key);
+        indexableText.push(tokens);
+    }
+    return indexableText;
 }
 
 function parseSemiNumber(_) {

--- a/test/unit/indexer/index.test.js
+++ b/test/unit/indexer/index.test.js
@@ -67,7 +67,7 @@ test('index.generateStats', (t) => {
         geometry: {}
     }];
     const geocoder_tokens = token.createReplacer({ 'street':'st','road':'rd' });
-    t.deepEqual(indexdocs.generateFrequency(docs, {}), {
+    t.deepEqual(indexdocs.generateFrequency(docs, token.createReplacer({})), {
         __COUNT__: [4],
         __MAX__: [2],
         main: [2],
@@ -76,13 +76,11 @@ test('index.generateStats', (t) => {
     });
     // @TODO should 'main' in this case collapse down to 2?
     t.deepEqual(indexdocs.generateFrequency(docs, geocoder_tokens), {
-        __COUNT__: [8],
+        __COUNT__: [4],
         __MAX__: [2],
-        main: [4],
+        main: [2],
         rd: [1],
-        st: [1],
-        street: [1],
-        road: [1]
+        st: [1]
     });
     t.end();
 });

--- a/test/unit/indexer/indexdocs.test.js
+++ b/test/unit/indexer/indexdocs.test.js
@@ -474,7 +474,7 @@ tape('indexdocs.generateFrequency', (t) => {
         geometry: {}
     }];
     const geocoder_tokens = token.createReplacer({ 'street':'st','road':'rd' });
-    t.deepEqual(indexdocs.generateFrequency(docs, {}), {
+    t.deepEqual(indexdocs.generateFrequency(docs, token.createReplacer({})), {
         __COUNT__: [4],
         __MAX__: [2],
         main: [2],
@@ -483,13 +483,11 @@ tape('indexdocs.generateFrequency', (t) => {
     });
     // @TODO should 'main' in this case collapse down to 2?
     t.deepEqual(indexdocs.generateFrequency(docs, geocoder_tokens), {
-        __COUNT__: [8],
+        __COUNT__: [4],
         __MAX__: [2],
-        main: [4],
+        main: [2],
         rd: [1],
-        st: [1],
-        street: [1],
-        road: [1]
+        st: [1]
     });
     t.end();
 });

--- a/test/unit/text-processing/termops.getMinimalIndexableText.test.js
+++ b/test/unit/text-processing/termops.getMinimalIndexableText.test.js
@@ -1,0 +1,79 @@
+'use strict';
+const termops = require('../../../lib/text-processing/termops');
+const token = require('../../../lib/text-processing/token');
+const test = require('tape');
+
+test('termops.getMinimalIndexableText', (t) => {
+    let replacer;
+    let doc;
+    let texts;
+
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'Main Street' } };
+    texts = [
+        ['main', 'street']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'creates indexableText');
+
+    replacer = token.createReplacer({ 'Street':'St' });
+    doc = { properties: { 'carmen:text': 'Main Street' } };
+    texts = [
+        ['main', 'st']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'creates contracted phrases using geocoder_tokens');
+
+    replacer = token.createReplacer({ 'Street':'St' });
+    doc = { properties: { 'carmen:text': 'Main Street, main st' } };
+    texts = [
+        ['main', 'st']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'dedupes phrases');
+
+    replacer = token.createReplacer({ 'Street':'St', 'Lane':'Ln' });
+    doc = { properties: { 'carmen:text': 'Main Street Lane' } };
+    texts = [
+        ['main', 'st', 'ln']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'dedupes phrases');
+
+    replacer = token.createReplacer({ 'dix-huitième':'18e' });
+    doc = { properties: { 'carmen:text': 'Avenue du dix-huitième régiment' } };
+    texts = [['avenue', 'du', '18e', 'régiment']];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'hypenated replacement');
+
+    replacer = token.createReplacer({});
+    doc = {
+        properties: {
+            'carmen:text':'Main Street',
+            'carmen:addressnumber': [[1, 10, 100, 200]]
+        }
+    };
+    texts = [
+        ['2##', 'main', 'street'],
+        ['1##', 'main', 'street'],
+        ['##', 'main', 'street'],
+        ['#', 'main', 'street'],
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [],  doc), texts, 'with range');
+
+    // sets indexDegens to false for translated text
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'Main Street', 'carmen:text_es': 'El Main Street' } };
+    texts = [
+        ['main', 'street'],
+        ['el', 'main', 'street']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'creates indexableText');
+
+    // doesn't indexDegens for synonyms
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'Latveria,Republic of Latveria' } };
+    texts = [
+        ['latveria'],
+        ['republic', 'of', 'latveria']
+    ];
+    t.deepEqual(termops.getMinimalIndexableText(replacer, [], doc), texts, 'creates indexableText w/ synonyms');
+
+    t.end();
+});
+


### PR DESCRIPTION
### Context
This branch makes a couple of changes meant to simplify index-time computation and speed up builds a bit. Nothing here is earth-shattering, but should be incrementally useful.


### Summary of Changes
- [x] only generate housenumber ranges once per document, rather than once per synonym and token replacement variant -- the properties used to decide what to generate here don't change along these axes and we were generating the same housenumber range over and over for no reason
- [x] introduce `termops.getMinimalIndexableText` with accompanying tests -- this is basically a forward port of what `getIndexableText` used to be before the introduction of language-aware text indexing and multiple indexing of token variants. In the course of indexing we end up calling `getIndexableText` twice, once at the beginning to generate a term frequency model which we later use to generate text variants of feature names with high-frequency words dropped from them, and again to actually index the text (using the term frequency model from the first run to decide which additional phrases to generate for each document in the second). Most of the complexity that has been added to this function over time has been to benefit the second run -- the first run pays no attention to languages, and doesn't benefit from multiple-indexing of variants (and in fact may suffer somewhat from it). Here we reintroduce the old way of performing this operation and use it on the frequency pass.


### Next Steps
Nope


cc @mapbox/geocoding-gang
