### PR TITLE
Sort final results with equal relevance by distance

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -206,6 +206,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
         }
     }
 
+
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
     result.sort(sortFeature);
@@ -387,19 +388,21 @@ function verifyContext(context, peers, strict, loose, indexes) {
 }
 
 /**
-* sortFeature - sorts the best results in the features according to the relevance, scoredist, position or if the address exists
+* sortFeature - sorts the best results in the features according to the relevance, distance, position or if the address exists
 */
 function sortFeature(a, b) {
+    // highest relevance
     return (b.properties['carmen:spatialmatch'].relev - a.properties['carmen:spatialmatch'].relev) ||
+    // prefer features with address included
         ((a.properties['carmen:address'] === null ? 1 : 0) - (b.properties['carmen:address'] === null ? 1 : 0)) ||
         ((a.geometry && a.geometry.omitted ? 1 : 0) - (b.geometry && b.geometry.omitted ? 1 : 0)) ||
-        ((b.properties['carmen:scoredist'] || 0) - (a.properties['carmen:scoredist'] || 0)) ||
+        ((a.properties['carmen:distance'] || 0) - (b.properties['carmen:distance'] || 0)) ||
         ((a.properties['carmen:position'] || 0) - (b.properties['carmen:position'] || 0)) ||
         0;
 }
 
 /**
-* sortContext - sort contexts based on the relevance, then score, layer type, address position, spatialmatch position and then id
+* sortContext - sort contexts based on the relevance, then distance, layer type, address position, spatialmatch position and then id
 */
 function sortContext(a, b) {
     // First, compute the relevance of this query term against
@@ -407,11 +410,9 @@ function sortContext(a, b) {
     if (a._relevance > b._relevance) return -1;
     if (a._relevance < b._relevance) return 1;
 
-    // sort by score
-    const as = a[0].properties['carmen:scoredist'] || 0;
-    const bs = b[0].properties['carmen:scoredist'] || 0;
-    if (as > bs) return -1;
-    if (as < bs) return 1;
+    // sort by distance
+    if (a[0].properties['carmen:distance'] < b[0].properties['carmen:distance']) return -1;
+    if (a[0].properties['carmen:distance'] > b[0].properties['carmen:distance']) return 1;
 
     // layer type
     if (a._typeindex < b._typeindex) return -1;

--- a/test/acceptance/geocode-unit.promote-language.test.js
+++ b/test/acceptance/geocode-unit.promote-language.test.js
@@ -95,7 +95,7 @@ tape('build queued features', (t) => {
 
 tape('find new york', (t) => {
     c.geocode('new york usa', {}, (err, res) => {
-        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].id, 'region.1');
         t.equal(res.features[0].relevance, 1);
         t.end();
     });
@@ -103,7 +103,7 @@ tape('find new york', (t) => {
 
 tape('find nueva york, language=es', (t) => {
     c.geocode('nueva york usa', { language: 'es' }, (err, res) => {
-        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].id, 'region.1');
         t.equal(res.features[0].relevance, 0.98, "query has penalty applied because 'usa' has no es translation");
         t.end();
     });
@@ -111,7 +111,7 @@ tape('find nueva york, language=es', (t) => {
 
 tape('find nueva york, language=ca', (t) => {
     c.geocode('nueva york', { language: 'ca' }, (err, res) => {
-        t.equal(res.features[0].id, 'place.1');
+        t.equal(res.features[0].id, 'region.1');
         t.equal(res.features[0].relevance, 1.00, "query has full relevance because 'nueva york' has no ca translation but es falls back");
         t.end();
     });
@@ -219,4 +219,3 @@ tape('teardown', (t) => {
     context.getTile.cache.reset();
     t.end();
 });
-

--- a/test/acceptance/geocode-unit.promote-on-identical-name.test.js
+++ b/test/acceptance/geocode-unit.promote-on-identical-name.test.js
@@ -162,7 +162,7 @@ tape('build queued features', (t) => {
 
 tape('let\'s find new york', (t) => {
     c.geocode('new york usa', {}, (err, res) => {
-        t.equal(res.features[0].id, 'place.3');
+        t.equal(res.features[0].id, 'region.2');
         t.equal(res.features[0].relevance, 1);
         t.end();
     });
@@ -280,7 +280,7 @@ tape('build queued features', (t) => {
 
 tape('nonthaburi', (t) => {
     c2.geocode('nonthaburi', {}, (err, res) => {
-        t.equal(res.features[0].id.split('.')[0], 'place', 'lead feature is place');
+        t.equal(res.features[0].id.split('.')[0], 'region', 'lead feature is place');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.promote-score.test.js
+++ b/test/acceptance/geocode-unit.promote-score.test.js
@@ -114,7 +114,7 @@ tape('build queued features', (t) => {
 
 tape('find georgia', (t) => {
     c.geocode('georgia', {}, (err, res) => {
-        t.equal(res.features[0].id, 'region.1');
+        t.equal(res.features[0].id, 'country.2');
         t.equal(res.features[0].relevance, 1.00);
         t.end();
     });
@@ -124,4 +124,3 @@ tape('teardown', (t) => {
     context.getTile.cache.reset();
     t.end();
 });
-

--- a/test/acceptance/geocode-unit.score.test.js
+++ b/test/acceptance/geocode-unit.score.test.js
@@ -226,9 +226,9 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('china', (t) => {
         c.geocode('china', { limit_verify:3, allow_dupes: true }, (err, res) => {
             t.ifError(err);
-            t.deepEqual(res.features[0].id, 'province.2');
-            t.deepEqual(res.features[1].id, 'city.3');
-            t.deepEqual(res.features[2].id, 'country.1');
+            t.deepEqual(res.features[0].id, 'country.1');
+            t.deepEqual(res.features[1].id, 'province.2');
+            t.deepEqual(res.features[2].id, 'city.3');
             t.deepEqual(res.features.length, 3);
             t.end();
         });
@@ -236,7 +236,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     tape('china (dedupe)', (t) => {
         c.geocode('china', { limit_verify:3 }, (err, res) => {
             t.ifError(err);
-            t.deepEqual(res.features[0].id, 'province.2');
+            t.deepEqual(res.features[0].id, 'country.1');
             t.deepEqual(res.features.length, 1);
             t.end();
         });
@@ -276,4 +276,3 @@ tape('teardown', (t) => {
     context.getTile.cache.reset();
     t.end();
 });
-

--- a/test/acceptance/geocode-unit.scoredist.test.js
+++ b/test/acceptance/geocode-unit.scoredist.test.js
@@ -62,10 +62,10 @@ const queue = require('d3-queue').queue;
         });
         q.awaitAll(t.end);
     });
-    tape('geocode proximity=10,10 => superscored', (t) => {
+    tape('geocode proximity=10,10 => nearest', (t) => {
         c.geocode('main st', { proximity:[10,10] }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].id, 'address.200', 'found address.200');
+            t.equals(res.features[0].id, 'address.201', 'found address.200');
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.scoresort.test.js
+++ b/test/acceptance/geocode-unit.scoresort.test.js
@@ -140,12 +140,11 @@ const queue = require('d3-queue').queue;
         q.awaitAll(t.end);
     });
 
-    // High-scored feature wins over low-scored features in index with high max score
-    tape('high score beats low score + high scorefactor', (t) => {
+    tape('results sorted by distance regardless of score', (t) => {
         c.geocode('smallville', null, (err, res) => {
             t.ifError(err);
-            t.equal(res.features[0].id, 'lamplace.1', 'Place (high score) is first result');
-            t.equal(res.features[1].id, 'namplace.1', 'Place (high score) is second result');
+            t.equal(res.features[0].id, 'place.1', 'Closest feature is first result');
+            t.equal(res.features[1].id, 'lamplace.1', 'Second closest feature is second result');
             t.end();
         });
     });
@@ -155,4 +154,3 @@ const queue = require('d3-queue').queue;
     });
 
 })();
-

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -4,22 +4,168 @@ const tape = require('tape');
 const bigAddress = require('../../fixtures/bigaddress.json');
 
 tape('verifymatch.sortFeature', (t) => {
-    const arr = [
-        { id: 7, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
-        { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
-        { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
-        { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
-        { id: 3, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
-        { id: 2, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
-        { id: 1, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
-    ];
-    arr.sort(verifymatch.sortFeature);
-    t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7]);
+
+    t.test('sort fake features in order', (t) => {
+        const arr = [
+            { id: 7, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
+            { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
+            { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
+            { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:distance': 5 }, geometry: {} },
+            { id: 3, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:distance': 4 }, geometry: {} },
+            { id: 2, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:distance': 3, 'carmen:position': 2 }, geometry: {} },
+            { id: 1, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:distance': 2, 'carmen:position': 1 }, geometry: {} }
+        ];
+        arr.sort(verifymatch.sortFeature);
+        t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7]);
+        t.end();
+    });
+
+    t.test('new york near san francisco', (t) => {
+        // --query="new york" --proximity="-122.4234,37.7715"
+        const input = [
+            { properties: { text: 'New York,NY,NYC,New York City', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104 } },
+            { properties: { text: 'New Yorker Buffalo Wings', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.6450163846417221, 'carmen:score': 3 } },
+            { properties: { text: 'New York Frankfurter Co.', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.4914344651849769, 'carmen:score': 1 } },
+            { properties: { text: 'New York,NY', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2426.866703400975, 'carmen:score': 79161 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'New York Frankfurter Co.', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.4914344651849769, 'carmen:score': 1 } },
+            { properties: { text: 'New Yorker Buffalo Wings', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.6450163846417221, 'carmen:score': 3 } },
+            { properties: { text: 'New York,NY', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2426.866703400975, 'carmen:score': 79161 } },
+            { properties: { text: 'New York,NY,NYC,New York City', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('chicago near san francisco', (t) => {
+        // --query="chicago" --proximity="-122.4234,37.7715"
+        const input = [
+            { properties: { text: 'Chicago', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988 } },
+            { properties: { text: 'Chicago Title', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.14084037845690478, 'carmen:score': 2 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'Chicago Title', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.14084037845690478, 'carmen:score': 2 } },
+            { properties: { text: 'Chicago', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('san near north sonoma county', (t) => {
+        // --query="san" --proximity="-123.0167,38.7471"
+        const input = [
+            { properties: { text: 'Santa Cruz', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 133.8263938095184, 'carmen:score': 587 } },
+            { properties: { text: 'São Paulo', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 6547.831697209755, 'carmen:score': 36433 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 6023.053777668511, 'carmen:score': 26709 } },
+            { properties: { text: 'San Francisco', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 74.24466022598429, 'carmen:score': 8015 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'San Francisco', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 74.24466022598429, 'carmen:score': 8015 } },
+            { properties: { text: 'Santa Cruz', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 133.8263938095184, 'carmen:score': 587 } },
+            { properties: { text: 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 6023.053777668511, 'carmen:score': 26709 } },
+            { properties: { text: 'São Paulo', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 6547.831697209755, 'carmen:score': 36433 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('santa cruz near sonoma county', (t) => {
+        // --query="santa cruz" --proximity="-123.0167,38.7471"
+        const input = [
+            { properties: { text: 'Santa Cruz', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 133.8263938095184, 'carmen:score': 587 } },
+            { properties: { text: 'Santa Cruz de Tenerife', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 5811.283048403849, 'carmen:score': 3456 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'Santa Cruz', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 133.8263938095184, 'carmen:score': 587 } },
+            { properties: { text: 'Santa Cruz de Tenerife', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 5811.283048403849, 'carmen:score': 3456 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('washington near baltimore', (t) => {
+        // --query="washington" --proximity="-76.6035,39.3008"
+        const input = [
+            { properties: { text: 'Washington,DC', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 34.81595024835296, 'carmen:score': 7400 } },
+            { properties: { text: 'Washington,WA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'Washington,DC', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 34.81595024835296, 'carmen:score': 7400 } },
+            { properties: { text: 'Washington,WA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('gilmour ave near guelph, on, canada', (t) => {
+        // --query="gilmour ave" --proximity="-80.1617,43.4963"
+        const input = [
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 36.12228253928214, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 188.29482550861198, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 246.29759329605977, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 3312.294287119006, 'carmen:score': 3 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 36.12228253928214, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 188.29482550861198, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 246.29759329605977, 'carmen:score': 0 } },
+            { properties: { text: 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 3312.294287119006, 'carmen:score': 3 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('cambridge near guelph, on, canada', (t) => {
+        // --query="cambridge" --proximity="-80.1617,43.4963"
+        const input = [
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 10.73122383596493, 'carmen:score': 294 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 464.50390088754625, 'carmen:score': 986 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721 } }
+        ];
+
+        const expected = [
+            { properties: { text: 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 10.73122383596493, 'carmen:score': 294 } },
+            { properties: { text: 'Cambridge, 02139, Massachusetts, United States', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 464.50390088754625, 'carmen:score': 986 } },
+            { properties: { text: 'Cambridgeshire, United Kingdom', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
+
+    t.test('united states near washington dc', (t) => {
+        // --query="United States" --proximity="-77.03361679999999,38.900039899999996"
+        const input = [
+            { properties: { text: 'United States of America, United States, America, USA, US', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 1117.3906777683906, 'carmen:score': 1634443 } },
+            { properties: { text: 'United States Department of Treasury Annex', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.11774815645353183, 'carmen:score': 0 } },
+        ];
+
+        const expected = [
+            { properties: { text: 'United States Department of Treasury Annex', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 0.11774815645353183, 'carmen:score': 0 } },
+            { properties: { text: 'United States of America, United States, America, USA, US', 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:distance': 1117.3906777683906, 'carmen:score': 1634443 } }
+        ];
+
+        t.deepEqual(input.sort(verifymatch.sortFeature), expected);
+        t.end();
+    });
 
     t.end();
 });
 
-tape('verifymatch.sortContext (no distance)', (t) => {
+tape('verifymatch.sortContext (with distance)', (t) => {
     let c;
     const arr = [];
 
@@ -39,80 +185,41 @@ tape('verifymatch.sortContext (no distance)', (t) => {
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ id: 6, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 1 }, geometry: {} }];
+    c = [{ id: 6, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 2 }, geometry: {} }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ id: 5, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, _geometry: {} }];
+    c = [{ id: 5, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1 }, geometry: {} }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ id: 4, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
+    c = [{ id: 4, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1 }, geometry: {} }];
     c._relevance = 1.0;
     c._typeindex = 2;
     arr.push(c);
 
-    c = [{ id: 3, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    c._distance = 20;
-    arr.push(c);
-
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    c._distance = 10;
-    arr.push(c);
-
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2, 'carmen:position': 2 }, geometry: {} }];
+    c = [{ id: 3, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1 }, geometry: {} }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
 
-    c = [{ id: 0, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2, 'carmen:position': 1 }, geometry: {} }];
+    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1 }, geometry: {} }];
+    c._relevance = 1.0;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1, 'carmen:position': 2 }, geometry: {} }];
+    c._relevance = 1.0;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 0, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 1, 'carmen:position': 1 }, geometry: {} }];
     c._relevance = 1.0;
     c._typeindex = 1;
     arr.push(c);
 
     arr.sort(verifymatch.sortContext);
     t.deepEqual(arr.map((c) => { return c[0].id; }), [0,1,2,3,4,5,6,7,8,9,10]);
-
-    t.end();
-});
-
-tape('verifymatch.sortContext (with distance)', (t) => {
-    let c;
-    const arr = [];
-
-    c = [{ id: 6 }];
-    c._relevance = 0.9;
-    arr.push(c);
-
-    c = [{ id: 5, properties: { 'carmen:address': '26' } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 4, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: { omitted: true } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 3, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 2;
-    arr.push(c);
-
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 1 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    arr.sort(verifymatch.sortContext);
-    t.deepEqual(arr.map((c) => { return c[0].id; }), [1,2,3,4,5,6]);
 
     t.end();
 });
@@ -125,11 +232,11 @@ tape('verifymatch.sortContext (distance vs addresstype)', (t) => {
     c._relevance = 0.9;
     arr.push(c);
 
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:scoredist': 1, 'carmen:addressnumber': [] } }];
+    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:distance': 2 } }];
     c._relevance = 1.0;
     arr.push(c);
 
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:scoredist': 2 } }];
+    c = [{ id: 1, properties: { 'carmen:address': '26' , 'carmen:distance': 1 } }];
     c._relevance = 1.0;
     arr.push(c);
 


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/749. Sorts results with equal relevance by distance and disregards score entirely. I originally tried stripping out all the places in verifymatch where we use `score` or `scoredist` and found it ended up being more trouble than it was worth. We should still run this branch against our downstream acceptance tests, but it's very unlikely we'd want to take this approach in production. It completely disregards _any_ sorting based on score/prominence and would mean that lower prominence, local results would be surfaced before local prominent results.


### Summary of Changes
- [ ] sort by `distance` instead of `scoredist` in `sortFeature` function
- [ ] sort by `distance` instead of `sortContext` in `sortFeature` function
- [ ] update acceptance and unit tests


### Next Steps
- [ ] publish a dev release
- [ ] run against downstream tests

cc @aarthykc @apendleton @miccolis @boblannon 
