### PR TITLE
Proximity test fix

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -107,7 +107,6 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 * @returns filtered - sorted and verified features
 */
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
-    let meanScore = 1;
     const result = [];
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
@@ -184,7 +183,6 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             feat.properties['carmen:spatialmatch'] = spatialmatch;
             feat.properties['carmen:geocoder_address_order'] = source.geocoder_address_order;
             feat.properties['carmen:zoom'] = cover.zoom;
-            if (feat.properties['carmen:score'] > 0) meanScore *= feat.properties['carmen:score'];
             result.push(feat);
         }
     }
@@ -192,7 +190,8 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     // Use a geometric mean for calculating final _scoredist.
     // This allows extremely high-scored outliers to beat local
     // results unless within an extremely close proximity.
-    if (result.length) meanScore = Math.pow(meanScore, 1 / result.length);
+    const meanScore = proximity.meanScore(result);
+
     // Set a score + distance combined heuristic.
     for (let k = 0; k < result.length; k++) {
         const feat = result[k];

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -13,6 +13,7 @@ module.exports.distance = distance;
 module.exports.center2zxy = center2zxy;
 module.exports.scoredist = scoredist;
 module.exports.distscore = distscore;
+module.exports.meanScore = meanScore;
 
 /**
  * distance - Return the distance in miles between a proximity point and a feature.
@@ -67,13 +68,12 @@ function center2zxy(center, z) {
 
 /**
  * Combines score and distance into a single score that can be used for sorting.
- *
  * The radius of effect is scaled to the zoom level of the feature tile, ranging from
- * 40 miles at z14 to 360 miles at z6. This value scales linearly, while tile size scales
+ * 200 miles at z14 to 1,800 miles at z6. This value scales linearly, while tile size scales
  * exponentially, so the effect is relatively stronger at higher zoom levels.
  *
  * @param {Number} meanScore The geometric mean of the scores of the top 20 features.
- * @param {Number} dist The distance from the feature to the proximity point.
+ * @param {Number} dist The distance from the feature to the proximity point in miles.
  * @param {Number} zoom The index zoom level this scoredist is being calculated for.
  * @param {Number} radius Radius (in miles) to apply the scoredist
  * @return {Number} proximity adjusted score value
@@ -91,11 +91,23 @@ function scoredist(meanScore, dist, zoom, radius) {
 
 /**
  * Similar to `scoredist`, used for including score + distance when sorting features returned by a reverse query.
- *
  * @param {Number} dist The distance in meters from the feature to the query point
  * @param {Number} score The feature's score
  * @return {Number} distance-adjusted score value
  */
 function distscore(dist, score) {
-    return Math.round(score * (1000 / (Math.max(dist,50))) * 10000) / 10000;
+    return Math.round(score * (1000 / (Math.max(dist, 50))) * 10000) / 10000;
+}
+
+/**
+ * Calculate the geometric mean of features' carmen:score
+ * @param {Array} features An array of carmen geojson feature objects
+ * @return {Number} meanScore - geometric mean
+ */
+function meanScore(features) {
+    const scoreProduct = features.reduce((scoreProduct, feat) => {
+        if (isNaN(feat.properties['carmen:score'])) throw new Error('carmen:score is not a number');
+        return scoreProduct * Math.max(feat.properties['carmen:score'], 1);
+    }, 1);
+    return Math.pow(scoreProduct, 1 / features.length);
 }

--- a/test/unit/util/proximity.meanScore.test.js
+++ b/test/unit/util/proximity.meanScore.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const meanScore = require('../../../lib/util/proximity').meanScore;
+const test = require('tape');
+
+test('find the geometric mean of 2 and 8', (t) => {
+    const input = [{
+        properties: { 'carmen:score': 2 }
+    },
+    {
+        properties: { 'carmen:score': 8 }
+    }];
+
+    t.equal(meanScore(input), 4, 'geometric mean of 2 and 8 is 4');
+    t.end();
+});
+
+test('find the geometric mean of 2 and 8', (t) => {
+    const input = [{
+        properties: { 'carmen:score': 0 }
+    },
+    {
+        properties: { 'carmen:score': 4 }
+    }];
+
+    t.equal(meanScore(input), 2, 'geometric mean of 0 and 4 is 2');
+    t.end();
+});
+
+test('throw an error if carmen:score is not a number', (t) => {
+    const input = [{
+        properties: { 'carmen:score': undefined }
+    },
+    {
+        properties: { 'carmen:score': 4 }
+    }];
+
+    t.throws(() => {
+        meanScore(input);
+    }, /carmen:score is not a number/);
+    t.end();
+});

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -1,5 +1,7 @@
 'use strict';
 const test = require('tape');
+const constants = require('../../../lib/constants');
+const proximity = require('../../../lib/util/proximity');
 
 const ZOOM_LEVELS = {
     address: 14,
@@ -8,11 +10,12 @@ const ZOOM_LEVELS = {
     region: 6,
     district: 9
 };
-const constants = require('../../../lib/constants');
-const scoredist = require('../../../lib/util/proximity').scoredist;
 
-function compare(a, b) {
-    return scoredist(b.score, b.distance, b.zoom, constants.PROXIMITY_RADIUS) - scoredist(a.score, a.distance, a.zoom, constants.PROXIMITY_RADIUS);
+
+function compareCreator(meanScore) {
+    return function compare(a, b) {
+        return proximity.scoredist(meanScore, b.properties.distance, b.properties.zoom, constants.PROXIMITY_RADIUS) - proximity.scoredist(meanScore, a.properties.distance, a.properties.zoom, constants.PROXIMITY_RADIUS);
+    };
 }
 
 test('scoredist', (t) => {
@@ -20,112 +23,127 @@ test('scoredist', (t) => {
     t.test('new york', (t) => {
         // --query="new york" --proximity="-122.4234,37.7715"
         const input = [
-            { text: 'New York,NY', distance: 2426.866703400975, score: 79161, zoom: ZOOM_LEVELS.region },
-            { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, score: 31104, zoom: ZOOM_LEVELS.place },
-            { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, score: 3, zoom: ZOOM_LEVELS.poi },
-            { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, score: 1, zoom: ZOOM_LEVELS.poi },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi } },
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi } },
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region } }
         ];
+
+        const meanScore = proximity.meanScore(input);
+
         const expected = [
-            { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, score: 3, zoom: ZOOM_LEVELS.poi },
-            { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, score: 1, zoom: ZOOM_LEVELS.poi },
-            { text: 'New York,NY', distance: 2426.866703400975, score: 79161, zoom: ZOOM_LEVELS.region },
-            { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, score: 31104, zoom: ZOOM_LEVELS.place },
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi } },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('chicago near san francisco', (t) => {
         // --query="chicago" --proximity="-122.4234,37.7715"
+        const meanScore = 1;
+
         const input = [
-            { text: 'Chicago', distance: 1855.8900334142313, score: 16988, zoom: ZOOM_LEVELS.place },
-            { text: 'Chicago Title', distance: 0.14084037845690478, score: 2, zoom: ZOOM_LEVELS.poi }
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi } }
         ];
         const expected = [
-            { text: 'Chicago Title', distance: 0.14084037845690478, score: 2, zoom: ZOOM_LEVELS.poi },
-            { text: 'Chicago', distance: 1855.8900334142313, score: 16988, zoom: ZOOM_LEVELS.place }
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi } },
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('san near north sonoma county', (t) => {
         // --query="san" --proximity="-123.0167,38.7471"
+
+        const meanScore = 1;
         const input = [
-            { text: 'São Paulo', distance: 6547.831697209755, score: 36433, zoom: ZOOM_LEVELS.place },
-            { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, score: 26709, zoom: ZOOM_LEVELS.place },
-            { text: 'San Francisco', distance: 74.24466022598429, score: 8015, zoom: ZOOM_LEVELS.place },
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place } }
         ];
         const expected = [
-            { text: 'San Francisco', distance: 74.24466022598429, score: 8015, zoom: ZOOM_LEVELS.place },
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
-            { text: 'São Paulo', distance: 6547.831697209755, score: 36433, zoom: ZOOM_LEVELS.place },
-            { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, score: 26709, zoom: ZOOM_LEVELS.place },
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('santa cruz near sonoma county', (t) => {
         // --query="santa cruz" --proximity="-123.0167,38.7471"
+        const meanScore = 1;
+
         const input = [
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
-            { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, score: 3456, zoom: ZOOM_LEVELS.place }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place } }
         ];
         const expected = [
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
-            { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, score: 3456, zoom: ZOOM_LEVELS.place }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('washington near baltimore', (t) => {
         // --query="washington" --proximity="-76.6035,39.3008"
+        const meanScore = 1;
+
         const input = [
-            { text: 'District of Columbia,DC', distance: 34.81595024835296, score: 7429, zoom: ZOOM_LEVELS.place },
-            { text: 'Washington,WA', distance: 2256.6130314083157, score: 33373, zoom: ZOOM_LEVELS.region }
+            { properties: { text: 'District of Columbia,DC', distance: 34.81595024835296, 'carmen:score': 7429, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region } }
         ];
         const expected = [
-            { text: 'District of Columbia,DC', distance: 34.81595024835296, score: 7429, zoom: ZOOM_LEVELS.place },
-            { text: 'Washington,WA', distance: 2256.6130314083157, score: 33373, zoom: ZOOM_LEVELS.region }
+            { properties: { text: 'District of Columbia,DC', distance: 34.81595024835296, 'carmen:score': 7429, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('gilmour ave near guelph, on, canada', (t) => {
         // --query="gilmour ave" --proximity="-80.1617,43.4963"
+        const meanScore = 1;
+
         const input = [
-            { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, score: 3, zoom: ZOOM_LEVELS.address },
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address } }
         ];
         const expected = [
-            { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, score: 0, zoom: ZOOM_LEVELS.address },
-            { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, score: 3, zoom: ZOOM_LEVELS.address },
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
     t.test('cambridge near guelph, on, canada', (t) => {
         // --query="cambridge" --proximity="-80.1617,43.4963"
+        const meanScore = 1;
+
         const input = [
-            { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, score: 294, zoom: ZOOM_LEVELS.place },
-            { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, score: 986, zoom: ZOOM_LEVELS.place },
-            { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, score: 2721, zoom: ZOOM_LEVELS.district },
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district } }
         ];
         const expected = [
-            { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, score: 294, zoom: ZOOM_LEVELS.place },
-            { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, score: 986, zoom: ZOOM_LEVELS.place },
-            { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, score: 2721, zoom: ZOOM_LEVELS.district },
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district } }
         ];
-        t.deepEqual(input.sort(compare), expected);
+        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
         t.end();
     });
 
@@ -138,10 +156,10 @@ test('zoom weighting', (t) => {
     const score = 1000;
     const distance = 30; // miles
 
-    t.deepEqual(scoredist(score, distance, 6, 40), 84027.7778, 'zoom 6');
-    t.deepEqual(scoredist(score, distance, 8, 40), 79719.3878, 'zoom 8');
-    t.deepEqual(scoredist(score, distance, 10, 40), 72250, 'zoom 10');
-    t.deepEqual(scoredist(score, distance, 12, 40), 56250, 'zoom 12');
-    t.deepEqual(scoredist(score, distance, 14, 40), 6250, 'zoom 14');
+    t.deepEqual(proximity.scoredist(score, distance, 6, 40), 84027.7778, 'zoom 6');
+    t.deepEqual(proximity.scoredist(score, distance, 8, 40), 79719.3878, 'zoom 8');
+    t.deepEqual(proximity.scoredist(score, distance, 10, 40), 72250, 'zoom 10');
+    t.deepEqual(proximity.scoredist(score, distance, 12, 40), 56250, 'zoom 12');
+    t.deepEqual(proximity.scoredist(score, distance, 14, 40), 6250, 'zoom 14');
     t.end();
 });

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -1,88 +1,131 @@
 'use strict';
 const test = require('tape');
 
+const ZOOM_LEVELS = {
+    address: 14,
+    poi: 14,
+    place: 12,
+    region: 6,
+    district: 9
+};
+const constants = require('../../../lib/constants');
 const scoredist = require('../../../lib/util/proximity').scoredist;
 
 function compare(a, b) {
-    return scoredist(b.score, b.distance) - scoredist(a.score, a.distance);
+    return scoredist(b.score, b.distance, b.zoom, constants.PROXIMITY_RADIUS) - scoredist(a.score, a.distance, a.zoom, constants.PROXIMITY_RADIUS);
 }
 
 test('scoredist', (t) => {
 
     t.test('new york', (t) => {
         // --query="new york" --proximity="-122.4234,37.7715"
-        const expected = [
-            { text: 'New York,NY', distance: 2426.866703400975, score: 79161 },
-            { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, score: 31104 },
-            { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, score: 3 },
-            { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, score: 1 },
+        const input = [
+            { text: 'New York,NY', distance: 2426.866703400975, score: 79161, zoom: ZOOM_LEVELS.region },
+            { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, score: 31104, zoom: ZOOM_LEVELS.place },
+            { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, score: 3, zoom: ZOOM_LEVELS.poi },
+            { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, score: 1, zoom: ZOOM_LEVELS.poi },
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, score: 3, zoom: ZOOM_LEVELS.poi },
+            { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, score: 1, zoom: ZOOM_LEVELS.poi },
+            { text: 'New York,NY', distance: 2426.866703400975, score: 79161, zoom: ZOOM_LEVELS.region },
+            { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, score: 31104, zoom: ZOOM_LEVELS.place },
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('chicago near san francisco', (t) => {
         // --query="chicago" --proximity="-122.4234,37.7715"
-        const expected = [
-            { text: 'Chicago', distance: 1855.8900334142313, score: 16988 },
-            { text: 'Chicago Title', distance: 0.14084037845690478, score: 2 }
+        const input = [
+            { text: 'Chicago', distance: 1855.8900334142313, score: 16988, zoom: ZOOM_LEVELS.place },
+            { text: 'Chicago Title', distance: 0.14084037845690478, score: 2, zoom: ZOOM_LEVELS.poi }
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'Chicago Title', distance: 0.14084037845690478, score: 2, zoom: ZOOM_LEVELS.poi },
+            { text: 'Chicago', distance: 1855.8900334142313, score: 16988, zoom: ZOOM_LEVELS.place }
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('san near north sonoma county', (t) => {
         // --query="san" --proximity="-123.0167,38.7471"
-        const expected = [
-            { text: 'San Francisco', distance: 74.24466022598429, score: 8015 },
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587 },
-            { text: 'São Paulo', distance: 6547.831697209755, score: 36433 },
-            { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, score: 26709 },
+        const input = [
+            { text: 'São Paulo', distance: 6547.831697209755, score: 36433, zoom: ZOOM_LEVELS.place },
+            { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, score: 26709, zoom: ZOOM_LEVELS.place },
+            { text: 'San Francisco', distance: 74.24466022598429, score: 8015, zoom: ZOOM_LEVELS.place },
+            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'San Francisco', distance: 74.24466022598429, score: 8015, zoom: ZOOM_LEVELS.place },
+            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
+            { text: 'São Paulo', distance: 6547.831697209755, score: 36433, zoom: ZOOM_LEVELS.place },
+            { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, score: 26709, zoom: ZOOM_LEVELS.place },
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('santa cruz near sonoma county', (t) => {
         // --query="santa cruz" --proximity="-123.0167,38.7471"
-        const expected = [
-            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587 },
-            { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, score: 3456 }
+        const input = [
+            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
+            { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, score: 3456, zoom: ZOOM_LEVELS.place }
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'Santa Cruz', distance: 133.8263938095184, score: 587, zoom: ZOOM_LEVELS.place },
+            { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, score: 3456, zoom: ZOOM_LEVELS.place }
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('washington near baltimore', (t) => {
         // --query="washington" --proximity="-76.6035,39.3008"
-        const expected = [
-            { text: 'District of Columbia,DC', distance: 34.81595024835296, score: 7429 },
-            { text: 'Washington,WA', distance: 2256.6130314083157, score: 33373 }
+        const input = [
+            { text: 'District of Columbia,DC', distance: 34.81595024835296, score: 7429, zoom: ZOOM_LEVELS.place },
+            { text: 'Washington,WA', distance: 2256.6130314083157, score: 33373, zoom: ZOOM_LEVELS.region }
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'District of Columbia,DC', distance: 34.81595024835296, score: 7429, zoom: ZOOM_LEVELS.place },
+            { text: 'Washington,WA', distance: 2256.6130314083157, score: 33373, zoom: ZOOM_LEVELS.region }
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('gilmour ave near guelph, on, canada', (t) => {
         // --query="gilmour ave" --proximity="-80.1617,43.4963"
-        const expected = [
-            { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, score: 0 },
-            { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, score: 0 },
-            { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, score: 0 },
-            { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, score: 3 },
+        const input = [
+            { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, score: 3, zoom: ZOOM_LEVELS.address },
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, score: 0, zoom: ZOOM_LEVELS.address },
+            { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, score: 3, zoom: ZOOM_LEVELS.address },
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 
     t.test('cambridge near guelph, on, canada', (t) => {
         // --query="cambridge" --proximity="-80.1617,43.4963"
-        const expected = [
-            { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, score: 294 },
-            { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, score: 986 },
-            { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, score: 2721 },
+        const input = [
+            { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, score: 294, zoom: ZOOM_LEVELS.place },
+            { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, score: 986, zoom: ZOOM_LEVELS.place },
+            { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, score: 2721, zoom: ZOOM_LEVELS.district },
         ];
-        t.deepEqual(expected.slice().sort(compare), expected);
+        const expected = [
+            { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, score: 294, zoom: ZOOM_LEVELS.place },
+            { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, score: 986, zoom: ZOOM_LEVELS.place },
+            { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, score: 2721, zoom: ZOOM_LEVELS.district },
+        ];
+        t.deepEqual(input.sort(compare), expected);
         t.end();
     });
 


### PR DESCRIPTION
### Context

This PR fixes proximity.scoredist.test.js unit tests to call the `scoredist` function with all required arguments. Previously, the tests only passed in the score and distance parameter, not the zoom or radius parameters, which meant the calculated `scoredist` value was always `NaN`. As part of that bug fix, we also moved the `meanScore` function, which calculates the geometric mean of carmen geojson features' `carmen:score`, to util/proximity.js and added unit tests.

### Summary of Changes
- [x] refactor proximity.scoredist.test.js tests to call `scoredist` function with zoom level and `PROXIMITY_RADIUS` constant
- [x] move `meanScore` function to util/proximity.js
- [x] write unit tests for `meanScore` function

### Next Steps
- [x] review by @yhahn 

cc @mapbox/geocoding-gang
