### PR TITLE
fixes poi.landmark

### DIFF
--- a/lib/geocoder/filter-sources.js
+++ b/lib/geocoder/filter-sources.js
@@ -93,7 +93,6 @@ function featureMatchesTypes(source, feature, options) {
 
         // Subtype check
         if (feature.properties['carmen:types'].indexOf(type[0]) !== -1 &&
-            feature.properties['carmen:score'] &&
             source.scoreranges &&
             source.scoreranges[type[1]] !== undefined) {
             const range = source.scoreranges[type[1]].slice(0);
@@ -137,4 +136,3 @@ function featureMatchesLanguage(feature, options) {
 function equivalentLanguages(a, b) {
     return equivalent[a] && equivalent[a].indexOf(b) > -1;
 }
-


### PR DESCRIPTION
### Context
Currently there's a slight difference in the way that `poi` and `poi.landmark` types search work when the `carmen:score == 0`. This PR changes that to make sure that both types return similar results [per our documentation](https://www.mapbox.com/api-documentation/#search-for-places).


### Next Steps
- [ ] Reviewed
- [ ] Merged 

cc @mapbox/search
