### PR TITLE
fix geocoder_format template parsing to handle presence of arabic comma

### DIFF
--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -54,7 +54,7 @@ function getPlaceName(context, formatString, language, languageMode, matched) {
         ).trim();
     } else {
         // Create template object that lists what we want to know
-        const template = formatString.replace(/ /g,'').replace(/,/g,'').trim().replace(/^{/,'').replace(/}$/,'').split(/}{|}-{/);
+        const template = formatString.replace(/ /g,'').replace(/,/g,'').replace(/،/g,'').trim().replace(/^{/,'').replace(/}$/,'').split(/}{|}-{/);
 
         // Go through template object one-by-one & check to see if context is available for this template property
         for (let i = 0; i < template.length; i++) {

--- a/test/unit/geocoder/ops.test.js
+++ b/test/unit/geocoder/ops.test.js
@@ -367,7 +367,7 @@ test('ops#toFeature + formatter + languageMode=strict + arabic comma', (t) => {
         }
     }];
 
-    let feature;
+    const feature;
 
     feature = ops.toFeature(context, {
         en: '{place._name}, {country._name}',

--- a/test/unit/geocoder/ops.test.js
+++ b/test/unit/geocoder/ops.test.js
@@ -367,9 +367,7 @@ test('ops#toFeature + formatter + languageMode=strict + arabic comma', (t) => {
         }
     }];
 
-    const feature;
-
-    feature = ops.toFeature(context, {
+    const feature = ops.toFeature(context, {
         en: '{place._name}, {country._name}',
         ar: '{place._name}، {country._name}'
     }, ['ar'], 'strict', true);

--- a/test/unit/geocoder/ops.test.js
+++ b/test/unit/geocoder/ops.test.js
@@ -345,3 +345,38 @@ test('ops#toFeature + formatter + languageMode=strict', (t) => {
     t.end();
 });
 
+test('ops#toFeature + formatter + languageMode=strict + arabic comma', (t) => {
+
+    const context = [{
+        properties: {
+            'carmen:text': 'Cairo',
+            'carmen:text_en': 'Cairo',
+            'carmen:text_ar': 'القاهرة',
+            'carmen:types': ['place'],
+            'carmen:center': [0, 0],
+            'carmen:extid': 'place.1'
+        }
+    }, {
+        properties: {
+            'carmen:text': 'Egypt',
+            'carmen:text_en': 'Egypt',
+            'carmen:text_ar': 'مصر',
+            'carmen:types': ['country'],
+            'carmen:center': [0, 0],
+            'carmen:extid': 'country.1'
+        }
+    }];
+
+    let feature;
+
+    feature = ops.toFeature(context, {
+        en: '{place._name}, {country._name}',
+        ar: '{place._name}، {country._name}'
+    }, ['ar'], 'strict', true);
+    t.deepEqual(feature.place_name, 'القاهرة، مصر');
+    t.deepEqual(feature.context, [
+        { id: 'country.1', language: 'ar', language_ar: 'ar', text: 'مصر', text_ar: 'مصر' }
+    ]);
+
+    t.end();
+});


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
`geocoder_format` template parsing relies in part on removing all instances of comma (`,`) from the template string. If format strings contain the arabic variant of the comma (`،` or U+060C), then template parsing is broken.  This PR removes that variant and fixes the parsing steps.

Here's a parse on a format template with normal commas:

```
[ 'place._name', 'region._name', 'country._name' ]
```

...and here's what it looks like when arabic comma is present:

```
[ 'place._name}،{region._name}،{country._name' ]
```

### Summary of Changes
- [x] add step to remove arabic comma
- [x] add test 


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/geocoding-gang
