### PR TITLE
Use proximity point and index bboxes as an additional stack sort hint

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -152,6 +152,10 @@ module.exports = function phrasematch(source, query, options, callback) {
     // cross-index comparisons.
     const scorefactor = (source._geocoder.freq.get('__MAX__') || [0])[0] || 1;
 
+    const proxMatch = options.proximity ?
+        bb.inside(options.proximity, source.bounds) :
+        false;
+
     const phrasematches = [];
 
     for (const subquery of subqueries) {
@@ -185,7 +189,7 @@ module.exports = function phrasematch(source, query, options, callback) {
 
         const prefix = (subquery.ender && !(source.geocoder_address && termops.isAddressNumber(subquery)));
 
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages, editMultiplier));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, scorefactor, source.idx, source._geocoder.grid, source.zoom, prefix, languages, editMultiplier, proxMatch));
     }
 
     return callback(null, new PhrasematchResult(phrasematches, source));
@@ -209,7 +213,7 @@ function PhrasematchResult(phrasematches, source) {
 * Attributes used by carmen-cache, all phrasematches from the same source have the same values for idx, cache, zoom
 **/
 module.exports.Phrasematch = Phrasematch;
-function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages, editMultiplier) {
+function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zoom, prefix, languages, editMultiplier, proxMatch) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -221,8 +225,9 @@ function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zo
     this.cache = cache;
     this.zoom = zoom;
     this.editMultiplier = editMultiplier || 1;
+    this.proxMatch = proxMatch || false;
 }
 
 Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages, this.editMultiplier);
+    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.scorefactor, this.idx, this.cache, this.zoom, this.prefix, this.languages, this.editMultiplier, this.proxMatch);
 };

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -340,6 +340,7 @@ function sortByRelevLengthIdx(a, b) {
     const first = (b.adjRelev - a.adjRelev) ||
         (a.length - b.length) ||
         (b.relev - a.relev) ||
+        (b[b.length - 1].proxMatch - a[a.length - 1].proxMatch) ||
         (b[b.length - 1].scorefactor - a[a.length - 1].scorefactor);
     if (first) return first;
 

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -151,6 +151,8 @@ function collapseToArchetypes(phrasematchResults) {
                     editMultiplier: inMatch.editMultiplier,
                     zoom: inMatch.zoom,
                     idx: inResult.idx,
+                    scorefactor: inMatch.scorefactor,
+                    proxMatch: inMatch.proxMatch,
                     exemplars: []
                 };
                 uniqMap.set(signature, outMatch);

--- a/test/acceptance/geocode-unit.prox_match.test.js
+++ b/test/acceptance/geocode-unit.prox_match.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../../lib/indexer/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+/**
+ * This test ensures that the sort algo in spatialMatch (pre cutoff)
+ * Uses the bbox of a given index to sort results if a proximity point is uses
+ *
+ * Indexes where the proximity point exists within the bbox will be sorted
+ * higher than those without
+ */
+const conf = {
+    poi1: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi1',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    poi2: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi2',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    poi3: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi3',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    poi4: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi4',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    poi5: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi5',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    poi6: new mem({
+        maxzoom: 6,
+        geocoder_type: 'poi6',
+        geocoder_name: 'poi',
+        bounds: [-26.191406,-17.140790,33.574219,8.754795]
+    }, () => {}),
+    good: new mem({
+        maxzoom: 6,
+        geocoder_type: 'good',
+        geocoder_name: 'poi',
+        bounds: [-106.171875,30.297018,-53.085938,54.059388]
+    }, () => {})
+};
+const c = new Carmen(conf);
+
+for (let i = 1; i < 7; i++) {
+    tape(`index poi${i}`, (t) => {
+        const poi = {
+            id: 1,
+            properties: {
+                'carmen:text': 'poi',
+                'carmen:center':[0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        queueFeature(conf[`poi${i}`], poi, t.end);
+    });
+}
+
+tape('index goodpoi', (t) => {
+    const poi = {
+        id: 1,
+        properties: {
+            'carmen:text':'poi I am good',
+            'carmen:center':[-81.74573, 41.49342]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [-81.74573, 41.49342]
+        }
+    };
+    queueFeature(conf.good, poi, t.end);
+});
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('Proximityless query', (t) => {
+    c.geocode('poi', {}, (err, res) => {
+        t.error(err);
+        t.ok(res.features[0].id !== 'goodpoi.1');
+        t.end();
+    });
+});
+
+tape('Proximity query', (t) => {
+    c.geocode('poi', {
+        spatialmatch_stack_limit: 2,
+        proximity: [-81.74573, 41.49342]
+    }, (err, res) => {
+        t.error(err);
+        t.equals(res.features[0].id, 'good.1');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});
+


### PR DESCRIPTION
### Context
#758 resulted in some changes in behavior for proximity-sensitive queries such that in some circumstances, the ideal response no longer made it above the 30-stack cutoff in spatialmatch. This PR introduces an additional hint for proximity queries to increase the odds that the right one makes it above the cutoff, and also fixes a bug I incidentally found along the way.


### Summary of Changes
- [x] for queries that have proximity points, at phrasematch time, check for each index whether or not the proximity point is inside the index's bbox, and attach the result to the phrasematch object
- [x] use bbox/prox-point overlap as an ordering hint, to prefer matches from indexes that contain the prox point over ones that don't
- [x] ensure that prox info is copied over in `collapseToArchetypes` in spatialmatch, and also do the same for `scorefactor`, which was supposed to be copied but wasn't, rendering that sort hint ineffective


### Next Steps
- [x] Tests. Definitely for the new proximity behavior, and also probably for the scorefactor behavior, since that was broken and nobody realized.


cc @mapbox/search 
