### PR TITLE
Don't penalize matches in indexes with an index-wide universal text flag

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -127,25 +127,20 @@ module.exports = function phrasematch(source, query, options, callback) {
     }
 
     let languages;
-    if (options.language) {
-        languages = [options.language[0]];
+    if (source.geocoder_universal_text) {
+        // if all text in the index is unversal, we won't apply any language
+        // penalties at all
+        languages = null;
     } else {
-        // this may not be what we want to do here
-        // if effectively treats 'default' as its own language, and a lack of
-        // specified language flag as a search over this language
-        // we could alternatively search all languages here by setting this field
-        // to undefined, or emply some other strategy
-        languages = ['default'];
-    }
-    languages = languages.map((l) => {
+        const languageName = options.language ? options.language[0] : 'default';
         // use the built-in language if we have it
-        if (source.lang.lang_map.hasOwnProperty(l)) {
-            return source.lang.lang_map[l];
+        if (source.lang.lang_map.hasOwnProperty(languageName)) {
+            languages = [source.lang.lang_map[languageName]];
         } else {
-            const label = cl.closestLangLabel(l, source.lang.lang_map);
-            return source.lang.lang_map[label || 'unmatched'];
+            const label = cl.closestLangLabel(languageName, source.lang.lang_map);
+            languages = [source.lang.lang_map[label || 'unmatched']];
         }
-    });
+    }
 
     // load up scorefactor used at indexing time.
     // it will be used to scale scores for approximated
@@ -220,12 +215,16 @@ function Phrasematch(subquery, weight, mask, phrase, scorefactor, idx, cache, zo
     this.phrase = phrase;
     this.scorefactor = scorefactor;
     this.prefix = prefix;
-    this.languages = languages;
     this.idx = idx;
     this.cache = cache;
     this.zoom = zoom;
     this.editMultiplier = editMultiplier || 1;
     this.proxMatch = proxMatch || false;
+    if (languages) {
+        // carmen-cache gives special treatment to the "languages" property
+        // being absent, so if we don't get one passed in, don't pass it through
+        this.languages = languages;
+    }
 }
 
 Phrasematch.prototype.clone = function() {

--- a/test/acceptance/geocode-unit.languageMode-universal.test.js
+++ b/test/acceptance/geocode-unit.languageMode-universal.test.js
@@ -59,6 +59,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
         c.geocode('10000', {}, (err, res) => {
             t.ifError(err);
             t.equal(res.features[0].place_name, '10000, United States');
+            t.equal(res.features[0].relevance, 1);
             t.end();
         });
     });
@@ -67,6 +68,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
         c.geocode('10000', { language: 'es' }, (err, res) => {
             t.ifError(err);
             t.equal(res.features[0].place_name, '10000, Estados Unidos');
+            t.equal(res.features[0].relevance, 1, 'no language penalty is applied for universal-text indexes');
             t.end();
         });
     });


### PR DESCRIPTION
### Context
#592 added a flag for marking a whole index as containing all universal (not-language-specific text). We thought that meant matches in those indexes were not penalized for cross-language mismatch, but that turns out not to be what that flag currently does; instead, it affects whether or not such matches can be included in results for queries made with the `languageMade: strict` flag even if they're out-of-language. This PR makes it also do the thing we already thought it did.

### Summary of Changes
- [x] if a phrasematch result is from an index with `geocoder_universal_text` set to true, don't set the `language` property on the phrasematch object that gets passed into coalesce (this will be interpreted by carmen-cache as an all-language match)
- [x] test to make sure a penalty is not applied


### Next Steps
- [x] wait for downstream passrates to ensure that this has the desired effect

cc @mapbox/search
