### PR TITLE
Don't bother stacking if a query is a single word

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -27,7 +27,18 @@ module.exports.sortByZoomIdx = sortByZoomIdx;
 function spatialmatch(query, phrasematchResults, options, callback) {
     let stacks;
 
-    if (phrasematchResults.length) {
+    if (phrasematchResults.length === 0) {
+        stacks = [];
+    } else if (query.length === 1) {
+        stacks = phrasematchResults.reduce((m, r) => {
+            if (r.length === 0) return m;
+            for (let i = 0; i < r.phrasematches.length; i++) {
+                // Todo probably missing relev & adjRelev
+                m.push([r.phrasematches[i]]);
+            }
+            return m;
+        },[]);
+    } else {
         // Fuzzy matching may have produced multiple phrasematches that will
         // behave identically when stacking -- they come from the same index
         // and have the same mask and weight. To avoid duplicate effort, we
@@ -40,8 +51,6 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         arch_stacks.sort(sortByRelevLengthIdx);
         arch_stacks = arch_stacks.slice(0, options.spatialmatch_stack_limit);
         stacks = expandFromArchetypes(arch_stacks, options.spatialmatch_stack_limit);
-    } else {
-        stacks = [];
     }
 
     // Rebalance weights, relevs of stacks here.


### PR DESCRIPTION
### Context
I'm wondering if stackable really needs for run for single word queries. PR attempts this shortcut. I'm pretty sure there are still missing pieces here, but tests pass. 

### Next Steps
- [ ] See what happens with a larger dataset
- [ ] Enforce the same limit that stackable does

cc @mapbox/geocoding-gang
