### PR TITLE
More heavily bias local results

### DIFF
--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -86,7 +86,7 @@ function scoredist(meanScore, dist, zoom, radius) {
     // square to weight nearer features higher
     distVal = Math.pow(distVal, 2);
     // heuristic: the closest features can be up to 100x times the geometric mean
-    return parseFloat((100 * meanScore * distVal).toFixed(4));
+    return parseFloat((300 * meanScore * distVal).toFixed(4));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "25.0.7",
+  "version": "25.0.7-weigh-local",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/test/unit/util/proximity.meanScore.test.js
+++ b/test/unit/util/proximity.meanScore.test.js
@@ -13,7 +13,7 @@ test('find the geometric mean of 2 and 8', (t) => {
     t.end();
 });
 
-test('find the geometric mean of 2 and 8', (t) => {
+test('find the geometric mean of 0 and 4', (t) => {
     const input = [
         { properties: { 'carmen:score': 0 } },
         { properties: { 'carmen:score': 4 } }

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -37,10 +37,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 79161 } },
-            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 31104 } },
-            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29172.6105 } },
-            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29127.7135 } }
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: 14, 'carmen:scoredist': 87517.8314 } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 87383.1406 } },
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: 6, 'carmen:scoredist': 79161 } },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: 12, 'carmen:scoredist': 31104 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -56,8 +56,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 18406.6285 } },
-            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 16988 } }
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: 14, 'carmen:scoredist': 55219.8854 } },
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: 12, 'carmen:scoredist': 16988 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -75,10 +75,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 631594.6334 } },
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 496553.9131 } },
-            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 36433 } },
-            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 26709 } }
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: 12, 'carmen:scoredist': 1894783.9001 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 1489661.7393 } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: 12, 'carmen:scoredist': 36433 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: 12, 'carmen:scoredist': 26709 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -94,8 +94,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 85980.2649 } },
-            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 3456 } }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 257940.7947 } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: 12, 'carmen:scoredist': 3456 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -110,8 +110,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1394410.9267 } },
-            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 33373 } }
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: 12, 'carmen:scoredist': 4183232.7802 } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: 6, 'carmen:scoredist': 33373 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -128,10 +128,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 88.3609 } },
-            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 3 } },
-            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0.4508 } },
-            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0 } }
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 265.0827 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 3 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 1.3524 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -147,9 +147,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 89120.0225 } },
-            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 4711.9645 } },
-            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district, 'carmen:scoredist': 2721 } }
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: 12, 'carmen:scoredist': 267360.0674 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: 12, 'carmen:scoredist': 14135.8936 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: 9, 'carmen:scoredist': 2721 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -164,8 +164,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: ZOOM_LEVELS.country, 'carmen:scoredist': 1634443 } },
-            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 127694.845 } }
+            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: 6, 'carmen:scoredist': 1634443 } },
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 383084.5351 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -37,10 +37,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: 14, 'carmen:scoredist': 87517.8314 } },
-            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 87383.1406 } },
-            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: 6, 'carmen:scoredist': 79161 } },
-            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: 12, 'carmen:scoredist': 31104 } }
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 87517.8314 } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 87383.1406 } },
+            { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 79161 } },
+            { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 31104 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -56,8 +56,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: 14, 'carmen:scoredist': 55219.8854 } },
-            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: 12, 'carmen:scoredist': 16988 } }
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 55219.8854 } },
+            { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 16988 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -75,10 +75,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: 12, 'carmen:scoredist': 1894783.9001 } },
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 1489661.7393 } },
-            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: 12, 'carmen:scoredist': 36433 } },
-            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: 12, 'carmen:scoredist': 26709 } }
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1894783.9001 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1489661.7393 } },
+            { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 36433 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 26709 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -94,8 +94,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: 12, 'carmen:scoredist': 257940.7947 } },
-            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: 12, 'carmen:scoredist': 3456 } }
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 257940.7947 } },
+            { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 3456 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -110,8 +110,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: 12, 'carmen:scoredist': 4183232.7802 } },
-            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: 6, 'carmen:scoredist': 33373 } }
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 4183232.7802 } },
+            { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 33373 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -128,10 +128,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 265.0827 } },
-            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: 14, 'carmen:scoredist': 3 } },
-            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 1.3524 } },
-            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 0 } }
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 265.0827 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 3 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 1.3524 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -147,9 +147,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: 12, 'carmen:scoredist': 267360.0674 } },
-            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: 12, 'carmen:scoredist': 14135.8936 } },
-            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: 9, 'carmen:scoredist': 2721 } }
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 267360.0674 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 14135.8936 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district, 'carmen:scoredist': 2721 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);
@@ -164,8 +164,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: 6, 'carmen:scoredist': 1634443 } },
-            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: 14, 'carmen:scoredist': 383084.5351 } }
+            { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: ZOOM_LEVELS.country, 'carmen:scoredist': 1634443 } },
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 383084.5351 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/747. To start, increase constant multiplier from 100 to 300 so that `scoredist` can be up to 300x the geometric mean score.

### Summary of Changes
- [x] increase constant multiplier in `scoredist` function to 300


### Next Steps
- [ ] publish a dev release
- [ ] run against downstream tests

cc @aarthykc @apendleton @miccolis @boblannon 
