### PR TITLE
Fix linting enforcement on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ step-library:
       run:
           name: Install apt dependencies
           command: |
-            set +e
             apt-get update -y
             apt-get install -y build-essential python git curl
             curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
@@ -17,7 +16,6 @@ step-library:
       run:
           name: Install node
           command: |
-            set +e
             echo 'export NVM_DIR=${HOME}/.nvm' >> $BASH_ENV
             source ${BASH_ENV}
             mkdir -p ${NVM_DIR}
@@ -31,14 +29,12 @@ step-library:
       run:
           name: "Yarn install"
           command: |
-            set +e
             yarn install
 
   - &yarn-test
       run:
           name: "Yarn lint/coverage/bench"
           command: |
-            set +e
             yarn run lint
             yarn run coverage
             yarn run bench


### PR DESCRIPTION
### Context
#723 refactored are Circle tests, and part of the refactor introduced `set +e` commands to several sequences of instructions in the pipeline. The effect of these commands was to cause the entire CI pipeline to show up as failed only if the last command in the sequence failed, rather than if any of them failed, so we were not properly enforcing linting (or, for that matter, tests 😨 ) -- only the step confirming that the benchmarks run was determining CI success or failure.

This branch fixes that problem, and I made two other temporary branches that I'll delete after merge of this one, https://github.com/mapbox/carmen/tree/break-linting-on-purpose and https://github.com/mapbox/carmen/tree/break-tests-on-purpose , to confirm that linting and tests, respectively, appropriately cause Circle tests to fail given this change.

Fixes #736 

### Summary of Changes
- [x] fix Circle linting and test passage enforcement by removing `set +e`


### Next Steps
No

cc @mapbox/geocoding-gang
