### PR TITLE
Use a different curve to bias local results

### DIFF
--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -83,8 +83,8 @@ function scoredist(meanScore, dist, zoom, radius) {
     const weightedRadius = radius * (15 - zoom);
     // flip distance to a float between 0-1, 1 being closest to the center point
     let distVal = 1 - Math.min(dist / weightedRadius, 1);
-    // square to weight nearer features higher
-    distVal = Math.pow(distVal, 2);
+    // weigh nearer features higher along a sine curve
+    distVal = Math.sin(distVal * Math.PI * 0.5);
     // heuristic: the closest features can be up to 100x times the geometric mean
     return parseFloat((100 * meanScore * distVal).toFixed(4));
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "25.0.7",
+  "version": "25.0.7-change-curve",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -39,8 +39,8 @@ test('scoredist', (t) => {
         const expected = [
             { properties: { text: 'New York,NY', distance: 2426.866703400975, 'carmen:score': 79161, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 79161 } },
             { properties: { text: 'New York,NY,NYC,New York City', distance: 2567.3550038898834, 'carmen:score': 31104, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 31104 } },
-            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29172.6105 } },
-            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29127.7135 } }
+            { properties: { text: 'New York Frankfurter Co.', distance: 0.4914344651849769, 'carmen:score': 1, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29316.2865 } },
+            { properties: { text: 'New Yorker Buffalo Wings', distance: 0.6450163846417221, 'carmen:score': 3, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 29316.1287 } }
         ];
 
         calculteScoreDist(input, proximity.meanScore(input));
@@ -56,7 +56,7 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 18406.6285 } },
+            { properties: { text: 'Chicago Title', distance: 0.14084037845690478, 'carmen:score': 2, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 18432.5686 } },
             { properties: { text: 'Chicago', distance: 1855.8900334142313, 'carmen:score': 16988, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 16988 } }
         ];
 
@@ -75,8 +75,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 631594.6334 } },
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 496553.9131 } },
+            { properties: { text: 'San Francisco', distance: 74.24466022598429, 'carmen:score': 8015, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 807081.5726 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 772600.3709 } },
             { properties: { text: 'São Paulo', distance: 6547.831697209755, 'carmen:score': 36433, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 36433 } },
             { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', distance: 6023.053777668511, 'carmen:score': 26709, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 26709 } }
         ];
@@ -94,7 +94,7 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 85980.2649 } },
+            { properties: { text: 'Santa Cruz', distance: 133.8263938095184, 'carmen:score': 587, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 133778.7958 } },
             { properties: { text: 'Santa Cruz de Tenerife', distance: 5811.283048403849, 'carmen:score': 3456, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 3456 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
@@ -110,7 +110,7 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1394410.9267 } },
+            { properties: { text: 'Washington,DC', distance: 34.81595024835296, 'carmen:score': 7400, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 1564973.3006 } },
             { properties: { text: 'Washington,WA', distance: 2256.6130314083157, 'carmen:score': 33373, zoom: ZOOM_LEVELS.region, 'carmen:scoredist': 33373 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
@@ -128,9 +128,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 88.3609 } },
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', distance: 36.12228253928214, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 126.3464 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 12.0819 } },
             { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', distance: 3312.294287119006, 'carmen:score': 3, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 3 } },
-            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', distance: 188.29482550861198, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0.4508 } },
             { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', distance: 246.29759329605977, 'carmen:score': 0, zoom: ZOOM_LEVELS.address, 'carmen:scoredist': 0 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
@@ -147,8 +147,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 89120.0225 } },
-            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 4711.9645 } },
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', distance: 10.73122383596493, 'carmen:score': 294, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 92359.0622 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', distance: 464.50390088754625, 'carmen:score': 986, zoom: ZOOM_LEVELS.place, 'carmen:scoredist': 32092.2243 } },
             { properties: { text: 'Cambridgeshire, United Kingdom', distance: 3566.2969841802374, 'carmen:score': 2721, zoom: ZOOM_LEVELS.district, 'carmen:scoredist': 2721 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
@@ -165,7 +165,7 @@ test('scoredist', (t) => {
 
         const expected = [
             { properties: { text: 'United States of America, United States, America, USA, US', distance: 1117.3906777683906, 'carmen:score': 1634443, zoom: ZOOM_LEVELS.country, 'carmen:scoredist': 1634443 } },
-            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 127694.845 } }
+            { properties: { text: 'United States Department of Treasury Annex', distance: 0.11774815645353183, 'carmen:score': 0, zoom: ZOOM_LEVELS.poi, 'carmen:scoredist': 127845.2816 } }
         ];
         calculteScoreDist(input, proximity.meanScore(input));
         t.deepEqual(input.sort(compareScoreDist), expected);


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/748. To start, weigh results along a sine curve when calculating `scoredist`.

### Summary of Changes
- [ ] weigh results along a sine curve

### Next Steps
- [ ] publish dev release
- [ ]  run against downstream tests

cc @aarthykc @apendleton @miccolis @boblannon 
