### PR TITLE
adding fuzzymatch and autocomplete cli params

### DIFF
--- a/bin/carmen.js
+++ b/bin/carmen.js
@@ -11,7 +11,7 @@ const Carmen = require('..');
 const settings = require('../package.json');
 const argv = require('minimist')(process.argv, {
     string: ['config', 'proximity', 'query', 'debug', 'types', 'tokens'],
-    boolean: ['geojson', 'stats', 'help', 'version']
+    boolean: ['geojson', 'stats', 'help', 'version', 'autocomplete', 'fuzzyMatch']
 });
 
 if (argv.help) {
@@ -30,6 +30,8 @@ if (argv.help) {
     console.log('  --debug="feat id"            Follows a feature through geocode"');
     console.log('  --reverseMode="{mode}"       Sort features in reverse queries by one of `score` or `distance`');
     console.log('  --languageMode="strict"      Only return results with text in a consistent script family');
+    console.log('  --autocomplete="true"        Submit as an autocomplete query');
+    console.log('  --fuzzyMatch="true"          Allow fuzzy matching');
     console.log('  --bbox="minX,minY,maxX,maxY" Limit results to those within the specified bounding box');
     console.log(' --routing=true                Return routable points, if possible');
     console.log('  --help                       Print this report');
@@ -105,6 +107,8 @@ if (argv.reverseMode) {
 }
 
 if (argv.routing) argv.routing = (argv.routing || false);
+if (argv.autocomplete) argv.autocomplete = (argv.autocomplete || false);
+if (argv.fuzzyMatch) argv.fuzzyMatch = (argv.fuzzyMatch || false);
 
 let load = +new Date();
 
@@ -120,7 +124,9 @@ carmen.geocode(argv.query, {
     'reverseMode': argv.reverseMode,
     'languageMode': argv.languageMode,
     'bbox': argv.bbox,
-    'routing': argv.routing
+    'routing': argv.routing,
+    'autocomplete': argv.autocomplete,
+    'fuzzyMatch': argv.fuzzyMatch,
 }, (err, data) => {
     if (err) throw err;
     load = +new Date() - load;

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -236,7 +236,8 @@ tape('bin/carmen query bbox', (t) => {
 });
 tape('bin/carmen query invalid bbox', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --bbox="-78.828,-34.465"', (err, stdout, stderr) => {
-        t.ok(err, 'bbox must be minX,minY,maxX,maxY');
+        t.ok(err);
+        t.equal(/bbox must be minX,minY,maxX,maxY/.test(stderr), true, 'error on invalid bbox');
         t.end();
     });
 });
@@ -251,7 +252,8 @@ tape('bin/carmen query proximity', (t) => {
 
 tape('bin/carmen query invalid proximity', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --proximity="-78.828;-34.465"', (err, stdout, stderr) => {
-        t.ok(err, 'Proximity must be LNG,LAT');
+        t.ok(err);
+        t.equal(/Proximity must be LNG,LAT/.test(stderr), true, 'error on invalid proximity');
         t.end();
     });
 });
@@ -285,6 +287,14 @@ tape('bin/carmen query fuzzyMatch false', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazol --fuzzyMatch="false"', (err, stdout, stderr) => {
         t.ifError(err);
         t.equal(/\d+\.\d+ Brazil/.test(stdout), false, 'does not find brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query reverseMode nonsense', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --reverseMode="nonsense"', (err, stdout, stderr) => {
+        t.ok(err);
+        t.equal(/reverseMode must be one of `score` or `distance`/.test(stderr), true, 'finds brazil');
         t.end();
     });
 });

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -231,3 +231,35 @@ tape('bin/carmen query invalid bbox', (t) => {
         t.end();
     });
 });
+
+tape('bin/carmen query autocomplete true', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=braz --autocomplete="true"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query autocomplete false', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=braz --autocomplete="false"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), false, 'does not find brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query fuzzyMatch true', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazol --fuzzyMatch="true"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query fuzzyMatch false', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazol --fuzzyMatch="false"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), false, 'does not find brazil');
+        t.end();
+    });
+});

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -116,6 +116,15 @@ tape('bin/carmen-index', (t) => {
     });
 });
 
+tape('bin/carmen', (t) => {
+    exec(bin + '/carmen.js --help', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\[options\]:/.test(stdout), true, 'finds help menu');
+        t.end();
+    });
+});
+
+
 tape('bin/carmen DEBUG', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query="canada" --debug="38"', (err, stdout, stderr) => {
         t.ifError(err);

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -241,6 +241,22 @@ tape('bin/carmen query invalid bbox', (t) => {
     });
 });
 
+tape('bin/carmen query proximity', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --proximity="-78.828,-34.465"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query invalid proximity', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazil --proximity="-78.828;-34.465"', (err, stdout, stderr) => {
+        t.ok(err, 'Proximity must be LNG,LAT');
+        t.end();
+    });
+});
+
+
 tape('bin/carmen query autocomplete true', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=braz --autocomplete="true"', (err, stdout, stderr) => {
         t.ifError(err);


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
This PR makes it possible to add `--fuzzyMatch` and `--autocomplete` when querying using the carmen CLI at `bin/carmen.js`

cc @mapbox/search 
