### PR TITLE
Be smarter about what we phrasematch

### DIFF
--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -356,10 +356,12 @@ function forwardGeocode(geocoder, query, options, callback) {
     // set an allowed_idx hash to limit spatialmatch stack i/o only to features
     // that are allowed by options.types.
     options.allowed_idx = {};
+    let maxidx = 0;
     for (const type in geocoder.bytype) {
         if (options.types && options.types.indexOf(type) === -1) continue;
         for (let i = 0; i < geocoder.bytype[type].length; i++) {
             options.allowed_idx[geocoder.bytype[type][i].idx] = true;
+            maxidx = Math.max(maxidx, geocoder.bytype[type][i].idx + 1);
         }
     }
 
@@ -367,31 +369,38 @@ function forwardGeocode(geocoder, query, options, callback) {
         if (options.types && options.types.indexOf(subtype) === -1) continue;
         for (let st = 0; st < geocoder.bysubtype[subtype].length; st++) {
             options.allowed_idx[geocoder.bysubtype[subtype][st].idx] = true;
+            maxidx = Math.max(maxidx, geocoder.bysubtype[subtype][st].idx + 1);
         }
     }
 
     // search runs `geocoder.search` over each backend with `data.query`,
     // condenses all of the results, and sorts them by potential usefulness.
-    for (const dbid in geocoder.indexes) q.defer(phrasematch, geocoder.indexes[dbid], query, options);
-    q.awaitAll((err, phrasematchResults) => {
+    for (const dbid in geocoder.indexes) {
+        if (geocoder.indexes[dbid].idx < maxidx) {
+            q.defer(phrasematch, geocoder.indexes[dbid], query, options);
+        }
+    }
+    q.awaitAll((err, _phrasematchResults) => {
         if (err) return callback(err);
+
         if (options.stats) {
             stats.spatialmatch.time = +new Date;
             stats.phrasematch.time = +new Date - stats.phrasematch.time;
         }
         if (options.debug) {
             options.debug.phrasematch = {};
-            for (let idx = 0; idx < phrasematchResults.length; idx++) {
-                const id = geocoder.byidx[idx].id;
+            for (const resultSet of _phrasematchResults) {
+                const id = geocoder.byidx[resultSet.idx].id;
                 options.debug.phrasematch[id] = {};
-                for (let x = 0; x < phrasematchResults[idx].phrasematches.length; x++) {
-                    const matched = phrasematchResults[idx].phrasematches[x];
+                for (let x = 0; x < resultSet.phrasematches.length; x++) {
+                    const matched = resultSet.phrasematches[x];
                     const phraseText = matched.subquery.join(' ');
                     options.debug.phrasematch[id][phraseText] = matched.weight;
                 }
             }
         }
 
+        const phrasematchResults = _phrasematchResults.filter((resultSet) => resultSet.phrasematches.length > 0);
         spatialmatch(queryData.query, phrasematchResults, options, spatialmatchComplete);
     });
 


### PR DESCRIPTION
### Context
At present we every index on every forward query even if we can't use those results because of a type filter (we rely on a later check in spatialmatch instead). This branch adds some more checks so we phrasematch less stuff.


### Summary of Changes
- [x] if the types filter is turned on, only attempt phrasematch operations on indexes that are either included in the types filter or have a lower idx (borrowing the `maxidx` strategy we already use in reverse)
- [x] after phrasematch, only include phrasematch result sets that actually found something, which should make stackable recurse a little less
- [x] fix some debug-mode code that expected to find phrasematch results for every index


### Next Steps
- [x] confirm that downstream tests still look fine


cc @mapbox/geocoding-gang
