### PR TITLE
Use cheap-ruler in proximity distance calculations

### DIFF
--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -1,6 +1,5 @@
 'use strict';
-const point = require('@turf/helpers').point;
-const turfdist = require('@turf/distance').default;
+const cheapRuler = require('cheap-ruler');
 
 const SphericalMercator = require('@mapbox/sphericalmercator');
 
@@ -8,6 +7,9 @@ const tileSize = 256;
 const merc = new SphericalMercator({
     size: tileSize
 });
+function tileCoord(x, y, z) {
+    return merc.ll([x * tileSize, y * tileSize], z);
+}
 
 module.exports.distance = distance;
 module.exports.center2zxy = center2zxy;
@@ -35,18 +37,16 @@ module.exports.meanScore = meanScore;
 function distance(proximity, center, cover) {
     if (!proximity) return 0;
 
-    const centerDist = turfdist(point(proximity), point(center), { units: 'miles' });
+    const ruler = cheapRuler(proximity[1], 'miles');
+    const centerDist = ruler.distance(proximity, center);
+
     // calculate the distance to the furthest corner of the cover
     const maxCoverDist = Math.max(
-        distanceToXYZ(proximity, cover.x + 0, cover.y + 0, cover.zoom),
-        distanceToXYZ(proximity, cover.x + 0, cover.y + 1, cover.zoom),
-        distanceToXYZ(proximity, cover.x + 1, cover.y + 0, cover.zoom),
-        distanceToXYZ(proximity, cover.x + 1, cover.y + 1, cover.zoom));
+        ruler.distance(proximity, tileCoord(cover.x + 0, cover.y + 0, cover.zoom)),
+        ruler.distance(proximity, tileCoord(cover.x + 0, cover.y + 1, cover.zoom)),
+        ruler.distance(proximity, tileCoord(cover.x + 1, cover.y + 0, cover.zoom)),
+        ruler.distance(proximity, tileCoord(cover.x + 1, cover.y + 1, cover.zoom)));
     return Math.min(centerDist, maxCoverDist);
-}
-
-function distanceToXYZ(proximity, x, y, z) {
-    return turfdist(point(proximity), point(merc.ll([x * tileSize, y * tileSize], z)), { units: 'miles' });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@turf/length": "^6.0.2",
     "@turf/nearest-point-on-line": "^6.0.2",
     "@turf/point-on-feature": "^5.1.5",
+    "cheap-ruler": "^2.5.1",
     "d3-queue": "3.0.x",
     "err-code": "^1.1.2",
     "fs-extra": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+cheap-ruler@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/cheap-ruler/-/cheap-ruler-2.5.1.tgz#1c47ece27fc14bc95e817e16d49ceb5009a7e987"
+
 chokidar@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"


### PR DESCRIPTION
Happened upon the proximity distance calculations and thought they may be a good spot to switch from turf to cheap-ruler. With proximity we're mostly interested in shorter distances and can spare a little accuracy for a query time speed-up.

Immediate problem is that a couple tests fail. While the expectation is that proximity would only care about things close together, our unit tests check distance calculations for items that are thousands of miles apart. Perhaps for good reasons.

### Next Steps

- [ ] Determine if accuracy of calculation for thousands of miles is something that is needed.
- [ ] If not, updated tests to reflect real usage. Get them passing before and after switch to cheap-ruler.

cc @mapbox/geocoding-gang
