### PR TITLE
Sort final results w/ proximity enabled based on relevance and score/proximity composite 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 25.6.1
+
+- Sort final results based on a composite scoredist and relevance score with penalties for features with `carmen:address` of `null`, omitted geometries, or `carmen:score`s of `-1` (ghost features)
+
 ## 25.5.1
 
 - Update all deps to latest versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 25.6.1
+## 25.6.0
 
 - Sort final results based on a composite scoredist and relevance score with penalties for features with `carmen:address` of `null`, omitted geometries, or `carmen:score`s of `-1` (ghost features)
 

--- a/index.js
+++ b/index.js
@@ -271,8 +271,8 @@ function Geocoder(indexes, options) {
             }
             this.byidx[i].bmask = bmask;
         }
-
-        // Find the max score of all features in all indexes
+        // Find the min and max score of all features in all indexes
+        this.minScore = this.byidx.reduce((min, source) => Math.min(min, source.minScore), 0) || 0;
         this.maxScore = this.byidx.reduce((max, source) => Math.max(max, source.maxscore), 0) || 1;
 
         this._error = err;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -407,8 +407,8 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
                 feat.properties['carmen:spatialmatch'].relev,
                 feat.properties['carmen:scoredist'],
                 feat.properties['carmen:address'],
-                feat.geometry && feat.geometry.omitted ? 1 : 0,
-                feat.properties['carmen:score'] < 0 ? 1 : 0
+                feat.geometry && feat.geometry.omitted,
+                feat.properties['carmen:score'] < 0
             );
         } else {
             feat.properties['carmen:scoredist'] += squishy;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -207,6 +207,10 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                 feat.properties['carmen:distance'],
                 feat.properties['carmen:zoom']
             );
+            feat.properties['carmen:relevance'] = proximity.relevanceScore(
+                feat.properties['carmen:spatialmatch'].relev,
+                feat.properties['carmen:scoredist']
+            );
         } else {
             feat.properties['carmen:scoredist'] = feat.properties['carmen:score'];
         }
@@ -396,7 +400,8 @@ function verifyContext(context, peers, strict, loose, indexes) {
 * sortFeature - sorts the best results in the features according to the relevance, scoredist, position or if the address exists
 */
 function sortFeature(a, b) {
-    return (b.properties['carmen:spatialmatch'].relev - a.properties['carmen:spatialmatch'].relev) ||
+    return ((b.properties['carmen:relevance'] ? b.properties['carmen:relevance'] : 0) - (a.properties['carmen:relevance'] ? a.properties['carmen:relevance'] : 0)) ||
+        (b.properties['carmen:spatialmatch'].relev - a.properties['carmen:spatialmatch'].relev) ||
         ((a.properties['carmen:address'] === null ? 1 : 0) - (b.properties['carmen:address'] === null ? 1 : 0)) ||
         ((a.geometry && a.geometry.omitted ? 1 : 0) - (b.geometry && b.geometry.omitted ? 1 : 0)) ||
         ((b.properties['carmen:scoredist'] || 0) - (a.properties['carmen:scoredist'] || 0)) ||

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -211,8 +211,8 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                 feat.properties['carmen:spatialmatch'].relev,
                 feat.properties['carmen:scoredist'],
                 feat.properties['carmen:address'],
-                feat.geometry && feat.geometry.omitted ? 1 : 0,
-                feat.properties['carmen:score'] < 0 ? 1 : 0
+                feat.geometry && feat.geometry.omitted,
+                feat.properties['carmen:score'] < 0
             );
         } else {
             feat.properties['carmen:scoredist'] = feat.properties['carmen:score'];

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -267,7 +267,7 @@ function loadContexts(geocoder, features, sets, options, callback) {
 
     q.awaitAll((err, contexts) => {
         if (err) return callback(err);
-        callback(null, verifyContexts(contexts, sets, geocoder.indexes));
+        callback(null, verifyContexts(contexts, sets, geocoder.indexes, options, geocoder));
     });
 }
 
@@ -279,7 +279,7 @@ function loadContexts(geocoder, features, sets, options, callback) {
 * @params {Object} indexes - indexes in the instance of the geocoder for e.g: {country: {}, region: {}, place:{}}
 * @returns {Object} contexts - feature hierachy sorted by the score value
 */
-function verifyContexts(contexts, sets, indexes) {
+function verifyContexts(contexts, sets, indexes, options, geocoder) {
     const peers = {};
     for (let c = 0; c < contexts.length; c++) {
         peers[contexts[c][0].properties['carmen:tmpid']] = contexts[c][0];
@@ -309,8 +309,8 @@ function verifyContexts(contexts, sets, indexes) {
             }
         }
 
-        const strictRelev = verifyContext(context, peers, verify, {}, indexes);
-        const looseRelev = verifyContext(context, peers, verify, sets, indexes);
+        const strictRelev = verifyContext(context, peers, verify, {}, indexes, options, geocoder);
+        const looseRelev = verifyContext(context, peers, verify, sets, indexes, options, geocoder);
         context._relevance = Math.max(strictRelev, looseRelev);
     }
     contexts.sort(sortContext);
@@ -320,7 +320,7 @@ function verifyContexts(contexts, sets, indexes) {
 /**
 https://github.com/mapbox/geocoding/issues/302
 */
-function verifyContext(context, peers, strict, loose, indexes) {
+function verifyContext(context, peers, strict, loose, indexes, options, geocoder) {
     const addressOrder = context[0].properties['carmen:geocoder_address_order'];
     let usedmask = 0;
     let lastmask = -1;
@@ -391,8 +391,29 @@ function verifyContext(context, peers, strict, loose, indexes) {
     // contained "gaps" in continuity between index levels --
     // EXCEPT in the case of an eligible higher-level feature that shares an
     // exact carmen:text value with something in its context (e.g. New York, New York)
-    if (squishy > 0)
-        context[0].properties['carmen:scoredist'] += squishy;
+    if (squishy > 0) {
+        const feat = context[0];
+        // Recalculate carmen:scoredist and carmen:relevance for smallest squishy feature
+        // with new higher score to ensure it returns before larger squishy features
+        if (options.proximity) {
+            feat.properties['carmen:scoredist'] = proximity.scoredist(
+                Math.min(feat.properties['carmen:score'] + squishy, geocoder.maxScore),
+                geocoder.minScore,
+                geocoder.maxScore,
+                feat.properties['carmen:distance'],
+                feat.properties['carmen:zoom']
+            );
+            feat.properties['carmen:relevance'] = proximity.relevanceScore(
+                feat.properties['carmen:spatialmatch'].relev,
+                feat.properties['carmen:scoredist'],
+                feat.properties['carmen:address'],
+                feat.geometry && feat.geometry.omitted ? 1 : 0,
+                feat.properties['carmen:score'] < 0 ? 1 : 0
+            );
+        } else {
+            feat.properties['carmen:scoredist'] += squishy;
+        }
+    }
 
     relevance = relevance > 0 ? relevance : 0;
 

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -199,10 +199,10 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
     // Set a score + distance combined heuristic.
     for (let k = 0; k < result.length; k++) {
         const feat = result[k];
-        // ghost features don't participate
-        if (options.proximity && feat.properties['carmen:score'] >= 0) {
+        if (options.proximity) {
             feat.properties['carmen:scoredist'] = proximity.scoredist(
                 feat.properties['carmen:score'],
+                geocoder.minScore,
                 geocoder.maxScore,
                 feat.properties['carmen:distance'],
                 feat.properties['carmen:zoom']
@@ -211,7 +211,8 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
                 feat.properties['carmen:spatialmatch'].relev,
                 feat.properties['carmen:scoredist'],
                 feat.properties['carmen:address'],
-                feat.geometry && feat.geometry.omitted ? 1 : 0
+                feat.geometry && feat.geometry.omitted ? 1 : 0,
+                feat.properties['carmen:score'] < 0 ? 1 : 0
             );
         } else {
             feat.properties['carmen:scoredist'] = feat.properties['carmen:score'];

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -209,7 +209,9 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             );
             feat.properties['carmen:relevance'] = proximity.relevanceScore(
                 feat.properties['carmen:spatialmatch'].relev,
-                feat.properties['carmen:scoredist']
+                feat.properties['carmen:scoredist'],
+                feat.properties['carmen:address'],
+                feat.geometry && feat.geometry.omitted ? 1 : 0
             );
         } else {
             feat.properties['carmen:scoredist'] = feat.properties['carmen:score'];
@@ -400,7 +402,7 @@ function verifyContext(context, peers, strict, loose, indexes) {
 * sortFeature - sorts the best results in the features according to the relevance, scoredist, position or if the address exists
 */
 function sortFeature(a, b) {
-    return ((b.properties['carmen:relevance'] ? b.properties['carmen:relevance'] : 0) - (a.properties['carmen:relevance'] ? a.properties['carmen:relevance'] : 0)) ||
+    return ((b.properties['carmen:relevance'] || 0) - (a.properties['carmen:relevance'] || 0)) ||
         (b.properties['carmen:spatialmatch'].relev - a.properties['carmen:spatialmatch'].relev) ||
         ((a.properties['carmen:address'] === null ? 1 : 0) - (b.properties['carmen:address'] === null ? 1 : 0)) ||
         ((a.geometry && a.geometry.omitted ? 1 : 0) - (b.geometry && b.geometry.omitted ? 1 : 0)) ||

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -420,7 +420,13 @@ function sortContext(a, b) {
     if (a._relevance > b._relevance) return -1;
     if (a._relevance < b._relevance) return 1;
 
-    // sort by score
+    // sort by relev + scoredist composite score
+    const ar = a[0].properties['carmen:relevance'] || 0;
+    const br = b[0].properties['carmen:relevance'] || 0;
+    if (ar > br) return -1;
+    if (br < ar) return 1;
+
+    // sort by scoredist
     const as = a[0].properties['carmen:scoredist'] || 0;
     const bs = b[0].properties['carmen:scoredist'] || 0;
     if (as > bs) return -1;

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -82,8 +82,8 @@ function center2zxy(center, z) {
  *  use the last value
  * @return {Number} proximity adjusted score value between 1 and 121
  */
-function scoredist(score, maxScore, dist, zoom) {
-    const scoreVal = scoreWeight(score, maxScore);
+function scoredist(score, minScore, maxScore, dist, zoom) {
+    const scoreVal = scoreWeight(score, minScore, maxScore);
     const distVal = distWeight(dist, zoom);
     return distVal * scoreVal;
 }
@@ -97,8 +97,10 @@ function scoredist(score, maxScore, dist, zoom) {
  * @param {Number} maxScore The highest score of all features in all indexes.
  * @return {Number} scaled score value
  */
-function scoreWeight(score, maxScore) {
-    return ((score / maxScore) * 10) + 1;
+function scoreWeight(score, minScore, maxScore) {
+    // scale score to a value between 0 and 1
+    const normalizedScore = (score - minScore) / (maxScore - minScore);
+    return (normalizedScore * 10) + 1;
 }
 
 /**
@@ -182,11 +184,12 @@ function distscore(dist, score) {
     return Math.round(score * (1000 / (Math.max(dist, 50))) * 10000) / 10000;
 }
 
-function relevanceScore(relev, scoredist, address, omitted) {
+function relevanceScore(relev, scoredist, address, omitted, ghost) {
     // add a slight penalty to features with carmen:address === null
-    // or ommitted geometries
+    // ommitted geometries, or scores of < 0
     if (address === null) relev = Math.max(0, relev - 0.01);
     if (omitted) relev = Math.max(0, relev - 0.01);
+    if (ghost) relev = Math.max(0, relev - 0.01);
     // scale scoredist to a value between 0 and 1, give a weight of 0.4
     const scoreDistWeight = ((scoredist - 1) / (121 - 1)) * 0.4;
     // give relevance score a weight of 0.6

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -187,7 +187,7 @@ function distscore(dist, score) {
 function relevanceScore(relev, scoredist, address, omitted, ghost) {
     // add a slight penalty to features with carmen:address === null
     // ommitted geometries, or scores of < 0
-    if (address === null) relev = Math.max(0, relev - 0.01);
+    if (address === null) relev = Math.max(0, relev - 0.005);
     if (omitted) relev = Math.max(0, relev - 0.01);
     if (ghost) relev = Math.max(0, relev - 0.01);
     // scale scoredist to a value between 0 and 1, give a weight of 0.4

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -19,6 +19,7 @@ module.exports.scaleRadius = scaleRadius;
 module.exports.gauss = gauss;
 module.exports.variance = variance;
 module.exports.distscore = distscore;
+module.exports.relevanceScore = relevanceScore;
 
 /**
  * distance - Return the distance in miles between a proximity point and a feature.
@@ -179,4 +180,11 @@ function variance(scale, decay) {
  */
 function distscore(dist, score) {
     return Math.round(score * (1000 / (Math.max(dist, 50))) * 10000) / 10000;
+}
+
+function relevanceScore(relev, scoredist) {
+    // scale scoredist to a value between 1 and 1.3
+    const scoreDistWeight = ((scoredist / 121) * 0.3) + 1;
+    // scale relevance score to a value between 0 and 1
+    return ((relev + 1) * scoreDistWeight) / 2.6;
 }

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -182,9 +182,14 @@ function distscore(dist, score) {
     return Math.round(score * (1000 / (Math.max(dist, 50))) * 10000) / 10000;
 }
 
-function relevanceScore(relev, scoredist) {
-    // scale scoredist to a value between 1 and 1.3
-    const scoreDistWeight = ((scoredist / 121) * 0.3) + 1;
-    // scale relevance score to a value between 0 and 1
-    return ((relev + 1) * scoreDistWeight) / 2.6;
+function relevanceScore(relev, scoredist, address, omitted) {
+    // add a slight penalty to features with carmen:address === null
+    // or ommitted geometries
+    if (address === null) relev = Math.max(0, relev - 0.01);
+    if (omitted) relev = Math.max(0, relev - 0.01);
+    // scale scoredist to a value between 0 and 1, give a weight of 0.4
+    const scoreDistWeight = ((scoredist - 1) / (121 - 1)) * 0.4;
+    // give relevance score a weight of 0.6
+    const relevWeight = relev * 0.6;
+    return relevWeight + scoreDistWeight;
 }

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -76,10 +76,10 @@ function center2zxy(center, z) {
  * Combine score and distance into a single score for sorting.
  *
  * @param {Number} score The score of the feature
+ * @param {Number} minScore The lowest score of all features in all indexes.
  * @param {Number} maxScore The maximum score of all features in all indexes
  * @param {Number} dist The distance from the feature to the proximity point in miles.
- * @param {String} type The feature type. If the feature has multiple types,
- *  use the last value
+ * @param {String} zoom The vector tile zoom level of the index the feature is part of.
  * @return {Number} proximity adjusted score value between 1 and 121
  */
 function scoredist(score, minScore, maxScore, dist, zoom) {
@@ -94,6 +94,7 @@ function scoredist(score, minScore, maxScore, dist, zoom) {
  * between a given feature's score and the highest score of all features in all indexes.
  *
  * @param {Number} score The score of the feature.
+ * @param {Number} minScore The lowest score of all features in all indexes.
  * @param {Number} maxScore The highest score of all features in all indexes.
  * @return {Number} scaled score value
  */
@@ -110,8 +111,7 @@ function scoreWeight(score, minScore, maxScore) {
  * distance weighting decays rapidly, then levels out towards the edge of the
  * proximity radius.
  * @param {Number} dist The distance in miles from the feature to the proximity point
- * @param {String} type The feature type. If the feature has multiple types,
- *  use the last value
+ * @param {String} zoom The vector tile zoom level of the index the feature is part of.
  * @return {Number} scaled score value
  */
 function distWeight(dist, zoom) {
@@ -123,8 +123,7 @@ function distWeight(dist, zoom) {
 
 /**
  * Set proximity radius by feature type
- * @param {String} type The feature type. If the feature has multiple types,
- *  use the last value
+ * @param {String} zoom The vector tile zoom level of the index the feature is part of.
  * @return {Number} scaled radius in miles
  */
 function scaleRadius(zoom) {
@@ -184,9 +183,21 @@ function distscore(dist, score) {
     return Math.round(score * (1000 / (Math.max(dist, 50))) * 10000) / 10000;
 }
 
+/**
+ * Combine scoredist and relevance into a single score for sorting. Apply penalties.
+ *
+ * @param {Number} relev The score of the feature
+ * @param {Number} scoredist proximity adjusted score value between 1 and 121
+ * @param {Number} address The carmen:address property of the feature. Equal to
+ * the street number if the user's query matches an address number and point in
+ * the address cluster.
+ * @param {Boolean} omitted True if the street's nearest endpoints match.
+ * @param {String} ghost True if the feature's carmen:score property is < 0.
+ * @return {Number} composite scoredist and relevance score between 0 and 1
+ */
 function relevanceScore(relev, scoredist, address, omitted, ghost) {
     // add a slight penalty to features with carmen:address === null
-    // ommitted geometries, or scores of < 0
+    // omitted geometries, or scores of < 0
     if (address === null) relev = Math.max(0, relev - 0.005);
     if (omitted) relev = Math.max(0, relev - 0.01);
     if (ghost) relev = Math.max(0, relev - 0.01);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "25.5.1",
+  "version": "25.6.1",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "25.6.1",
+  "version": "25.6.0",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/test/acceptance/geocode-unit.proximity-squishy.test.js
+++ b/test/acceptance/geocode-unit.proximity-squishy.test.js
@@ -1,0 +1,100 @@
+'use strict';
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+// identically-named features should reverse the gappy penalty and
+// instead prioritize the highest-index feature
+// but local feature should still return first with proximity enabled
+const conf = {
+    country: new mem({ maxzoom: 6, minscore: 0, maxscore: 10000 }, () => {}),
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true, minscore: 0, maxscore: 10000 }, () => {}),
+    poi: new mem({ maxzoom: 6, minscore: 0, maxscore: 10000 }, () => {})
+};
+
+const c = new Carmen(conf);
+
+tape('index country', (t) => {
+    queueFeature(conf.country, {
+        id: 1,
+        properties: {
+            'carmen:center': [45,45],
+            'carmen:score': 600,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [40,40],
+                [40,50],
+                [50,50],
+                [50,40],
+                [40,40],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index place', (t) => {
+    queueFeature(conf.place, {
+        id: 1,
+        properties: {
+            'carmen:center': [45,45],
+            'carmen:score': 500,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [40,40],
+                [40,50],
+                [50,50],
+                [50,40],
+                [40,40],
+            ]]
+        }
+    }, t.end);
+});
+
+tape('index poi', (t) => {
+    queueFeature(conf.poi, {
+        id: 1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 1,
+            'carmen:text': 'Georgia Cafe',
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [0,0]
+        }
+    }, t.end);
+});
+
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('find georgia', (t) => {
+    c.geocode('georgia', { proximity: [0,0] }, (err, res) => {
+        t.equal(res.features[0].id, 'poi.1', 'Georgia Cafe');
+        t.equal(res.features[1].id, 'place.1', 'Georgia (place)');
+        t.equal(res.features[2].id, 'country.1', 'Georgia (country)');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -5,7 +5,7 @@ const bigAddress = require('../../fixtures/bigaddress.json');
 
 tape('verifymatch.sortFeature', (t) => {
     t.test('generic features', (t) => {
-        const arr = [
+        const input = [
             { id: 11, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
             { id: 10, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
             { id: 9, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
@@ -14,12 +14,12 @@ tape('verifymatch.sortFeature', (t) => {
             { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
             { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
             { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 2, properties: { 'carmen:relevance': 0.7783773045, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null, 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 1, properties: { 'carmen:relevance': 0.7787666879, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 3, properties: { 'carmen:relevance': 0.6, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
+            { id: 3, properties: { 'carmen:relevance': 0.6, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+            { id: 2, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null, 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+            { id: 1, properties: { 'carmen:relevance': 1.0, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
         ];
-        arr.sort(verifymatch.sortFeature);
-        t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9,10,11]);
+        input.sort(verifymatch.sortFeature);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9,10,11]);
 
         t.end();
     });

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -4,42 +4,20 @@ const tape = require('tape');
 const bigAddress = require('../../fixtures/bigaddress.json');
 
 tape('verifymatch.sortFeature', (t) => {
-    t.test('generic features', (t) => {
-        const input = [
-            { id: 11, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
-            { id: 10, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
-            { id: 9, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
-            { id: 8, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': -1 }, geometry: {} },
-            { id: 7, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
-            { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
-            { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
-            { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 3, properties: { 'carmen:relevance': 0.6, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 2, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null, 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-            { id: 1, properties: { 'carmen:relevance': 1.0, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
-        ];
-        input.sort(verifymatch.sortFeature);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9,10,11]);
+    const input = [
+        { id: 8, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null, 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: { omitted: true } },
+        { id: 7, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null, 'carmen:scoredist': 4, 'carmen:position': 1 }, geometry: { omitted: true } },
+        { id: 6, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null, 'carmen:scoredist': 4 }, geometry: { omitted: true } },
+        { id: 5, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null, 'carmen:scoredist': 5 }, geometry: { omitted: true } },
+        { id: 4, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null }, geometry: {} },
+        { id: 3, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': '26' } },
+        { id: 2, properties: { 'carmen:relevance': 0.99, 'carmen:spatialmatch': { relev: 1.0 } } },
+        { id: 1, properties: { 'carmen:relevance': 1.0 } }
+    ];
+    input.sort(verifymatch.sortFeature);
+    t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
 
-        t.end();
-    });
-    t.test('planet granite test case', (t) => {
-
-        const input = [
-            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1, 'carmen:relevance': 0.6 } },
-            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139, 'carmen:relevance': 0.6093304633333333 } },
-            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823, 'carmen:relevance': 0.6090560766666666 } },
-            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406, 'carmen:relevance': 0.6089846866666666 } },
-            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766, 'carmen:relevance': 0.60893922 } },
-            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728, 'carmen:relevance': 0.6087624266666666 } },
-            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937, 'carmen:relevance': 0.6085831233333333 } },
-            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:relevance': 0.60333333, 'carmen:address': null } }
-        ];
-
-        input.sort(verifymatch.sortFeature);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
-        t.end();
-    });
+    t.end();
 });
 
 tape('verifymatch.sortContext (no distance)', (t) => {

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -5,16 +5,18 @@ const bigAddress = require('../../fixtures/bigaddress.json');
 
 tape('verifymatch.sortFeature', (t) => {
     const arr = [
-        { id: 7, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
-        { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
-        { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
-        { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
-        { id: 3, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
-        { id: 2, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
-        { id: 1, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
+        { id: 9, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
+        { id: 8, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
+        { id: 7, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
+        { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
+        { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
+        { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
+        { id: 3, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+        { id: 2, properties: { 'carmen:relevance': 0.9, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+        { id: 1, properties: { 'carmen:relevance': 1.0, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
     ];
     arr.sort(verifymatch.sortFeature);
-    t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7]);
+    t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9]);
 
     t.end();
 });

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -4,21 +4,42 @@ const tape = require('tape');
 const bigAddress = require('../../fixtures/bigaddress.json');
 
 tape('verifymatch.sortFeature', (t) => {
-    const arr = [
-        { id: 9, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
-        { id: 8, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
-        { id: 7, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
-        { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
-        { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
-        { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
-        { id: 3, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-        { id: 2, properties: { 'carmen:relevance': 0.9, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
-        { id: 1, properties: { 'carmen:relevance': 1.0, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
-    ];
-    arr.sort(verifymatch.sortFeature);
-    t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9]);
+    t.test('generic features', (t) => {
+        const arr = [
+            { id: 11, properties: { 'carmen:spatialmatch': { relev: 0.9 }, 'carmen:address': null } },
+            { id: 10, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null } },
+            { id: 9, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26' }, geometry: { omitted: true } },
+            { id: 8, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': -1 }, geometry: {} },
+            { id: 7, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 2 }, geometry: {} },
+            { id: 6, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 3 }, geometry: {} },
+            { id: 5, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 4, 'carmen:position': 2 }, geometry: {} },
+            { id: 4, properties: { 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+            { id: 2, properties: { 'carmen:relevance': 0.7783773045, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': null, 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+            { id: 1, properties: { 'carmen:relevance': 0.7787666879, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} },
+            { id: 3, properties: { 'carmen:relevance': 0.6, 'carmen:spatialmatch': { relev: 1.0 }, 'carmen:address': '26', 'carmen:scoredist': 5, 'carmen:position': 1 }, geometry: {} }
+        ];
+        arr.sort(verifymatch.sortFeature);
+        t.deepEqual(arr.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8,9,10,11]);
 
-    t.end();
+        t.end();
+    });
+    t.test('planet granite test case', (t) => {
+
+        const input = [
+            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1, 'carmen:relevance': 0.6 } },
+            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139, 'carmen:relevance': 0.6093304633333333 } },
+            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823, 'carmen:relevance': 0.6090560766666666 } },
+            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406, 'carmen:relevance': 0.6089846866666666 } },
+            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766, 'carmen:relevance': 0.60893922 } },
+            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728, 'carmen:relevance': 0.6087624266666666 } },
+            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937, 'carmen:relevance': 0.6085831233333333 } },
+            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:relevance': 0.60333333, 'carmen:address': null } }
+        ];
+
+        input.sort(verifymatch.sortFeature);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
+        t.end();
+    });
 });
 
 tape('verifymatch.sortContext (no distance)', (t) => {

--- a/test/unit/util/proximity.relevanceScore.test.js
+++ b/test/unit/util/proximity.relevanceScore.test.js
@@ -1,0 +1,90 @@
+'use strict';
+const test = require('tape');
+const proximity = require('../../../lib/util/proximity');
+
+function compareRelevanceScore(a, b) {
+    return b.properties['carmen:relevance'] - a.properties['carmen:relevance'];
+}
+
+function calculateRelevanceScore(input) {
+    for (let k = 0; k < input.length; k++) {
+        const feat = input[k];
+        feat.properties['carmen:relevance'] = proximity.relevanceScore(
+            feat.properties['carmen:spatialmatch'].relev,
+            feat.properties['carmen:scoredist'],
+            feat.properties['carmen:address'],
+            feat.geometry && feat.geometry.omitted,
+            feat.properties['carmen:score'] < 0
+        );
+    }
+}
+
+test('calculate relevanceScore', (t) => {
+    const minRelev = 0;
+    const maxRelev = 1;
+    const minScoredist = 1;
+    const maxScoredist = 121;
+    t.equal(proximity.relevanceScore(minRelev, minScoredist), 0, 'min relevanceScore value is 0');
+    t.equal(proximity.relevanceScore(maxRelev, maxScoredist), 1, 'max relevanceScore value is 1');
+    t.ok(proximity.relevanceScore(maxRelev, minScoredist, null) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with carmen:address of null receive a lower relevanceScore');
+    t.ok(proximity.relevanceScore(maxRelev, minScoredist, 123, true) < proximity.relevanceScore(maxRelev, maxScoredist, 123), 'features with geometry.omitted receive a lower relevanceScore');
+    t.ok(proximity.relevanceScore(maxRelev, minScoredist, 123, null, true) < proximity.relevanceScore(maxRelev, maxScoredist, 123, null), 'ghost features receive a lower relevanceScore');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, null), 0, 'min relevanceScore with carmen:address of null is 0');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, 123, true), 0, 'min relevanceScore with geometry.omitted is 0');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, 123, null, true), 0, 'min relevanceScore with ghost feature is 0');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, null, true, true), 0, 'min relevanceScore with carmen:address of null, geometry.omitted, and ghost feature is 0');
+    t.end();
+});
+
+
+test('sort features based on relevanceScore', (t) => {
+    t.test('language penalty, planet near planet granite portland, oregon',  (t) => {
+        const input = [
+            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
+            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
+            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
+            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
+            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
+            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
+            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
+            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } }
+        ];
+
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
+        t.end();
+    });
+
+    t.test('address = null, waupaca near madison, wisconsin', (t) => {
+        const input = [
+            { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
+            { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
+            { id: 3, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
+            { id: 4, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
+            { id: 5, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
+            { id: 6, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
+            { id: 7, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
+            { id: 8, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
+        ];
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
+        t.end();
+    });
+
+    t.test('ghost features, sunset district near san francisco', (t) => {
+        const input = [
+            { id: 2, properties: { 'carmen:text': 'Sunset District','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': -1,'carmen:scoredist': 10.980303 } },
+            { id: 1, properties: { 'carmen:text': 'Sunset City','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': 10,'carmen:scoredist': 11.000193 } },
+            { id: 3, properties: { 'carmen:text': 'DTOWN PARTY BUS','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 451,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
+            { id: 4, properties: { 'carmen:text': 'District Resource Placement Centre','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 790,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
+            { id: 5, properties: { 'carmen:text': 'District Building','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 794,'carmen:score': 0, 'carmen:scoredist': 1.000006 } }
+        ];
+
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5]);
+        t.end();
+    });
+});

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -2,6 +2,7 @@
 const test = require('tape');
 const proximity = require('../../../lib/util/proximity');
 
+const minScore = -1;
 const maxScore = 1634443;
 const ZOOM_LEVELS = {
     address: 14,
@@ -23,16 +24,13 @@ function compareRelevanceScore(a, b) {
 function calculateScoreDist(input) {
     for (let k = 0; k < input.length; k++) {
         const feat = input[k];
-        if (feat.properties['carmen:score'] >= 0) {
-            feat.properties['carmen:scoredist'] = parseFloat(proximity.scoredist(
-                feat.properties['carmen:score'],
-                maxScore,
-                feat.properties['carmen:distance'],
-                feat.properties['carmen:zoom']
-            ).toFixed(6));
-        } else {
-            feat.properties['carmen:scoredist'] = feat.properties['carmen:score'];
-        }
+        feat.properties['carmen:scoredist'] = parseFloat(proximity.scoredist(
+            feat.properties['carmen:score'],
+            minScore,
+            maxScore,
+            feat.properties['carmen:distance'],
+            feat.properties['carmen:zoom']
+        ).toFixed(6));
     }
 }
 
@@ -43,7 +41,8 @@ function calculateRelevanceScore(input) {
             feat.properties['carmen:spatialmatch'].relev,
             feat.properties['carmen:scoredist'],
             feat.properties['carmen:address'],
-            feat.geometry && feat.geometry.omitted ? 1 : 0
+            feat.geometry && feat.geometry.omitted ? 1 : 0,
+            feat.properties['carmen:score'] < 0 ? 1 : 0
         );
     }
 }
@@ -83,6 +82,22 @@ test('relevanceScore', (t) => {
         t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
         t.end();
     });
+
+    t.test('ghost features, sunset district near san francisco', (t) => {
+        const input = [
+            { id: 2, properties: { 'carmen:text': 'Sunset District','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': -1,'carmen:scoredist': 10.980303 } },
+            { id: 1, properties: { 'carmen:text': 'Sunset City','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': 10,'carmen:scoredist': 11.000193 } },
+            { id: 3, properties: { 'carmen:text': 'DTOWN PARTY BUS','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 451,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
+            { id: 4, properties: { 'carmen:text': 'District Resource Placement Centre','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 790,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
+            { id: 5, properties: { 'carmen:text': 'District Building','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 794,'carmen:score': 0, 'carmen:scoredist': 1.000006 } }
+        ];
+
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5]);
+        t.end();
+    });
+
 });
 
 
@@ -98,10 +113,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'New York Frankfurter Co.', 'carmen:distance': 0.4914344651849769, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.99977 } },
-            { properties: { 'carmen:text': 'New Yorker Buffalo Wings', 'carmen:distance': 0.6450163846417221, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999689 } },
-            { properties: { 'carmen:text': 'New York,NY', 'carmen:distance': 2426.866703400975, 'carmen:score': 79161, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 3.064512 } },
-            { properties: { 'carmen:text': 'New York,NY,NYC,New York City', 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.190303 } }
+            { properties: { 'carmen:text': 'New York Frankfurter Co.', 'carmen:distance': 0.4914344651849769, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999837 } },
+            { properties: { 'carmen:text': 'New Yorker Buffalo Wings', 'carmen:distance': 0.6450163846417221, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999757 } },
+            { properties: { 'carmen:text': 'New York,NY', 'carmen:distance': 2426.866703400975, 'carmen:score': 79161, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 3.064524 } },
+            { properties: { 'carmen:text': 'New York,NY,NYC,New York City', 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.190309 } }
         ];
 
         calculateScoreDist(input);
@@ -117,8 +132,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Chicago Title', 'carmen:distance': 0.14084037845690478, 'carmen:score': 2, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 11.00011 } },
-            { properties: { 'carmen:text': 'Chicago', 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.104021 } }
+            { properties: { 'carmen:text': 'Chicago Title', 'carmen:distance': 0.14084037845690478, 'carmen:score': 2, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 11.000177 } },
+            { properties: { 'carmen:text': 'Chicago', 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.104027 } }
         ];
 
         calculateScoreDist(input);
@@ -136,10 +151,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'San Francisco', 'carmen:distance': 74.24466022598429, 'carmen:score': 8015, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.34334 } },
-            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442749 } },
-            { properties: { 'carmen:text': 'São Paulo', 'carmen:distance': 6547.831697209755, 'carmen:score': 36433, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.222908 } },
-            { properties: { 'carmen:text': 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:distance': 6023.053777668511, 'carmen:score': 26709, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.163413 } }
+            { properties: { 'carmen:text': 'San Francisco', 'carmen:distance': 74.24466022598429, 'carmen:score': 8015, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.343406 } },
+            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442813 } },
+            { properties: { 'carmen:text': 'São Paulo', 'carmen:distance': 6547.831697209755, 'carmen:score': 36433, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.222914 } },
+            { properties: { 'carmen:text': 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:distance': 6023.053777668511, 'carmen:score': 26709, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.163419 } }
         ];
 
         calculateScoreDist(input);
@@ -155,8 +170,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442749 } },
-            { properties: { 'carmen:text': 'Santa Cruz de Tenerife', 'carmen:distance': 5811.283048403849, 'carmen:score': 3456, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.021145 } }
+            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442813 } },
+            { properties: { 'carmen:text': 'Santa Cruz de Tenerife', 'carmen:distance': 5811.283048403849, 'carmen:score': 3456, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.021151 } }
         ];
 
         calculateScoreDist(input);
@@ -172,8 +187,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Washington,DC', 'carmen:distance': 34.81595024835296, 'carmen:score': 7400, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.454749 } },
-            { properties: { 'carmen:text': 'Washington,WA', 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 2.940293 } }
+            { properties: { 'carmen:text': 'Washington,DC', 'carmen:distance': 34.81595024835296, 'carmen:score': 7400, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.454816 } },
+            { properties: { 'carmen:text': 'Washington,WA', 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 2.940307 } }
         ];
 
         calculateScoreDist(input);
@@ -191,10 +206,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:distance': 36.12228253928214, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 9.514727 } },
-            { properties: { 'carmen:text': 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:distance': 188.29482550861198, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.126642 } },
-            { properties: { 'carmen:text': 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:distance': 246.29759329605977, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.00567 } },
-            { properties: { 'carmen:text': 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:distance': 3312.294287119006, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000018 } }
+            { properties: { 'carmen:text': 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:distance': 36.12228253928214, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 9.514785 } },
+            { properties: { 'carmen:text': 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:distance': 188.29482550861198, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.126649 } },
+            { properties: { 'carmen:text': 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:distance': 246.29759329605977, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.005676 } },
+            { properties: { 'carmen:text': 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:distance': 3312.294287119006, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000024 } }
         ];
 
         calculateScoreDist(input);
@@ -211,9 +226,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:distance': 10.73122383596493, 'carmen:score': 294, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.015838 } },
-            { properties: { 'carmen:text': 'Cambridge, 02139, Massachusetts, United States', 'carmen:distance': 464.50390088754625, 'carmen:score': 986, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 5.812925 } },
-            { properties: { 'carmen:text': 'Cambridgeshire, United Kingdom', 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.016648 } }
+            { properties: { 'carmen:text': 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:distance': 10.73122383596493, 'carmen:score': 294, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.015906 } },
+            { properties: { 'carmen:text': 'Cambridge, 02139, Massachusetts, United States', 'carmen:distance': 464.50390088754625, 'carmen:score': 986, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 5.812961 } },
+            { properties: { 'carmen:text': 'Cambridgeshire, United Kingdom', 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.016654 } }
         ];
 
         calculateScoreDist(input);
@@ -230,7 +245,7 @@ test('scoredist', (t) => {
 
         const expected = [
             { properties: { 'carmen:text': 'United States of America, United States, America, USA, US', 'carmen:distance': 1117.3906777683906, 'carmen:score': 1634443, 'carmen:zoom': ZOOM_LEVELS.country, 'carmen:scoredist': 79.416753 } },
-            { properties: { 'carmen:text': 'United States Department of Treasury Annex', 'carmen:distance': 0.11774815645353183, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999983 } }
+            { properties: { 'carmen:text': 'United States Department of Treasury Annex', 'carmen:distance': 0.11774815645353183, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 11.00005 } }
         ];
 
         calculateScoreDist(input);
@@ -241,11 +256,11 @@ test('scoredist', (t) => {
     t.test('missi near mission neighborhood san francisco', (t) => {
         // --query="missi" --proximity="-122.4213562,37.75234222"
         const input = [
-            { id: 20, properties: { 'carmen:text': 'Mission District', 'carmen:distance': 0.641155642372423, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 14, properties: { 'carmen:text': 'Mission Terrace', 'carmen:distance': 2.0543295828567985, 'carmen:score': 50, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 13, properties: { 'carmen:text': 'Mission District', 'carmen:distance': 0.641155642372423, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 16, properties: { 'carmen:text': 'Mission Terrace', 'carmen:distance': 2.0543295828567985, 'carmen:score': 50, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
             { id: 1, properties: { 'carmen:text': 'Mission', 'carmen:distance': 0.5365405586195869, 'carmen:score': 609, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 15, properties: { 'carmen:text': 'Mission Bay', 'carmen:distance': 2.083206525530076, 'carmen:score': 46, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 19, properties: { 'carmen:text': 'Mission Dolores', 'carmen:distance': 0.8734705397622807, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 17, properties: { 'carmen:text': 'Mission Bay', 'carmen:distance': 2.083206525530076, 'carmen:score': 46, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 15, properties: { 'carmen:text': 'Mission Dolores', 'carmen:distance': 0.8734705397622807, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
             { id: 5, properties: { 'carmen:text': 'Mission Branch Library', 'carmen:distance': 0.09171422623336412, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 9, properties: { 'carmen:text': 'Mission Tires & Service Center', 'carmen:distance': 0.41252770420569307, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 11, properties: { 'carmen:text': 'Mission Dental Care', 'carmen:distance': 0.47809299593103194, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
@@ -256,10 +271,10 @@ test('scoredist', (t) => {
             { id: 4, properties: { 'carmen:text': 'Mission Cultural Center for Latino Arts,college, university', 'carmen:distance': 0.18621060494099984, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 7, properties: { 'carmen:text': 'Mission Critter', 'carmen:distance': 0.24892887064676822, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 6, properties: { 'carmen:text': 'Mission Wishing Tree', 'carmen:distance': 0.10633212084221495, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 18, properties: { 'carmen:text': 'Mississippi', 'carmen:distance': 1873.3273481255542, 'carmen:score': 17955, 'carmen:zoom': ZOOM_LEVELS.region } },
-            { id: 16, properties: { 'carmen:text': 'Mission Bay Mobile Home Park', 'carmen:distance': 15.112097493445267, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 17, properties: { 'carmen:text': 'Mission-Foothill', 'carmen:distance': 19.97574371302543, 'carmen:score': 44, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 13, properties: { 'carmen:text': 'Mission Workshop,bicycle, bike, cycle', 'carmen:distance': 0.821663496329208, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 20, properties: { 'carmen:text': 'Mississippi', 'carmen:distance': 1873.3273481255542, 'carmen:score': 17955, 'carmen:zoom': ZOOM_LEVELS.region } },
+            { id: 18, properties: { 'carmen:text': 'Mission Bay Mobile Home Park', 'carmen:distance': 15.112097493445267, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 19, properties: { 'carmen:text': 'Mission-Foothill', 'carmen:distance': 19.97574371302543, 'carmen:score': 44, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 14, properties: { 'carmen:text': 'Mission Workshop,bicycle, bike, cycle', 'carmen:distance': 0.821663496329208, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 12, properties: { 'carmen:text': 'Mission Pet Hospital', 'carmen:distance': 0.6281933184839765, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
         ];
 
@@ -275,10 +290,11 @@ test('scoredist', (t) => {
 });
 
 test('scoreWeight', (t) => {
+    const minScore = 0;
     const maxScore = 1000;
-    t.equal(proximity.scoreWeight(0, maxScore), 1, 'score 0 => scoreWeight 1');
-    t.equal(proximity.scoreWeight(maxScore * 0.5, maxScore), 6, ' score 1/2 of maxScore => scoreWeight 6');
-    t.equal(proximity.scoreWeight(maxScore, maxScore), 11, 'score maxScore => scoreWeight 11');
+    t.equal(proximity.scoreWeight(0, minScore, maxScore), 1, 'score minScore => scoreWeight 1');
+    t.equal(proximity.scoreWeight((maxScore - minScore) * 0.5, minScore, maxScore), 6, ' score of midpoint => scoreWeight 6');
+    t.equal(proximity.scoreWeight(maxScore, minScore, maxScore), 11, 'score maxScore => scoreWeight 11');
     t.end();
 });
 

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -16,7 +16,11 @@ function compareScoreDist(a, b) {
     return b.properties['carmen:scoredist'] - a.properties['carmen:scoredist'];
 }
 
-function calculteScoreDist(input) {
+function compareRelevanceScore(a, b) {
+    return b.properties['carmen:relevance'] - a.properties['carmen:relevance'];
+}
+
+function calculateScoreDist(input) {
     for (let k = 0; k < input.length; k++) {
         const feat = input[k];
         if (feat.properties['carmen:score'] >= 0) {
@@ -31,6 +35,36 @@ function calculteScoreDist(input) {
         }
     }
 }
+
+function calculateRelevanceScore(input) {
+    for (let k = 0; k < input.length; k++) {
+        const feat = input[k];
+        feat.properties['carmen:relevance'] = proximity.relevanceScore(
+            feat.properties['carmen:spatialmatch'].relev,
+            feat.properties['carmen:scoredist']
+        );
+    }
+}
+
+test('relevanceScore language penalty', (t) => {
+    const input = [
+        { id: 7, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
+        { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
+        { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
+        { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
+        { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
+        { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
+        { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
+    ];
+
+    calculateRelevanceScore(input);
+    input.sort(compareRelevanceScore);
+
+    t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7]);
+
+    t.end();
+});
+
 
 test('scoredist', (t) => {
 
@@ -50,7 +84,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'New York,NY,NYC,New York City', 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.190303 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -67,7 +101,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Chicago', 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.104021 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -88,7 +122,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:distance': 6023.053777668511, 'carmen:score': 26709, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.163413 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -105,7 +139,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Santa Cruz de Tenerife', 'carmen:distance': 5811.283048403849, 'carmen:score': 3456, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.021145 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -122,7 +156,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Washington,WA', 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 2.940293 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -143,7 +177,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:distance': 3312.294287119006, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000018 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -162,7 +196,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'Cambridgeshire, United Kingdom', 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.016648 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -179,7 +213,7 @@ test('scoredist', (t) => {
             { properties: { 'carmen:text': 'United States Department of Treasury Annex', 'carmen:distance': 0.11774815645353183, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999983 } }
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
     });
@@ -209,7 +243,7 @@ test('scoredist', (t) => {
             { id: 12, properties: { 'carmen:text': 'Mission Pet Hospital', 'carmen:distance': 0.6281933184839765, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
         ];
 
-        calculteScoreDist(input);
+        calculateScoreDist(input);
         input.sort(compareScoreDist);
         for (let i = 0; i < input.length; i++) {
             const feat = input[i];

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -70,12 +70,12 @@ test('relevanceScore', (t) => {
         const input = [
             { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
             { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
-            { id: 8, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
-            { id: 3, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
-            { id: 4, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
-            { id: 5, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
-            { id: 6, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
-            { id: 7, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
+            { id: 3, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
+            { id: 4, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
+            { id: 5, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
+            { id: 6, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
+            { id: 7, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
+            { id: 8, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
         ];
         calculateRelevanceScore(input);
         input.sort(compareRelevanceScore);

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -17,10 +17,6 @@ function compareScoreDist(a, b) {
     return b.properties['carmen:scoredist'] - a.properties['carmen:scoredist'];
 }
 
-function compareRelevanceScore(a, b) {
-    return b.properties['carmen:relevance'] - a.properties['carmen:relevance'];
-}
-
 function calculateScoreDist(input) {
     for (let k = 0; k < input.length; k++) {
         const feat = input[k];
@@ -33,73 +29,6 @@ function calculateScoreDist(input) {
         ).toFixed(6));
     }
 }
-
-function calculateRelevanceScore(input) {
-    for (let k = 0; k < input.length; k++) {
-        const feat = input[k];
-        feat.properties['carmen:relevance'] = proximity.relevanceScore(
-            feat.properties['carmen:spatialmatch'].relev,
-            feat.properties['carmen:scoredist'],
-            feat.properties['carmen:address'],
-            feat.geometry && feat.geometry.omitted ? 1 : 0,
-            feat.properties['carmen:score'] < 0 ? 1 : 0
-        );
-    }
-}
-
-test('relevanceScore', (t) => {
-    t.test('language penalty, planet near planet granite portland, oregon',  (t) => {
-        const input = [
-            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
-            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
-            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
-            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
-            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
-            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
-            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
-            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } }
-        ];
-
-        calculateRelevanceScore(input);
-        input.sort(compareRelevanceScore);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
-        t.end();
-    });
-
-    t.test('address = null, waupaca near madison, wisconsin', (t) => {
-        const input = [
-            { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
-            { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
-            { id: 3, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
-            { id: 4, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
-            { id: 5, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
-            { id: 6, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
-            { id: 7, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
-            { id: 8, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
-        ];
-        calculateRelevanceScore(input);
-        input.sort(compareRelevanceScore);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
-        t.end();
-    });
-
-    t.test('ghost features, sunset district near san francisco', (t) => {
-        const input = [
-            { id: 2, properties: { 'carmen:text': 'Sunset District','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': -1,'carmen:scoredist': 10.980303 } },
-            { id: 1, properties: { 'carmen:text': 'Sunset City','carmen:spatialmatch': { relev: 1 }, 'carmen:distance': 4,'carmen:score': 10,'carmen:scoredist': 11.000193 } },
-            { id: 3, properties: { 'carmen:text': 'DTOWN PARTY BUS','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 451,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
-            { id: 4, properties: { 'carmen:text': 'District Resource Placement Centre','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 790,'carmen:score': 0, 'carmen:scoredist': 1.000006 } },
-            { id: 5, properties: { 'carmen:text': 'District Building','carmen:spatialmatch': { relev: 0.99 }, 'carmen:distance': 794,'carmen:score': 0, 'carmen:scoredist': 1.000006 } }
-        ];
-
-        calculateRelevanceScore(input);
-        input.sort(compareRelevanceScore);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5]);
-        t.end();
-    });
-
-});
-
 
 test('scoredist', (t) => {
 
@@ -332,20 +261,5 @@ test('variance', (t) => {
     t.equal(parseFloat(proximity.variance(0.75, 0.5).toFixed(4)), 0.4058, 'scale 0.75, decay 0.5 => variance 0.4058');
     t.equal(parseFloat(proximity.variance(0.5, 0.5).toFixed(4)), 0.1803, 'scale 0.5, decay 0.5 => variance 0.1803');
     t.equal(parseFloat(proximity.variance(0.25, 0.5).toFixed(4)), 0.0451, 'scale 0.25, decay 0.5 => variance 0.0451');
-    t.end();
-});
-
-test('relevanceScore', (t) => {
-    const minRelev = 0;
-    const maxRelev = 1;
-    const minScoredist = 1;
-    const maxScoredist = 121;
-    t.equal(proximity.relevanceScore(minRelev, minScoredist), 0, 'min relevanceScore value is 0');
-    t.equal(proximity.relevanceScore(maxRelev, maxScoredist), 1, 'max relevanceScore value is 1');
-    t.ok(proximity.relevanceScore(maxRelev, minScoredist, null) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with carmen:address of null receive a lower relevanceScore');
-    t.ok(proximity.relevanceScore(maxRelev, minScoredist, 123, true) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with geometry.ommitted receive a lower relevanceScore');
-    t.equal(proximity.relevanceScore(minRelev, minScoredist, null), 0, 'min relevanceScore with carmen:address of null is 0');
-    t.equal(proximity.relevanceScore(minRelev, minScoredist, 123, true), 0, 'min relevanceScore with geometry.ommitted is 0');
-    t.equal(proximity.relevanceScore(minRelev, minScoredist, null, true), 0, 'min relevanceScore with carmen:address of null and geometry.ommitted is 0');
     t.end();
 });

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -41,28 +41,48 @@ function calculateRelevanceScore(input) {
         const feat = input[k];
         feat.properties['carmen:relevance'] = proximity.relevanceScore(
             feat.properties['carmen:spatialmatch'].relev,
-            feat.properties['carmen:scoredist']
+            feat.properties['carmen:scoredist'],
+            feat.properties['carmen:address'],
+            feat.geometry && feat.geometry.omitted ? 1 : 0
         );
     }
 }
 
-test('relevanceScore language penalty', (t) => {
-    const input = [
-        { id: 7, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
-        { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
-        { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
-        { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
-        { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
-        { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
-        { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
-    ];
+test('relevanceScore', (t) => {
+    t.test('language penalty, planet near planet granite portland, oregon',  (t) => {
+        const input = [
+            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
+            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
+            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
+            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
+            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
+            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
+            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
+            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } }
+        ];
 
-    calculateRelevanceScore(input);
-    input.sort(compareRelevanceScore);
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
+        t.end();
+    });
 
-    t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7]);
-
-    t.end();
+    t.test('address = null, waupaca near madison, wisconsin', (t) => {
+        const input = [
+            { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
+            { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
+            { id: 8, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
+            { id: 3, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
+            { id: 4, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
+            { id: 5, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
+            { id: 6, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
+            { id: 7, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
+        ];
+        calculateRelevanceScore(input);
+        input.sort(compareRelevanceScore);
+        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
+        t.end();
+    });
 });
 
 
@@ -296,5 +316,20 @@ test('variance', (t) => {
     t.equal(parseFloat(proximity.variance(0.75, 0.5).toFixed(4)), 0.4058, 'scale 0.75, decay 0.5 => variance 0.4058');
     t.equal(parseFloat(proximity.variance(0.5, 0.5).toFixed(4)), 0.1803, 'scale 0.5, decay 0.5 => variance 0.1803');
     t.equal(parseFloat(proximity.variance(0.25, 0.5).toFixed(4)), 0.0451, 'scale 0.25, decay 0.5 => variance 0.0451');
+    t.end();
+});
+
+test('relevanceScore', (t) => {
+    const minRelev = 0;
+    const maxRelev = 1;
+    const minScoredist = 1;
+    const maxScoredist = 121;
+    t.equal(proximity.relevanceScore(minRelev, minScoredist), 0, 'min relevanceScore value is 0');
+    t.equal(proximity.relevanceScore(maxRelev, maxScoredist), 1, 'max relevanceScore value is 1');
+    t.ok(proximity.relevanceScore(maxRelev, minScoredist, null) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with carmen:address of null receive a lower relevanceScore');
+    t.ok(proximity.relevanceScore(maxRelev, minScoredist, 123, true) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with geometry.ommitted receive a lower relevanceScore');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, null), 0, 'min relevanceScore with carmen:address of null is 0');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, 123, true), 0, 'min relevanceScore with geometry.ommitted is 0');
+    t.equal(proximity.relevanceScore(minRelev, minScoredist, null, true), 0, 'min relevanceScore with carmen:address of null and geometry.ommitted is 0');
     t.end();
 });


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/771. First pass at creating a composite score with `relevance` _and_ `scoredist` when `proximity` is enabled rather than using `scoredist` as a tie breaker for `relevance`. The current implementation gives `relevance` a weight of 1 and `scoredist` a weight of 0.3. These thresholds are arbitrary; I chose them because they create a final score that  overcomes a single 4% penalty on an element in the stack when the feature doesn't have a `carmen:text_<language code>` property in the user-specified language. The final result is stored in the `carmen:relevance` property (we should probably revisit this naming) and is a value between 0 and 1.

### Summary of Changes
- [x] add `carmen:relevance` property to features when proximity is enabled
- [x] sort by `carmen:relevance` first if it exists

### Next Steps
- [x] test against downstream passrates. I chose these weight thresholds based on a single test case https://github.com/mapbox/carmen/compare/bump-language-penalty?expand=1#diff-3170dfb751a08557bb216e0c49b2cea1R49 and will likely tweak
- [ ] make sure we have test cases that capture this behavior for language, typo, and word frequency penalties
- [ ] document https://github.com/mapbox/carmen/compare/bump-language-penalty?expand=1#diff-d3439e250bdd6a8098bb9bd4095efcc1R185 and make constants/math more transparent
- [x] move https://github.com/mapbox/carmen/compare/bump-language-penalty?expand=1#diff-3170dfb751a08557bb216e0c49b2cea1R49 to its own test file
- [ ] use `carmen:relevance` as the final `relevance` displayed to the use  in the response when `proximity` is enabled

cc @apendleton @aarthykc @boblannon @miccolis 
