### PR TITLE
handle nonmatching text with hyphens

### DIFF
--- a/lib/text-processing/closest-lang.js
+++ b/lib/text-processing/closest-lang.js
@@ -59,7 +59,12 @@ const getLanguage = function(str) {
             }
             if (obj) match.push(obj);
         });
-        return match;
+        if (match.length > 0) {
+            return match;
+        } else {
+            // there was a string with a hyphen in it but it still didn't match anything
+            return false
+        }
     }
     return false;
 };

--- a/test/acceptance/geocode-unit.language-flag.test.js
+++ b/test/acceptance/geocode-unit.language-flag.test.js
@@ -242,6 +242,14 @@ const addFeature = require('../../lib/indexer/addfeature'),
         });
     });
 
+    // return nothing on nonexistent with hyphen in string
+    tape('Rossiyskaya => Russian Federation - {language: "nonexistent-nonexistent"}', (t) => {
+        c.geocode('Russian Federation', { limit_verify:1, language: 'nonexistent-nonexistent' }, (err, res) => {
+            t.ok(err, 'throws error');
+            t.end();
+        });
+    });
+
     // also 'translate' the context when available
     tape('St Petersburg => Санкт-Петербу́рг, Северо-Западный федеральный округ, Российская Федерация - {language: "ru"}', (t) => {
         c.geocode('St Petersburg', { language: 'ru' }, (err, res) => {

--- a/test/unit/text-processing/closest-lang.test.js
+++ b/test/unit/text-processing/closest-lang.test.js
@@ -115,7 +115,7 @@ tape('handle nonmatching text with hypens', (t) => {
 
     const bad = 'عربى - السعودية';
 
-    t.equal(closestLangLabel.getLanguage(bad), false);
+    t.equal(closestLangLabel(bad, {'en': 'English'}), undefined, 'non-matching strings that happen to have hyphens should return undefined');
 
     t.end();
 });

--- a/test/unit/text-processing/closest-lang.test.js
+++ b/test/unit/text-processing/closest-lang.test.js
@@ -110,3 +110,12 @@ tape('serbian fallbacks', (t) => {
 
     t.end();
 });
+
+tape('handle nonmatching text with hypens', (t) => {
+
+    const bad = 'عربى - السعودية';
+
+    t.equal(closestLangLabel.getLanguage(bad), false);
+
+    t.end();
+});


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
fixes #730 

### Summary of Changes
- [x] when checking for matches in hyphenated strings, first check to make sure `matches` has length > 0 before returning


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/geocoding-gang
