### PR TITLE
[first cut] parameterized cutoffs

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -9,12 +9,8 @@ module.exports = {
     PROXIMITY_RADIUS: 200,
     MAX_TEXT_SYNONYMS: 10,
     MIN_CORRECTION_LENGTH: 4,
-    // STACKABLE_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/spatialmatch.js#L277
     STACKABLE_LIMIT: 100,
-    // SPATIALMATCH_STACK_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/spatialmatch.js#L40
     SPATIALMATCH_STACK_LIMIT: 30,
-    // MAX_CORRECTION_LENGTH: https://github.com/mapbox/carmen/blob/master/lib/geocoder/phrasematch.js#L43
     MAX_CORRECTION_LENGTH: 8,
-    // VERIFYMATCH_STACK_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/verifymatch.js#L48
     VERIFYMATCH_STACK_LIMIT: 20
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,5 +8,13 @@ module.exports = {
     MAX_QUERY_TOKENS: 20,
     PROXIMITY_RADIUS: 200,
     MAX_TEXT_SYNONYMS: 10,
-    MIN_CORRECTION_LENGTH: 4
+    MIN_CORRECTION_LENGTH: 4,
+    // STACKABLE_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/spatialmatch.js#L277
+    STACKABLE_LIMIT: 100,
+    // SPATIALMATCH_STACK_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/spatialmatch.js#L40
+    SPATIALMATCH_STACK_LIMIT: 30,
+    // MAX_CORRECTION_LENGTH: https://github.com/mapbox/carmen/blob/master/lib/geocoder/phrasematch.js#L43
+    MAX_CORRECTION_LENGTH: 8,
+    // VERIFYMATCH_STACK_LIMIT: https://github.com/mapbox/carmen/blob/master/lib/geocoder/verifymatch.js#L48
+    VERIFYMATCH_STACK_LIMIT: 20
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -9,6 +9,9 @@ module.exports = {
     PROXIMITY_RADIUS: 200,
     MAX_TEXT_SYNONYMS: 10,
     MIN_CORRECTION_LENGTH: 4,
+    // Though spatialmatches are sliced to SPATIALMATCH_STACK_LIMIT elements
+    // after stackable, the stackable limit should be higehr to leave some
+    // headroom as this step does not include type filtering.
     STACKABLE_LIMIT: 100,
     SPATIALMATCH_STACK_LIMIT: 30,
     MAX_CORRECTION_LENGTH: 8,

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -393,9 +393,6 @@ function forwardGeocode(geocoder, query, options, callback) {
         }
 
         spatialmatch(queryData.query, phrasematchResults, options, spatialmatchComplete);
-
-        // these options are parameterized cutoffs that can be tweaked for performance benefits
-        // or for improving result quality
     });
 
     function spatialmatchComplete(err, matched) {

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -36,6 +36,7 @@ const ops = require('./ops'),
  * @param {boolean} [options.autocomplete=true] - If true, indexes will be returned as part of the results.
  * @param {string} [options.reverseMode='distance'] - Choices are `'distance'`, `'score'`. Affects the way that a result's context array is built
  * @param {boolean} [options.routing=false] - If true, routable_points will be returned as part of the results for features whose sources are flagged as `geocoder_routable` in the tile json.
+ *
  * @param {function} callback - a callback function
  */
 module.exports = function(geocoder, query, options, callback) {
@@ -52,6 +53,10 @@ module.exports = function(geocoder, query, options, callback) {
     options.bbox = options.bbox || false;
     options.reverseMode = options.reverseMode || 'distance';
     options.routing = options.routing || false;
+    options.stackable_limit = options.stackable_limit || constants.STACKABLE_LIMIT;
+    options.spatialmatch_stack_limit = options.spatialmatch_stack_limit || constants.SPATIALMATCH_STACK_LIMIT;
+    options.max_correction_length = options.max_correction_length || constants.MAX_CORRECTION_LENGTH;
+    options.verifymatch_stack_limit = options.verifymatch_stack_limit || constants.VERIFYMATCH_STACK_LIMIT;
 
     // Limit query length
     if (query.length > constants.MAX_QUERY_CHARS) {
@@ -484,4 +489,3 @@ function toFeatures(geocoder, contexts, options) {
     if (options.indexes) data.indexes = Object.keys(indexes);
     return data;
 }
-

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -53,6 +53,9 @@ module.exports = function(geocoder, query, options, callback) {
     options.bbox = options.bbox || false;
     options.reverseMode = options.reverseMode || 'distance';
     options.routing = options.routing || false;
+
+    // these options are parameterized cutoffs that can be tweaked for performance benefits
+    // or for improving result quality
     options.stackable_limit = options.stackable_limit || constants.STACKABLE_LIMIT;
     options.spatialmatch_stack_limit = options.spatialmatch_stack_limit || constants.SPATIALMATCH_STACK_LIMIT;
     options.max_correction_length = options.max_correction_length || constants.MAX_CORRECTION_LENGTH;
@@ -390,6 +393,9 @@ function forwardGeocode(geocoder, query, options, callback) {
         }
 
         spatialmatch(queryData.query, phrasematchResults, options, spatialmatchComplete);
+
+        // these options are parameterized cutoffs that can be tweaked for performance benefits
+        // or for improving result quality
     });
 
     function spatialmatchComplete(err, matched) {

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -40,7 +40,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     const tokenized = termops.tokenize(
         termops.encodableText(token.replaceToken(source.token_replacer, query))
     );
-    const maxDistance = (options.fuzzyMatch && tokenized.length <= 8) ? 1 : 0;
+    const maxDistance = (options.fuzzyMatch && tokenized.length <= options.max_correction_length) ? 1 : 0;
 
     let subqueries;
     if (!source.geocoder_address) {

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -273,8 +273,6 @@ function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, rel
         if (bmask[stack[j].idx]) return;
     }
 
-    // Though spatialmatches are sliced to 30 elements after this step
-    // leave some headroom as this step does not include type filtering.
     // Recurse, including this level
     const phrasematches = phrasematchResult.phrasematches;
     for (let i = 0; i < phrasematches.length; i++) {

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -5,7 +5,6 @@ const coalesce = require('@mapbox/carmen-cache').coalesce;
 const bbox = require('../util/bbox.js');
 const termops = require('../text-processing/termops');
 const constants = require('../constants');
-let limit = constants.stackable_limit;
 
 module.exports = spatialmatch;
 module.exports.stackable = stackable;
@@ -27,7 +26,6 @@ module.exports.sortByZoomIdx = sortByZoomIdx;
 
 function spatialmatch(query, phrasematchResults, options, callback) {
     let stacks;
-    limit = options.stackable_limit;
 
     if (phrasematchResults.length) {
         // Fuzzy matching may have produced multiple phrasematches that will
@@ -36,7 +34,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         // collapse our matches down to ones that are distinct along these axes,
         // then expand them back out again after stacking.
         const archetypes = collapseToArchetypes(phrasematchResults);
-        let arch_stacks = stackable(archetypes);
+        let arch_stacks = stackable(archetypes, options.stackable_limit);
         arch_stacks = allowed(arch_stacks, options);
         arch_stacks.forEach((arch_stack) => { arch_stack.sort(sortByZoomIdx); });
         arch_stacks.sort(sortByRelevLengthIdx);
@@ -245,7 +243,7 @@ function stackByIdx(stack) {
 * @params {Array} stack a list of indexes that stack spatially
 * @params {Number} relevance score for each feature
 **/
-function stackable(phrasematchResults, memo, idx, mask, nmask, stack, relev, adjRelev) {
+function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, relev, adjRelev) {
     if (memo === undefined) {
         memo = {
             stacks: [],
@@ -262,7 +260,7 @@ function stackable(phrasematchResults, memo, idx, mask, nmask, stack, relev, adj
 
     // Recurse, skipping this level
     if (phrasematchResults[idx + 1] !== undefined) {
-        stackable(phrasematchResults, memo, idx + 1, mask, nmask, stack, relev, adjRelev);
+        stackable(phrasematchResults, limit, memo, idx + 1, mask, nmask, stack, relev, adjRelev);
     }
 
     const phrasematchResult = phrasematchResults[idx];
@@ -322,7 +320,7 @@ function stackable(phrasematchResults, memo, idx, mask, nmask, stack, relev, adj
 
         // Recurse to next level
         if (phrasematchResults[idx + 1] !== undefined) {
-            stackable(phrasematchResults, memo, idx + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
+            stackable(phrasematchResults, limit, memo, idx + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
         }
     }
 

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -5,6 +5,7 @@ const coalesce = require('@mapbox/carmen-cache').coalesce;
 const bbox = require('../util/bbox.js');
 const termops = require('../text-processing/termops');
 const constants = require('../constants');
+let limit = constants.stackable_limit;
 
 module.exports = spatialmatch;
 module.exports.stackable = stackable;
@@ -26,6 +27,8 @@ module.exports.sortByZoomIdx = sortByZoomIdx;
 
 function spatialmatch(query, phrasematchResults, options, callback) {
     let stacks;
+    limit = options.stackable_limit;
+
     if (phrasematchResults.length) {
         // Fuzzy matching may have produced multiple phrasematches that will
         // behave identically when stacking -- they come from the same index
@@ -37,8 +40,8 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         arch_stacks = allowed(arch_stacks, options);
         arch_stacks.forEach((arch_stack) => { arch_stack.sort(sortByZoomIdx); });
         arch_stacks.sort(sortByRelevLengthIdx);
-        arch_stacks = arch_stacks.slice(0,30);
-        stacks = expandFromArchetypes(arch_stacks, 30);
+        arch_stacks = arch_stacks.slice(0, options.spatialmatch_stack_limit);
+        stacks = expandFromArchetypes(arch_stacks, options.spatialmatch_stack_limit);
     } else {
         stacks = [];
     }
@@ -274,8 +277,6 @@ function stackable(phrasematchResults, memo, idx, mask, nmask, stack, relev, adj
 
     // Though spatialmatches are sliced to 30 elements after this step
     // leave some headroom as this step does not include type filtering.
-    const limit = 100;
-
     // Recurse, including this level
     const phrasematches = phrasematchResult.phrasematches;
     for (let i = 0; i < phrasematches.length; i++) {

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -45,7 +45,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     }
 
     // Limit initial feature check to the best 20 max.
-    if (spatialmatches.length > 20) spatialmatches = spatialmatches.slice(0,20);
+    if (spatialmatches.length > options.verifymatch_stack_limit) spatialmatches = spatialmatches.slice(0, options.verifymatch_stack_limit);
 
     const q = queue(10);
     for (let i = 0; i < spatialmatches.length; i++) q.defer(loadFeature, spatialmatches[i], i);

--- a/test/acceptance/geocode-unit.cutoffs.test.js
+++ b/test/acceptance/geocode-unit.cutoffs.test.js
@@ -1,0 +1,176 @@
+'use strict';
+// Test geocoder_tokens
+
+const tape = require('tape');
+const Carmen = require('../..');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../../lib/indexer/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+(() => {
+    const conf = {
+        country: new mem({ maxzoom: 6 }, () => {}),
+        place: new mem({ maxzoom: 6 }, () => {})
+    };
+
+    const c = new Carmen(conf);
+    tape('index country - United States', (t) => {
+        queueFeature(conf.country, {
+            id: 1,
+            properties: {
+                'carmen:text':'United States',
+                'carmen:center': [0,0],
+                'carmen:zxy': ['6/32/32']
+            }
+        }, t.end);
+    });
+
+    tape('index country - United Kingdom', (t) => {
+        queueFeature(conf.country, {
+            id: 2,
+            properties: {
+                'carmen:text':'United Kingdom',
+                'carmen:center': [0, 1],
+                'carmen:zxy': ['6/32/32']
+            }
+        }, t.end);
+    });
+
+    tape('index places in the United States', (t) => {
+        const q = queue(1);
+        for (let i = 1; i <= 11; i++) q.defer((i, done) => {
+            queueFeature(conf.place, {
+                id:i,
+                properties: {
+                    'carmen:text':'place ' + i,
+                    'carmen:center': [0,0],
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0,0]
+                }
+            }, done);
+        }, i);
+        q.awaitAll(t.end);
+    });
+
+    tape('index place 1 in United Kingdom', (t) => {
+        queueFeature(conf.place, {
+            id: 50,
+            properties: {
+                'carmen:text':'place 1',
+                'carmen:center': [0,1],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,1]
+            }
+        }, t.end);
+    });
+
+    tape('build queued features', (t) => {
+        const q = queue();
+        Object.keys(conf).forEach((c) => {
+            q.defer((cb) => {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
+    tape('max_correction_length > query length', (t) => {
+        // Number of words in the query = 6
+        // parameterized max_correction_length = 5
+        // this test case should not return results because we should not attempt fuzzy search
+        // for a query whose length is greater than the max_correction_length
+        c.geocode('place places 11 unitted states america', { max_correction_length: 5 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features.length, 0, 'ok, does not return a result for max_correction_length > query length');
+            t.end();
+        });
+    });
+
+    tape('max_correction_length <= query length', (t) => {
+        // Number of words in the query = 6
+        // default max_correction_length = 8
+        // this test case should return results because we attempt fuzzy search
+        // for a query whose length <= max_correction_length
+        c.geocode('places places 11 unitted states america', { }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 11, United States', 'ok, returns a result when max_correction_length <= query length');
+            t.end();
+        });
+    });
+
+    tape('verifymatch_stack_limit=1', (t) => {
+        // providing parameter verifymatch_stack_limit=1 reduces the number of indexes sent to VerifyMatch
+        // only returns place 1 from the United States
+        c.geocode('place 1 united', { autocomplete: true, verifymatch_stack_limit: 1 }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.error(res.features[1], undefined, 'Does not include place 1 from United Kingdom');
+            t.end();
+        });
+    });
+
+    tape('verifymatch_stack_limit > 1', (t) => {
+        // providing parameter verifymatch_stack_limit > 1 increases the number of indexes to verifymatch
+        c.geocode('place 1 united', { autocomplete: true, verifymatch_stack_limit: 30 }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.deepEquals(res.features[1].center, [0,1], 'Includes results for id.112 place 1');
+            t.end();
+        });
+    });
+
+    tape('spatialmatch_stack_limit=1', (t) => {
+        // providing parameter spatialmatch_stack_limit=1 reduces the number of stacks to truncate from stackable() filter function
+        // only returns place 1 from the United States
+        c.geocode('place 1 united', { autocomplete: true, spatialmatch_stack_limit: 1 }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.error(res.features[1], undefined, 'Does not include place 1 from United Kingdom');
+            t.end();
+        });
+    });
+
+    tape('spatialmatch_stack_limit > 1', (t) => {
+        // providing parameter spatialmatch_stack_limit > 1 increases the number of stacks to truncate from stackable() filter function
+        c.geocode('place 1 united', { autocomplete: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.deepEquals(res.features[1].center, [0,1], 'Includes results for id.50 place 1');
+            t.end();
+        });
+    });
+
+    tape('stackable_limit=1', (t) => {
+        // providing parameter stackable_limit=1 determines the number of stacks considered for type filtering
+        // only returns place 1 from the United States
+        c.geocode('place 1 united', { autocomplete: true, stackable_limit: 1, spatialmatch_stack_limit: 1 }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.error(res.features[1], undefined, 'Does not include place 1 from United Kingdom');
+            t.end();
+        });
+    });
+
+    tape('stackable_limit > 1', (t) => {
+        // providing parameter stackable_limit>1 determines the number of stacks considered for type filtering
+        c.geocode('place 1 united', { autocomplete: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].place_name, 'place 1, United States', 'returns place 1 from United States');
+            t.deepEquals(res.features[0].center, [0,0], 'Center for place 1 from United States');
+            t.deepEquals(res.features[1].center, [0,1], 'Includes results for id.50 place 1');
+            t.end();
+        });
+    });
+
+})();

--- a/test/unit/geocoder/spatialmatch.stackable.test.js
+++ b/test/unit/geocoder/spatialmatch.stackable.test.js
@@ -3,6 +3,7 @@ const stackable = require('../../../lib/geocoder/spatialmatch.js').stackable;
 const sortByRelevLengthIdx = require('../../../lib/geocoder/spatialmatch.js').sortByRelevLengthIdx;
 const sortByZoomIdx = require('../../../lib/geocoder/spatialmatch.js').sortByZoomIdx;
 const phrasematch = require('../../../lib/geocoder/phrasematch');
+const constants = require('../../../lib/constants');
 const Phrasematch = phrasematch.Phrasematch;
 const PhrasematchResult = phrasematch.PhrasematchResult;
 const test = require('tape');
@@ -14,7 +15,7 @@ test('stackable simple', (t) => {
     let debug = stackable([
         new PhrasematchResult([a1], { idx: 0, bmask: {}, ndx: 0 }),
         new PhrasematchResult([b1, b2], { idx: 1, bmask: {}, ndx: 1 })
-    ]);
+    ], constants.STACKABLE_LIMIT);
 
     debug.forEach((stack) => { stack.sort(sortByZoomIdx); });
     debug.sort(sortByRelevLengthIdx);
@@ -37,7 +38,7 @@ test('stackable nmask', (t) => {
         new PhrasematchResult([a1], { idx: 0, bmask: {}, ndx: 0 }),
         new PhrasematchResult([b1], { idx: 1, bmask: {}, ndx: 1 }),
         new PhrasematchResult([c1], { idx: 2, bmask: {}, ndx: 1 })
-    ]);
+    ], constants.STACKABLE_LIMIT);
 
     debug.forEach((stack) => { stack.sort(sortByZoomIdx); });
     debug.sort(sortByRelevLengthIdx);
@@ -58,7 +59,7 @@ test('stackable bmask', (t) => {
     let debug = stackable([
         new PhrasematchResult([a1], { idx: 0, bmask: [0, 1], ndx: 0 }),
         new PhrasematchResult([b1], { idx: 1, bmask: [1, 0], ndx: 1 })
-    ]);
+    ], constants.STACKABLE_LIMIT);
 
     debug.forEach((stack) => { stack.sort(sortByZoomIdx); });
     debug.sort(sortByRelevLengthIdx);
@@ -84,7 +85,7 @@ test('stackable complex', (t) => {
         new PhrasematchResult([a1, a2], { idx: 0, bmask: [], ndx: 0 }),
         new PhrasematchResult([b1, b2], { idx: 1, bmask: [], ndx: 1 }),
         new PhrasematchResult([c1, c2], { idx: 1, bmask: [], ndx: 2 }),
-    ]);
+    ], constants.STACKABLE_LIMIT);
 
     debug.forEach((stack) => { stack.sort(sortByZoomIdx); });
     debug.sort(sortByRelevLengthIdx);
@@ -120,7 +121,7 @@ test('stackable direction change', (t) => {
         new PhrasematchResult([b1, b2], { idx: 1, bmask: [], ndx: 1 }),
         new PhrasematchResult([c1, c2], { idx: 2, bmask: [], ndx: 2 }),
         new PhrasematchResult([d1, d2], { idx: 3, bmask: [], ndx: 3 }),
-    ]);
+    ], constants.STACKABLE_LIMIT);
 
     debug.forEach((stack) => { stack.sort(sortByZoomIdx); });
     debug.sort(sortByRelevLengthIdx);
@@ -186,7 +187,7 @@ test('stackable bench', (t) => {
             }
         }
         const start = +new Date;
-        stackable(phraseMatches);
+        stackable(phraseMatches, constants.STACKABLE_LIMIT);
         return (+new Date) - start;
     }
     t.end();


### PR DESCRIPTION
### Context
Per #746, 
This allows users to toggle limits that have been currently hard coded for performance benefits. The defaults have been added to the `constants.js` file and are overriden if the user provides a value through the options object.

### Summary of Changes
- [ ] changes to `constants.js` to include the default values 
- [ ] changes to verify, spatial and phrase match use options when provided
- [ ] tests to illustrate differences when the cutoffs are provided vs when the default is used

### Next Steps
- [ ] Bench marks
- [ ] js docs for the new options in `geocode.js`

cc @mapbox/geocoding-gang
