### PR TITLE
Slightly penalize address matches with no housenumbers, and update te…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,4 +85,3 @@ workflows:
         jobs:
             - node6
             - node8
-            - node10

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -174,6 +174,13 @@ module.exports = function phrasematch(source, query, options, callback) {
             );
         }
 
+        // we expect addresses typically to have house numbers
+        // if this is an address but has no house number, penalize it with respect
+        // to other kinds of matches
+        if (source.geocoder_address && !/#/.test(phrase)) {
+            editMultiplier *= .99;
+        }
+
         const prefix = (subquery.ender && !(source.geocoder_address && termops.isAddressNumber(subquery)));
 
         phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages, editMultiplier));

--- a/test/acceptance/geocode-unit.address-format.test.js
+++ b/test/acceptance/geocode-unit.address-format.test.js
@@ -243,7 +243,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
     tape('Search for an address without a number (multiple layers)', (t) => {
         c.geocode('fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.deepEquals(res,  { 'type':'FeatureCollection','query':['fake','street'],'features':[{ 'id':'address.1','type':'Feature','text':'fake street','place_name':'fake street springfield, maine 12345, united states','relevance':1.0,'place_type': ['address'],'properties':{},'center':[0,0],'geometry':{ 'type':'GeometryCollection','geometries':[{ 'type':'MultiPoint','coordinates':[[0,0],[0,0],[0,0]] }] },'context':[{ 'id':'place.1','text':'springfield' },{ 'id':'postcode.1','text':'12345' },{ 'id':'region.1','text':'maine' },{ 'id':'country.1','text':'united states' }] }] });
+            t.deepEquals(res,  { 'type':'FeatureCollection','query':['fake','street'],'features':[{ 'id':'address.1','type':'Feature','text':'fake street','place_name':'fake street springfield, maine 12345, united states','relevance':0.99,'place_type': ['address'],'properties':{},'center':[0,0],'geometry':{ 'type':'GeometryCollection','geometries':[{ 'type':'MultiPoint','coordinates':[[0,0],[0,0],[0,0]] }] },'context':[{ 'id':'place.1','text':'springfield' },{ 'id':'postcode.1','text':'12345' },{ 'id':'region.1','text':'maine' },{ 'id':'country.1','text':'united states' }] }] });
             t.end();
         });
     });
@@ -308,7 +308,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
     tape('test address index for DE relev', (t) => {
         c.geocode('fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 1.00);
+            t.equals(res.features[0].relevance, 0.99);
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.backy.test.js
+++ b/test/acceptance/geocode-unit.backy.test.js
@@ -72,7 +72,7 @@ tape('lessingstrasse koln 50825', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'lessingstrasse, koln, 50825');
         t.deepEqual(res.features[0].id, 'street.1');
-        t.deepEqual(res.features[0].relevance, 1);
+        t.assert(1 - res.features[0].relevance < .01);
         t.end();
     });
 });
@@ -81,7 +81,7 @@ tape('lessingstrasse 50825 koln', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'lessingstrasse, koln, 50825');
         t.deepEqual(res.features[0].id, 'street.1');
-        t.deepEqual(res.features[0].relevance, 0.8333333333333333);
+        t.deepEqual(res.features[0].relevance, 0.83);
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.debug.test.js
+++ b/test/acceptance/geocode-unit.debug.test.js
@@ -99,9 +99,9 @@ tape('west st, tonawanda, ny', (t) => {
 
         // Found debug feature in spatialmatch results @ position 1
         t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
-        t.deepEqual(res.debug.spatialmatch.covers[0].relev, 0.3333333333333333);
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[0].relev < .01);
         t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
-        t.deepEqual(res.debug.spatialmatch.covers[1].relev, 0.3333333333333333);
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[1].relev < .01);
         t.deepEqual(res.debug.spatialmatch_position, 1);
 
         // Debug feature not found in verifymatch
@@ -134,11 +134,11 @@ tape('west st, tonawanda, ny', (t) => {
         // Found debug feature in spatialmatch results @ position 1
         t.deepEqual(res.debug.spatialmatch.covers[0].id, 5);
         t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
-        t.deepEqual(res.debug.spatialmatch.covers[0].relev, 0.3333333333333333);
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[0].relev < .01);
         t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
-        t.deepEqual(res.debug.spatialmatch.covers[1].relev, 0.3333333333333333);
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[1].relev < .01);
         t.deepEqual(res.debug.spatialmatch.covers[2].text, 'tonawanda');
-        t.deepEqual(res.debug.spatialmatch.covers[2].relev, 0.3333333333333333);
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[2].relev < .01);
         t.deepEqual(res.debug.spatialmatch_position, 0);
 
         // Debug feature not found in verifymatch

--- a/test/acceptance/geocode-unit.fuzzy.test.js
+++ b/test/acceptance/geocode-unit.fuzzy.test.js
@@ -209,7 +209,7 @@ tape('build queued features', (t) => {
 });
 
 tape('100 main st washington dc - without fuzzy', (t) => {
-    complex.geocode('100 Main St washington dc', { limit_verify: 2, autocomplete: true, fuzzyMatch: false }, (err, res) => {
+    complex.geocode('100 Main St washington dc', { limit_verify: 2, autocomplete: true, fuzzyMatch: false, types: ['address'] }, (err, res) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
         t.deepEqual(res.features[0].id, 'address.100');

--- a/test/acceptance/geocode-unit.order.test.js
+++ b/test/acceptance/geocode-unit.order.test.js
@@ -116,7 +116,7 @@ tape('Log Cabin Ln North Carolina Winston-Salem', (t) => {
     c.geocode('Log Cabin Ln North Carolina Winston-Salem', { limit_verify: 2 }, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].text, 'Log Cabin Ln', 'ok when query order is mixed up');
-        t.equal(res.features[0].relevance, 0.8333333333333333, 'Mixed-up order lowers relevance');
+        t.equal(res.features[0].relevance, 0.83, 'Mixed-up order lowers relevance');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.stacky.test.js
+++ b/test/acceptance/geocode-unit.stacky.test.js
@@ -74,7 +74,7 @@ tape('windsor court windsor', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'windsor court, windsor');
         t.deepEqual(res.features[0].id, 'street.1');
-        t.deepEqual(res.features[0].relevance, 1);
+        t.deepEqual(res.features[0].relevance, 0.995);
         t.end();
     });
 });


### PR DESCRIPTION
…st fixtures accordingly

### Context
This PR introduces a slight penalty for matches within address indexes that don't contain housenumbers. Given a match for `bakery`, it's more likely to be intended to refer to bakeries than `bakery street`.


### Summary of Changes
- [x] add penalty
- [x] update tests


### Next Steps
No


cc @mapbox/geocoding-gang
