### PR TITLE
Switch to carmen-cache@reduce-x-language-penalty

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.21.4",
+    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/66407c9be35d599a4cb876e40a4daf06df293bcf",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "https://github.com/mapbox/carmen-cache/tarball/66407c9be35d599a4cb876e40a4daf06df293bcf",
+    "@mapbox/carmen-cache": "0.21.5",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/acceptance/geocode-unit.localtext.test.js
+++ b/test/acceptance/geocode-unit.localtext.test.js
@@ -110,7 +110,7 @@ tape('Российская => Russian Federation (autocomplete without language 
         t.ifError(err);
         t.deepEqual(res.features.length, 1, '1 result');
         t.deepEqual(res.features[0].place_name, 'Russian Federation');
-        t.ok(res.features[0].relevance <= .9, 'Relevance penalty was applied for out-of-language match');
+        t.ok(res.features[0].relevance <= .96, 'Relevance penalty was applied for out-of-language match');
         t.deepEqual(res.features[0].id, 'country.2');
         t.deepEqual(res.features[0].id, 'country.2');
         t.end();
@@ -135,7 +135,7 @@ tape('Российская => Российская Федерация (autocompl
         t.ifError(err);
         t.deepEqual(res.features.length, 1, '1 result');
         t.deepEqual(res.features[0].place_name, 'Russian Federation');
-        t.ok(res.features[0].relevance <= .9, 'Relevance penalty was applied for out-of-language match');
+        t.ok(res.features[0].relevance <= .96, 'Relevance penalty was applied for out-of-language match');
         t.deepEqual(res.features[0].place_name_ru, 'Российская Федерация');
         t.deepEqual(res.features[0].id, 'country.2');
         t.end();

--- a/test/acceptance/geocode-unit.promote-language.test.js
+++ b/test/acceptance/geocode-unit.promote-language.test.js
@@ -104,7 +104,7 @@ tape('find new york', (t) => {
 tape('find nueva york, language=es', (t) => {
     c.geocode('nueva york usa', { language: 'es' }, (err, res) => {
         t.equal(res.features[0].id, 'place.1');
-        t.equal(res.features[0].relevance, 0.95, "query has penalty applied because 'usa' has no es translation");
+        t.equal(res.features[0].relevance, 0.98, "query has penalty applied because 'usa' has no es translation");
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.translation-noauto.test.js
+++ b/test/acceptance/geocode-unit.translation-noauto.test.js
@@ -72,7 +72,7 @@ const runTests = (mode) => {
 
             t.deepEqual(res.features[1].place_name, 'South Carolina', 'found: South Carolina (in second place)');
             t.deepEqual(res.features[1].id, 'region.1');
-            t.ok(res.features[0].relevance - res.features[1].relevance >= 0.05, 'South Carolina has a relevance penalty vs. Delaware');
+            t.ok(res.features[0].relevance - res.features[1].relevance > 0, 'South Carolina has a relevance penalty vs. Delaware');
 
             t.end();
         });
@@ -86,7 +86,7 @@ const runTests = (mode) => {
 
             t.deepEqual(res.features[1].place_name, 'South Carolina', 'found: South Carolina (in second place)');
             t.deepEqual(res.features[1].id, 'region.1');
-            t.ok(res.features[0].relevance - res.features[1].relevance >= 0.05, 'South Carolina has a relevance penalty vs. Delaware');
+            t.ok(res.features[0].relevance - res.features[1].relevance > 0, 'South Carolina has a relevance penalty vs. Delaware');
 
             t.end();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,9 +89,9 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-cache@0.21.4":
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.21.4.tgz#e4553ce52c420f9786ddbd2c025c4efb64d53ccc"
+"@mapbox/carmen-cache@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.21.5.tgz#b1cc3f8bf76f112675d0a14f593ec8c2dc0f9f73"
   dependencies:
     nan "~2.10.0"
     node-pre-gyp "~0.10.1"


### PR DESCRIPTION
### Context
This PR switches to carmen-cache@reduce-x-language-penalty, which decreases the penalty applied to out-of-language matches in coalesce from 10% to 4%, and update tests accordingly for new, higher relevance values.

The motivation was newfound interactions between the previous penalty and new, lower penalties introduced as part of the fuzzy search push. This allowed for circumstances where fuzzy matches would beat correctly spelled matches that were out of language, and in testing this seemed not to conform with user expectations.


### Summary of Changes
- [x] switch to carmen-cache@reduce-x-language-penalty
- [x] update tests with new relevance numbers


### Next Steps
- [x] test with upstream packages that depend on carmen
- [x] if test results look okay, merge mapbox/carmen-cache#128, publish a new binary, and cut a release to npm
- [x] switch to released carmen-cache
- [ ] merge this PR, and release


cc @mapbox/geocoding-gang
