### PR TITLE
Switch to node-fuzzy-phrase@no-mmap

### DIFF
--- a/lib/text-processing/closest-lang.js
+++ b/lib/text-processing/closest-lang.js
@@ -63,7 +63,7 @@ const getLanguage = function(str) {
             return match;
         } else {
             // there was a string with a hyphen in it but it still didn't match anything
-            return false
+            return false;
         }
     }
     return false;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",
-    "@mapbox/node-fuzzy-phrase": "0.1.3",
+    "@mapbox/node-fuzzy-phrase": "https://github.com/mapbox/node-fuzzy-phrase/tarball/cd06f1d930c0a924718c17bb40ff317c813573eb",
     "@mapbox/sphericalmercator": "^1.1.0",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",

--- a/test/unit/text-processing/closest-lang.test.js
+++ b/test/unit/text-processing/closest-lang.test.js
@@ -115,7 +115,7 @@ tape('handle nonmatching text with hypens', (t) => {
 
     const bad = 'عربى - السعودية';
 
-    t.equal(closestLangLabel(bad, {'en': 'English'}), undefined, 'non-matching strings that happen to have hyphens should return undefined');
+    t.equal(closestLangLabel(bad, { 'en': 'English' }), undefined, 'non-matching strings that happen to have hyphens should return undefined');
 
     t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,9 +155,9 @@
     d3-queue "~2.0.3"
     sqlite3 "4.x"
 
-"@mapbox/node-fuzzy-phrase@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-fuzzy-phrase/-/node-fuzzy-phrase-0.1.3.tgz#f4622dbbb5bd527c9f6b8b3c0065a93c5446ca71"
+"@mapbox/node-fuzzy-phrase@https://github.com/mapbox/node-fuzzy-phrase/tarball/cd06f1d930c0a924718c17bb40ff317c813573eb":
+  version "0.1.3-no-mmap"
+  resolved "https://github.com/mapbox/node-fuzzy-phrase/tarball/cd06f1d930c0a924718c17bb40ff317c813573eb#1130b14e21a1433f65a764f1bde837b1bd55f452"
   dependencies:
     "@mapbox/cfn-config" "^2.15.0"
     "@mapbox/cloudfriend" "^1.9.1"


### PR DESCRIPTION
### Context
We're observing some potential issues with warmup time in production, and are investigating whether or not using mmap'ed IO is contributing to them. This branch switches to a node-fuzzy-phrase branch that's been rebuilt not to use mmap; see https://github.com/mapbox/node-fuzzy-phrase/pull/14 .


### Summary of Changes
- [x] switch to node-fuzzy-phrase@no-mmap
- [x] fix some linting errors that somehow made it into master


### Next Steps
- [ ] if we proceed, merge underlying PRs and switch to a released node-fuzzy-phrase


cc @mapbox/geocoding-gang
