### PR TITLE
Calculate and sort by real scoredists in proximity.scoredist unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v25.0.7
+
+- Refactor proximity.scoredist tests
+
 ## v25.0.6
 
 - Fix proximity.scoredist tests

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "25.0.6",
+  "version": "25.0.7",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/test/unit/util/proximity.meanScore.test.js
+++ b/test/unit/util/proximity.meanScore.test.js
@@ -4,36 +4,30 @@ const meanScore = require('../../../lib/util/proximity').meanScore;
 const test = require('tape');
 
 test('find the geometric mean of 2 and 8', (t) => {
-    const input = [{
-        properties: { 'carmen:score': 2 }
-    },
-    {
-        properties: { 'carmen:score': 8 }
-    }];
+    const input = [
+        { properties: { 'carmen:score': 2 } },
+        { properties: { 'carmen:score': 8 } }
+    ];
 
     t.equal(meanScore(input), 4, 'geometric mean of 2 and 8 is 4');
     t.end();
 });
 
 test('find the geometric mean of 2 and 8', (t) => {
-    const input = [{
-        properties: { 'carmen:score': 0 }
-    },
-    {
-        properties: { 'carmen:score': 4 }
-    }];
+    const input = [
+        { properties: { 'carmen:score': 0 } },
+        { properties: { 'carmen:score': 4 } }
+    ];
 
     t.equal(meanScore(input), 2, 'geometric mean of 0 and 4 is 2');
     t.end();
 });
 
 test('throw an error if carmen:score is not a number', (t) => {
-    const input = [{
-        properties: { 'carmen:score': undefined }
-    },
-    {
-        properties: { 'carmen:score': 4 }
-    }];
+    const input = [
+        { properties: { 'carmen:score': undefined } },
+        { properties: { 'carmen:score': 4 } }
+    ];
 
     t.throws(() => {
         meanScore(input);

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -8,19 +8,26 @@ const ZOOM_LEVELS = {
     poi: 14,
     place: 12,
     region: 6,
-    district: 9
+    district: 9,
+    country: 6
 };
 
+function compareScoreDist(a, b) {
+    return b.properties['carmen:scoredist'] - a.properties['carmen:scoredist'];
+}
 
-function compareCreator(meanScore) {
-    return function compare(a, b) {
-        return proximity.scoredist(meanScore, b.properties.distance, b.properties.zoom, constants.PROXIMITY_RADIUS) - proximity.scoredist(meanScore, a.properties.distance, a.properties.zoom, constants.PROXIMITY_RADIUS);
-    };
+function calculteScoreDist(input, meanScore) {
+    input.forEach((feat) => {
+        feat.properties['carmen:scoredist'] = Math.max(
+            feat.properties['carmen:score'],
+            proximity.scoredist(meanScore, feat.properties.distance, feat.properties.zoom, constants.PROXIMITY_RADIUS)
+        );
+    });
 }
 
 test('scoredist', (t) => {
 
-    t.test('new york', (t) => {
+    t.test('new york near san francisco', (t) => {
         // --query="new york" --proximity="-122.4234,37.7715"
         const input = [
             { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place } },
@@ -29,137 +36,156 @@ test('scoredist', (t) => {
             { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region } }
         ];
 
-        const meanScore = proximity.meanScore(input);
-
         const expected = [
-            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi } },
-            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi } },
-            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region } }
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: 6, 'carmen:scoredist': 79161 } },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: 12, 'carmen:scoredist': 31104 } },
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: 14, 'carmen:scoredist': 29172.6105 } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 29127.7135 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('chicago near san francisco', (t) => {
         // --query="chicago" --proximity="-122.4234,37.7715"
-        const meanScore = 1;
-
         const input = [
             { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi } }
         ];
+
         const expected = [
-            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi } },
-            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place } }
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: 14, 'carmen:scoredist': 18406.6285 } },
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: 12, 'carmen:scoredist': 16988 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('san near north sonoma county', (t) => {
         // --query="san" --proximity="-123.0167,38.7471"
-
-        const meanScore = 1;
         const input = [
             { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place } }
         ];
+
         const expected = [
-            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place } }
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: 12, 'carmen:scoredist': 631594.6334 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 496553.9131 } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: 12, 'carmen:scoredist': 36433 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: 12, 'carmen:scoredist': 26709 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('santa cruz near sonoma county', (t) => {
         // --query="santa cruz" --proximity="-123.0167,38.7471"
-        const meanScore = 1;
-
         const input = [
             { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place } }
         ];
+
         const expected = [
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place } }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 85980.2649 } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: 12, 'carmen:scoredist': 3456 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('washington near baltimore', (t) => {
         // --query="washington" --proximity="-76.6035,39.3008"
-        const meanScore = 1;
-
         const input = [
-            { properties: { text: 'District of Columbia,DC', distance: 34.81595024835296, 'carmen:score': 7429, zoom: ZOOM_LEVELS.place } },
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region } }
         ];
+
         const expected = [
-            { properties: { text: 'District of Columbia,DC', distance: 34.81595024835296, 'carmen:score': 7429, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region } }
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: 12, 'carmen:scoredist': 1394410.9267 } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: 6, 'carmen:scoredist': 33373 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('gilmour ave near guelph, on, canada', (t) => {
         // --query="gilmour ave" --proximity="-80.1617,43.4963"
-        const meanScore = 1;
-
         const input = [
             { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
             { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
             { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
             { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address } }
         ];
+
         const expected = [
-            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
-            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
-            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address } },
-            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address } }
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 88.3609 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 3 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0.4508 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
     t.test('cambridge near guelph, on, canada', (t) => {
         // --query="cambridge" --proximity="-80.1617,43.4963"
-        const meanScore = 1;
-
         const input = [
             { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place } },
             { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district } }
         ];
+
         const expected = [
-            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place } },
-            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district } }
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: 12, 'carmen:scoredist': 89120.0225 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: 12, 'carmen:scoredist': 4711.9645 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: 9, 'carmen:scoredist': 2721 } }
         ];
-        t.deepEqual(input.sort(compareCreator(meanScore)), expected);
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
 
+    t.test('united states near washington dc', (t) => {
+        // --query="United States" --proximity="-77.03361679999999,38.900039899999996"
+        const input = [
+            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: ZOOM_LEVELS.country } },
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi } },
+        ];
 
+        const expected = [
+            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: 6, 'carmen:scoredist': 1634443 } },
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 127694.845 } }
+        ];
+        calculteScoreDist(input, proximity.meanScore(input));
+        t.deepEqual(input.sort(compareScoreDist), expected);
+        t.end();
+    });
     t.end();
 });
 
-// The radius of effect extends further at lower zooms
 test('zoom weighting', (t) => {
     const score = 1000;
     const distance = 30; // miles
+    const input = [
+        { properties: { distance: distance, zoom: 14, 'carmen:score': score } },
+        { properties: { distance: distance, zoom: 12, 'carmen:score': score } },
+        { properties: { distance: distance, zoom: 10, 'carmen:score': score } },
+        { properties: { distance: distance, zoom: 8, 'carmen:score': score } },
+        { properties: { distance: distance, zoom: 6, 'carmen:score': score } }
+    ];
 
-    t.deepEqual(proximity.scoredist(score, distance, 6, 40), 84027.7778, 'zoom 6');
-    t.deepEqual(proximity.scoredist(score, distance, 8, 40), 79719.3878, 'zoom 8');
-    t.deepEqual(proximity.scoredist(score, distance, 10, 40), 72250, 'zoom 10');
-    t.deepEqual(proximity.scoredist(score, distance, 12, 40), 56250, 'zoom 12');
-    t.deepEqual(proximity.scoredist(score, distance, 14, 40), 6250, 'zoom 14');
+    calculteScoreDist(input, proximity.meanScore(input));
+    t.deepEqual(input.sort(compareScoreDist).map((f) => f.properties.zoom), [6,8,10,12,14], 'features with lower zoom levels have higher scoredist values');
     t.end();
 });

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -37,10 +37,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: 6, 'carmen:scoredist': 79161 } },
-            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: 12, 'carmen:scoredist': 31104 } },
-            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: 14, 'carmen:scoredist': 29172.6105 } },
-            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 29127.7135 } }
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 79161 } },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 31104 } },
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29172.6105 } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29127.7135 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -56,8 +56,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: 14, 'carmen:scoredist': 18406.6285 } },
-            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: 12, 'carmen:scoredist': 16988 } }
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 18406.6285 } },
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 16988 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -75,10 +75,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: 12, 'carmen:scoredist': 631594.6334 } },
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 496553.9131 } },
-            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: 12, 'carmen:scoredist': 36433 } },
-            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: 12, 'carmen:scoredist': 26709 } }
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 631594.6334 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 496553.9131 } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 36433 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 26709 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -94,8 +94,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 85980.2649 } },
-            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: 12, 'carmen:scoredist': 3456 } }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 85980.2649 } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 3456 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -110,8 +110,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: 12, 'carmen:scoredist': 1394410.9267 } },
-            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: 6, 'carmen:scoredist': 33373 } }
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1394410.9267 } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 33373 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -128,10 +128,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 88.3609 } },
-            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 3 } },
-            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0.4508 } },
-            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0 } }
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 88.3609 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 3 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0.4508 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -147,9 +147,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: 12, 'carmen:scoredist': 89120.0225 } },
-            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: 12, 'carmen:scoredist': 4711.9645 } },
-            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: 9, 'carmen:scoredist': 2721 } }
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 89120.0225 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 4711.9645 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district, 'carmen:scoredist': 2721 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -164,8 +164,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: 6, 'carmen:scoredist': 1634443 } },
-            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 127694.845 } }
+            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: ZOOM_LEVELS.country, 'carmen:scoredist': 1634443 } },
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 127694.845 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);


### PR DESCRIPTION
### Context

Unit test updates as part of https://github.com/mapbox/carmen/issues/747, https://github.com/mapbox/carmen/issues/748, and https://github.com/mapbox/carmen/issues/749. This changes proximity.scoredist unit tests to store whatever is greater, `carmen:score` or the calculated `scoredist` in the `carmen:scoredist` property and sort by `carmen:scoredist`. This follows how verifymatch calculates `carmen:scoredist`:

https://github.com/mapbox/carmen/blob/f831f2dfc9eb965752939f5809b18315b38b7659/lib/geocoder/verifymatch.js#L200-L203

### Summary of Changes
- [ ] fix array/object formatting in proximity.meanScore tests
- [ ] set  `carmen:scoredist` on `expected` feature arrays to whichever is greater, `carmen:score` or the calculated `scoredist` and sort by that value
- [ ] for zoom weighting tests, test the order of the expected results rather than the actual score values, as we care that features with lower zoom levels have higher `scoredist`s, not necessarily what those values are

### Next Steps
- [ ] review
- [ ] patch release

cc @aarthykc @apendleton @miccolis @boblannon 
