### PR TITLE
Fuzzy length limit

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -22,7 +22,6 @@ module.exports = function phrasematch(source, query, options, callback) {
     options.autocomplete = !!(options.autocomplete || false);
     options.bbox = options.bbox || false;
     options.fuzzyMatch = options.fuzzyMatch === undefined ? true : !!options.fuzzyMatch;
-    const maxDistance = options.fuzzyMatch ? 1 : 0;
 
     // if requested country isn't included, skip
     if (options.stacks) {
@@ -41,6 +40,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     const tokenized = termops.tokenize(
         termops.encodableText(token.replaceToken(source.token_replacer, query))
     );
+    const maxDistance = (options.fuzzyMatch && tokenized.length <= 8) ? 1 : 0;
 
     let subqueries;
     if (!source.geocoder_address) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",
-    "@mapbox/node-fuzzy-phrase": "0.1.2",
+    "@mapbox/node-fuzzy-phrase": "0.1.3",
     "@mapbox/sphericalmercator": "^1.1.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,9 +155,9 @@
     d3-queue "~2.0.3"
     sqlite3 "4.x"
 
-"@mapbox/node-fuzzy-phrase@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-fuzzy-phrase/-/node-fuzzy-phrase-0.1.2.tgz#ff55998da5a25432238735fb48e607bb620d815d"
+"@mapbox/node-fuzzy-phrase@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-fuzzy-phrase/-/node-fuzzy-phrase-0.1.3.tgz#f4622dbbb5bd527c9f6b8b3c0065a93c5446ca71"
   dependencies:
     "@mapbox/cfn-config" "^2.15.0"
     "@mapbox/cloudfriend" "^1.9.1"


### PR DESCRIPTION
### Context
The fuzzy search work that landed in #719 introduced the possibility for higher latency in some classes of queries. This PR restricts the circumstances in which fuzzy matching is applied to achieve better performance.


### Summary of Changes
- [x] disable fuzzy matching on queries longer than eight tokesn
- [x] switch to a new release of node-fuzzy-phrase that does not attempt to fuzzy-match one-letter words (this is in addition to previously added performance mitigations around short words introduced in #727).


### Next Steps
- [ ] merge/release


cc @mapbox/geocoding-gang
