### PR TITLE
Consider nmask earlier in stackable

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -265,6 +265,8 @@ function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, rel
 
     const phrasematchResult = phrasematchResults[idx];
 
+    if (nmask & phrasematchResult.nmask) return;
+
     // For each stacked item check the next bmask for its idx.
     // If the bmask includes the idx these indexes cannot stack
     // (their geocoder_stack do not intersect at all).
@@ -278,7 +280,7 @@ function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, rel
     for (let i = 0; i < phrasematches.length; i++) {
         const next = phrasematches[i];
         if (mask & next.mask) continue;
-        if (nmask & phrasematchResult.nmask) continue;
+        if (nmask & phrasematchResult.nmask) throw new Error('Hrmmm');
 
         // compare index order to input order to determine direction
         if (stack.length &&


### PR DESCRIPTION
### Context
Another potential speedup, this PR avoids checking the `nmask` or the index and match being evaluated more than once per index. Not totally clear what this gets us, but it should avoid unnecessary iteration.

### Next Steps
- [ ] Verify that we want this, and remote the extraneous throw :)

cc @mapbox/geocoding-gang
