### PR TITLE
Auto-populate language text from default text

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ function Geocoder(indexes, options) {
             const types = info.geocoder_types || [type];
             let stack = info.geocoder_stack || false;
             const languages = info.geocoder_languages || [];
+            const autopopulate = info.geocoder_languages_from_default || {};
             if (typeof stack === 'string') stack = [stack];
 
             const scoreRangeKeys = info.scoreranges ? Object.keys(info.scoreranges) : [];
@@ -217,6 +218,7 @@ function Geocoder(indexes, options) {
             lang.lang_map = {};
             lang.languages.forEach((l, idx) => { lang.lang_map[l] = idx; });
             lang.lang_map['unmatched'] = 128; // @TODO verify this is the right approach
+            lang.autopopulate = autopopulate;
             source.lang = lang;
 
             // add byname index lookup

--- a/lib/geocoder/ops.js
+++ b/lib/geocoder/ops.js
@@ -228,7 +228,7 @@ function getMatchingText(item, geocoder, requestedLanguage) {
     const textKey = closest ? 'carmen:text_' + closest : 'carmen:text';
     const closestText = item.properties[textKey].split(',')[0];
 
-    if (item.properties['carmen:matches_language'] && !/,/.exec(item.properties[textKey])) return;
+    if (item.properties['carmen:matches_language'] && (requestedLanguage ? closest === requestedLanguage : true) && !/,/.exec(item.properties[textKey])) return;
 
     // now we get to play the came of figuring out which phrase this was originally
     const source = geocoder.byidx[item.properties['carmen:idx']];

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -317,7 +317,10 @@ function loadDoc(freq, patch, doc, source, zoom, token_replacer, globalTokens) {
     const maxScore = freq['__MAX__'][0] || 0;
     const scaledScore = termops.encode3BitLogScale(doc.properties['carmen:score'], maxScore) || 0;
 
-    const texts = termops.getIndexableText(token_replacer, globalTokens, doc, false);
+
+    const stack = doc.properties['carmen:geocoder_stack'] || '';
+    const autopopulate = source.lang.autopopulate[stack] || false;
+    const texts = termops.getIndexableText(token_replacer, globalTokens, doc, autopopulate);
     const allPhrases = new Map();
     let phrase, phraseObj, languages, y = new Map(); // eslint-disable-line prefer-const
 

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -320,7 +320,7 @@ function loadDoc(freq, patch, doc, source, zoom, token_replacer, globalTokens) {
 
     const stack = doc.properties['carmen:geocoder_stack'] || '';
     const autopopulate = source.lang.autopopulate[stack] || false;
-    const texts = termops.getIndexableText(token_replacer, globalTokens, doc, autopopulate);
+    const texts = termops.getIndexableText(token_replacer, globalTokens, doc, autopopulate, source.categories);
     const allPhrases = new Map();
     let phrase, phraseObj, languages, y = new Map(); // eslint-disable-line prefer-const
 

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -242,7 +242,7 @@ function getHousenumRangeV3(doc) {
 // Takes a geocoder_tokens token mapping and a text string and returns
 // an array of one or more arrays of tokens that should be indexed.
 module.exports.getIndexableText = getIndexableText;
-function getIndexableText(replacer, globalTokens, doc) {
+function getIndexableText(replacer, globalTokens, doc, defaultLanguages) {
     const indexableText = Object.create(null);
 
     // find all the per-language fields
@@ -257,6 +257,13 @@ function getIndexableText(replacer, globalTokens, doc) {
             if (!cl.hasLanguage(language)) throw new Error(code[1] + ' is an invalid language code');
             if (doc.properties[keys[i]]) langTexts.set(language, keys[i]);
         }
+    }
+
+    let autoPopulate = [];
+    if (defaultLanguages && defaultLanguages.length) {
+        // only include a language in the auto-populate list if we don't have
+        // supplied translations for it
+        autoPopulate = defaultLanguages.filter((lang) => !langTexts.has(lang));
     }
 
     // set up the replacer
@@ -278,6 +285,9 @@ function getIndexableText(replacer, globalTokens, doc) {
                 texts.set(text, langsForText);
             }
             langsForText.push(lang);
+            if (lang == 'default' && autoPopulate.length) {
+                for (const autoLang of autoPopulate) langsForText.push(autoLang);
+            }
         }
     }
 

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -245,7 +245,9 @@ module.exports.getIndexableText = getIndexableText;
 function getIndexableText(replacer, globalTokens, doc) {
     const indexableText = Object.create(null);
 
+    // find all the per-language fields
     const langTexts = new Map();
+    langTexts.set('default', 'carmen:text');
     const keys = Object.keys(doc.properties);
     const length = keys.length;
     for (let i = 0; i < length; i ++) {
@@ -253,58 +255,65 @@ function getIndexableText(replacer, globalTokens, doc) {
         if (code) {
             const language = code[1].replace('-', '_');
             if (!cl.hasLanguage(language)) throw new Error(code[1] + ' is an invalid language code');
-            if (doc.properties[keys[i]]) langTexts.set(keys[i], language);
+            if (doc.properties[keys[i]]) langTexts.set(language, keys[i]);
         }
     }
 
-    const texts = doc.properties['carmen:text'].split(',');
+    // set up the replacer
+    let combinedReplacer = [];
+    if (globalTokens && globalTokens.length) combinedReplacer = combinedReplacer.concat(globalTokens);
+    if (replacer && replacer.length) combinedReplacer = combinedReplacer.concat(replacer);
+
+    const defaultTexts = doc.properties['carmen:text'].split(',');
     const housenumRange = getHousenumRangeV3(doc);
 
-    // get tokens for default text
-    getTokens(texts, 'default');
-
-    // get tokens for each of the languages' text
+    // consolidate all the phrases together across languages
+    const texts = new Map();
     for (const langText of langTexts) {
-        const lang = (langText[1] === 'universal') ? 'all' : langText[1];
-        getTokens(doc.properties[langText[0]].split(','), lang);
-    }
-
-    function getTokens(texts, language) {
-        let combinedReplacer = [];
-        if (globalTokens && globalTokens.length) combinedReplacer = combinedReplacer.concat(globalTokens);
-        if (replacer && replacer.length) combinedReplacer = combinedReplacer.concat(replacer);
-
-        for (let x = 0; x < texts.length; x++) {
-            // push tokens with replacements
-            let variants = token.enumerateTokenReplacements(combinedReplacer, texts[x]);
-
-            // we should limit how many we produce to a not-insane number
-            variants = variants.slice(0, 8);
-
-            for (const variant of variants) {
-                const tokens = tokenize(variant);
-                if (!tokens.length) continue;
-
-                // push tokens with housenum range token if applicable
-                if (housenumRange) {
-                    let l = housenumRange.length;
-                    while (l--) {
-                        const withHousenums = [housenumRange[l]].concat(tokens);
-                        add(withHousenums, language);
-                    }
-                }
-                add(tokens, language);
+        const lang = (langText[0] === 'universal') ? 'all' : langText[0];
+        for (const text of doc.properties[langText[1]].split(',')) {
+            let langsForText = texts.get(text);
+            if (!langsForText) {
+                langsForText = [];
+                texts.set(text, langsForText);
             }
+            langsForText.push(lang);
         }
     }
 
-    function add(tokens, language) {
-        if (!tokens.length) return;
+    // at this point we have a map of a bunch of phrases (so, individual synonyms)
+    // each of which is mapped to a list of languages for which it's valid
 
-        const key = tokens.join(' ');
+    // next we'll get the variants of each phrase, and add them for each language
+    for (const entry of texts) {
+        const text = entry[0];
+        const langs = entry[1];
 
-        indexableText[key] = indexableText[key] || new Set();
-        indexableText[key].add(language);
+        // push tokens with replacements
+        let variants = token.enumerateTokenReplacements(combinedReplacer, text);
+
+        // we should limit how many we produce to a not-insane number
+        variants = variants.slice(0, 8);
+
+        for (const variant of variants) {
+            const tokens = tokenize(variant);
+            if (!tokens.length) continue;
+
+            const keys = [tokens.join(' ')];
+            // push tokens with housenum range token if applicable
+            if (housenumRange) {
+                let l = housenumRange.length;
+                while (l--) {
+                    const withHousenums = [housenumRange[l]].concat(tokens);
+                    keys.push(withHousenums.join(' '));
+                }
+            }
+
+            for (const key of keys) {
+                indexableText[key] = indexableText[key] || new Set();
+                for (const language of langs) indexableText[key].add(language);
+            }
+        }
     }
 
     const output = [];

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -242,7 +242,7 @@ function getHousenumRangeV3(doc) {
 // Takes a geocoder_tokens token mapping and a text string and returns
 // an array of one or more arrays of tokens that should be indexed.
 module.exports.getIndexableText = getIndexableText;
-function getIndexableText(replacer, globalTokens, doc, defaultLanguages) {
+function getIndexableText(replacer, globalTokens, doc, defaultLanguages, categories) {
     const indexableText = Object.create(null);
 
     // find all the per-language fields
@@ -276,8 +276,18 @@ function getIndexableText(replacer, globalTokens, doc, defaultLanguages) {
     // consolidate all the phrases together across languages
     const texts = new Map();
     for (const langText of langTexts) {
-        const lang = (langText[0] === 'universal') ? 'all' : langText[0];
-        for (const text of doc.properties[langText[1]].split(',')) {
+        const synonyms = doc.properties[langText[1]].split(',');
+        for (let i = 0; i < synonyms.length; i++) {
+            const text = synonyms[i].trim();
+
+            let lang;
+            // treat category terms in the non-display position as universal
+            if (langText[0] === 'universal' || (i > 0 && categories && categories.has(text))) {
+                lang = 'all';
+            } else {
+                lang = langText[0];
+            }
+
             let langsForText = texts.get(text);
             if (!langsForText) {
                 langsForText = [];

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -271,7 +271,6 @@ function getIndexableText(replacer, globalTokens, doc, defaultLanguages) {
     if (globalTokens && globalTokens.length) combinedReplacer = combinedReplacer.concat(globalTokens);
     if (replacer && replacer.length) combinedReplacer = combinedReplacer.concat(replacer);
 
-    const defaultTexts = doc.properties['carmen:text'].split(',');
     const housenumRange = getHousenumRangeV3(doc);
 
     // consolidate all the phrases together across languages
@@ -285,7 +284,7 @@ function getIndexableText(replacer, globalTokens, doc, defaultLanguages) {
                 texts.set(text, langsForText);
             }
             langsForText.push(lang);
-            if (lang == 'default' && autoPopulate.length) {
+            if (lang === 'default' && autoPopulate.length) {
                 for (const autoLang of autoPopulate) langsForText.push(autoLang);
             }
         }

--- a/test/acceptance/geocode-unit.language-autopopulate.test.js
+++ b/test/acceptance/geocode-unit.language-autopopulate.test.js
@@ -1,0 +1,82 @@
+'use strict';
+// Ensure that results that have equal relev in phrasematch
+// are matched against the 0.5 relev bar instead of 0.75
+
+const tape = require('tape');
+const Carmen = require('../..');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../../lib/indexer/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+const conf = {
+    country: new mem({ maxzoom: 6, geocoder_languages: ['en', 'es', 'ru', 'zh_Latn'], geocoder_languages_from_default: {'ru': ['en']} }, () => {}),
+};
+const c = new Carmen(conf);
+
+tape('index country', (t) => {
+    const country = {
+        type: 'Feature',
+        properties: {
+            'carmen:center': [0, 0],
+            'carmen:zxy': ['6/30/30'],
+            'carmen:text': 'Russian Federation, Rossiyskaya Federatsiya',
+            'carmen:text_ru': 'Российская Федерация',
+            'carmen:text_zh_Latn': 'Elousi',
+            'carmen:text_es': null,
+            'carmen:geocoder_stack': 'ru'
+        },
+        id: 2,
+        geometry: { type: 'MultiPolygon', coordinates: [] },
+        bbox: [-11.25, 5.615, -5.625, 11.1784]
+    };
+    queueFeature(conf.country, country, t.end);
+});
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('russia => Russian Federation', (t) => {
+    c.geocode('russia', { limit_verify:1, autocomplete:1 }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'Russian Federation');
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance === 1, 'No relevance penalty was applied');
+        t.end();
+    });
+});
+
+tape('russia => Russian Federation', (t) => {
+    c.geocode('russia', { limit_verify:1, language: 'ru' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance < 1, 'Relevance penalty was applied for out of language match');
+        t.end();
+    });
+});
+
+tape('russia => Russian Federation', (t) => {
+    c.geocode('russia', { limit_verify:1, language: 'es' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance < 1, 'Relevance penalty was applied for out of language match');
+        t.end();
+    });
+});
+
+tape('russia => Russian Federation', (t) => {
+    c.geocode('russia', { limit_verify:1, language: 'es' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance < 1, 'Relevance penalty was not applied for English, which was autopopulated');
+        t.end();
+    });
+});

--- a/test/acceptance/geocode-unit.language-autopopulate.test.js
+++ b/test/acceptance/geocode-unit.language-autopopulate.test.js
@@ -11,7 +11,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
     buildQueued = addFeature.buildQueued;
 
 const conf = {
-    country: new mem({ maxzoom: 6, geocoder_languages: ['en', 'es', 'ru', 'zh_Latn'], geocoder_languages_from_default: {'ru': ['en']} }, () => {}),
+    country: new mem({ maxzoom: 6, geocoder_languages: ['en', 'es', 'ru', 'zh_Latn'], geocoder_languages_from_default: { 'ru': ['en'] } }, () => {}),
 };
 const c = new Carmen(conf);
 

--- a/test/acceptance/geocode-unit.language-universal-categories.js
+++ b/test/acceptance/geocode-unit.language-universal-categories.js
@@ -1,0 +1,72 @@
+'use strict';
+// Ensure that results that have equal relev in phrasematch
+// are matched against the 0.5 relev bar instead of 0.75
+
+const tape = require('tape');
+const Carmen = require('../..');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../../lib/indexer/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+const conf = {
+    country: new mem({ maxzoom: 6, geocoder_languages: ['en', 'es', 'ru', 'zh_Latn'], geocoder_languages_from_default: { 'ru': ['en'] }, geocoder_categories: ['coffee'] }, () => {}),
+};
+const c = new Carmen(conf);
+
+tape('index country', (t) => {
+    const country = {
+        type: 'Feature',
+        properties: {
+            'carmen:center': [0, 0],
+            'carmen:zxy': ['6/30/30'],
+            'carmen:text': 'Russian Federation, Rossiyskaya Federatsiya,coffee',
+            'carmen:text_ru': 'Российская Федерация',
+            'carmen:text_zh_Latn': 'Elousi',
+            'carmen:text_es': null,
+            'carmen:geocoder_stack': 'ru'
+        },
+        id: 2,
+        geometry: { type: 'MultiPolygon', coordinates: [] },
+        bbox: [-11.25, 5.615, -5.625, 11.1784]
+    };
+    queueFeature(conf.country, country, t.end);
+});
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('russia => Russian Federation', (t) => {
+    c.geocode('russia', { limit_verify:1, language: 'ru' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance < 1, 'Relevance penalty was applied for out of language match');
+        t.end();
+    });
+});
+
+tape('rossiyskaya => Russian Federation', (t) => {
+    c.geocode('rossiyskaya', { limit_verify:1, language: 'ru' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance < 1, 'Relevance penalty was applied for out of language match');
+        t.end();
+    });
+});
+
+tape('coffee => Russian Federation', (t) => {
+    c.geocode('coffee', { limit_verify:1, language: 'ru' }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].id, 'country.2');
+        t.ok(res.features[0].relevance >= 1, 'Relevance penalty was not applied because categories are universal');
+        t.end();
+    });
+});

--- a/test/unit/indexer/indexdocs.test.js
+++ b/test/unit/indexer/indexdocs.test.js
@@ -33,7 +33,7 @@ tape('indexdocs.loadDoc', (t) => {
     freq[tokens[1]] = [100];
 
     // Indexes single doc.
-    const err = indexdocs.loadDoc(freq, patch, doc, { lang: { has_languages: false } }, zoom, token_replacer);
+    const err = indexdocs.loadDoc(freq, patch, doc, { lang: { has_languages: false, autopopulate: {} } }, zoom, token_replacer);
     t.ok(typeof err !== 'number', 'no error');
 
     t.deepEqual(Object.keys(patch.grid).length, 2, '2 patch.grid entries');

--- a/test/unit/text-processing/termops.getIndexableText.test.js
+++ b/test/unit/text-processing/termops.getIndexableText.test.js
@@ -236,6 +236,23 @@ test('termops.getIndexableText', (t) => {
     ];
     t.deepEqual(termops.getIndexableText(replacer, [], doc, true), texts, 'universal text');
 
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York'} };
+    texts = [
+        { languages: ['default', 'en'], tokens: ['new', 'york'] },
+        { languages: ['es'], tokens: ['nueva', 'york'] }
+    ];
+    t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en']), texts, 'auto-populate from default works');
+
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'text_en': 'The Big Apple'} };
+    texts = [
+        { languages: ['default'], tokens: ['new', 'york'] },
+        { languages: ['es'], tokens: ['nueva', 'york'] },
+        { languages: ['en'], tokens: ['the', 'big', 'apple'] },
+    ];
+    t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en']), texts, 'auto-populate doesn\'t overwrite supplied translation');
+
     t.end();
 });
 

--- a/test/unit/text-processing/termops.getIndexableText.test.js
+++ b/test/unit/text-processing/termops.getIndexableText.test.js
@@ -119,11 +119,11 @@ test('termops.getIndexableText', (t) => {
         }
     };
     texts = [
+        { languages: ['default'], tokens: ['main', 'street'] },
         { languages: ['default'], tokens: ['2##', 'main', 'street'] },
         { languages: ['default'], tokens: ['1##', 'main', 'street'] },
         { languages: ['default'], tokens: ['##', 'main', 'street'] },
-        { languages: ['default'], tokens: ['#', 'main', 'street'] },
-        { languages: ['default'], tokens: ['main', 'street'] }
+        { languages: ['default'], tokens: ['#', 'main', 'street'] }
     ];
     t.deepEqual(termops.getIndexableText(replacer, [],  doc), texts, 'with range');
 
@@ -135,16 +135,16 @@ test('termops.getIndexableText', (t) => {
         }
     };
     texts = [
+        { tokens: ['main', 'st'],            languages: ['default'] },
         { tokens: ['2##', 'main', 'st'],     languages: ['default'] },
         { tokens: ['1##', 'main', 'st'],     languages: ['default'] },
         { tokens: ['##', 'main', 'st'],      languages: ['default'] },
         { tokens: ['#', 'main', 'st'],       languages: ['default'] },
-        { tokens: ['main', 'st'],            languages: ['default'] },
+        { tokens: ['main', 'street'],        languages: ['default'] },
         { tokens: ['2##', 'main', 'street'], languages: ['default'] },
         { tokens: ['1##', 'main', 'street'], languages: ['default'] },
         { tokens: ['##', 'main', 'street'],  languages: ['default'] },
-        { tokens: ['#', 'main', 'street'],   languages: ['default'] },
-        { tokens: ['main', 'street'],        languages: ['default'] }
+        { tokens: ['#', 'main', 'street'],   languages: ['default'] }
     ];
     t.deepEqual(termops.getIndexableText(replacer, [],  doc), texts, 'with range');
 

--- a/test/unit/text-processing/termops.getIndexableText.test.js
+++ b/test/unit/text-processing/termops.getIndexableText.test.js
@@ -245,6 +245,24 @@ test('termops.getIndexableText', (t) => {
     t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en']), texts, 'auto-populate from default works');
 
     replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'New York,NYC,bakery', 'carmen:text_es': 'Nueva York' } };
+    texts = [
+        { tokens: ['new', 'york'], languages: ['default', 'en'] },
+        { tokens: ['nyc'], languages: ['default', 'en'] },
+        { tokens: ['bakery'], languages: ['all'] },
+        { tokens: ['nueva', 'york'], languages: ['es'] }
+    ];
+    t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en'], new Set(['bakery'])), texts, 'auto-universalize categories works');
+
+    replacer = token.createReplacer({});
+    doc = { properties: { 'carmen:text': 'bakery,New York' } };
+    texts = [
+        { tokens: ['bakery'], languages: ['default', 'en'] },
+        { tokens: ['new', 'york'], languages: ['default', 'en'] }
+    ];
+    t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en'], new Set(['bakery'])), texts, 'display words are not universalized');
+
+    replacer = token.createReplacer({});
     doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'text_en': 'The Big Apple' } };
     texts = [
         { languages: ['default'], tokens: ['new', 'york'] },

--- a/test/unit/text-processing/termops.getIndexableText.test.js
+++ b/test/unit/text-processing/termops.getIndexableText.test.js
@@ -237,7 +237,7 @@ test('termops.getIndexableText', (t) => {
     t.deepEqual(termops.getIndexableText(replacer, [], doc, true), texts, 'universal text');
 
     replacer = token.createReplacer({});
-    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York'} };
+    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York' } };
     texts = [
         { languages: ['default', 'en'], tokens: ['new', 'york'] },
         { languages: ['es'], tokens: ['nueva', 'york'] }
@@ -245,7 +245,7 @@ test('termops.getIndexableText', (t) => {
     t.deepEqual(termops.getIndexableText(replacer, [], doc, ['en']), texts, 'auto-populate from default works');
 
     replacer = token.createReplacer({});
-    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'text_en': 'The Big Apple'} };
+    doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'text_en': 'The Big Apple' } };
     texts = [
         { languages: ['default'], tokens: ['new', 'york'] },
         { languages: ['es'], tokens: ['nueva', 'york'] },


### PR DESCRIPTION
### Context
Sometimes we have features where our data provider hasn't specified the language's text, but it can be reasonably inferred from a feature's country. This PR adds a fallback mechanism that allows indexing a feature's default text such that it won't be penalized at query time given searches in the language we think the text is in, even though it hasn't been explicitly specified.

It also more generally restructures the `getIndexableText` function, where the bulk of the work here is happening, to hopefully be a little easier to understand. In the previous version, the function had two nested inner functions it used to mutate the structures it was working it, which made the flow pretty tough to follow. It now proceeds in order from top to bottom. Oh, and tests.

Preliminary exploration of using this branch in production has suggested that category synonyms specifically need some special treatment beyond what we're already doing here, so my plan now is to take another pass and add some more logic there. The work in #758 should provide the foundation there: my plan will be to recognize category synonyms specifically, and index them as all-language synonyms instead of language-specific.


### Summary of Changes
- [x] refactor `getIndexableText`
- [x] add language auto-population mechanism
- [x] add tests


### Next Steps
- [x] add special treatment for categories


cc @mapbox/geocoding-gang
