### PR TITLE
Fix default behavior for --fuzzyMatch and --autocomplete in the CLI tool

### DIFF
--- a/bin/carmen.js
+++ b/bin/carmen.js
@@ -111,6 +111,10 @@ if (argv.reverseMode) {
 
 if (argv.routing) argv.routing = (argv.routing || false);
 
+// this has to be done because minimist only allows null as a default value,
+// but carmen checks whether these values `=== undefined`
+if (argv.autocomplete === null) argv.autocomplete = undefined;
+if (argv.fuzzyMatch === null) argv.fuzzyMatch = undefined;
 
 let load = +new Date();
 

--- a/bin/carmen.js
+++ b/bin/carmen.js
@@ -11,8 +11,11 @@ const Carmen = require('..');
 const settings = require('../package.json');
 const argv = require('minimist')(process.argv, {
     string: ['config', 'proximity', 'query', 'debug', 'types', 'tokens'],
-    boolean: ['geojson', 'stats', 'help', 'version', 'autocomplete', 'fuzzyMatch']
+    boolean: ['geojson', 'stats', 'help', 'version', 'autocomplete', 'fuzzyMatch'],
+    default: {'autocomplete': null, 'fuzzyMatch': null}
 });
+
+console.dir(argv);
 
 if (argv.help) {
     console.log('carmen.js --query="<query>" [options]');
@@ -107,8 +110,7 @@ if (argv.reverseMode) {
 }
 
 if (argv.routing) argv.routing = (argv.routing || false);
-if (argv.autocomplete) argv.autocomplete = (argv.autocomplete || false);
-if (argv.fuzzyMatch) argv.fuzzyMatch = (argv.fuzzyMatch || false);
+
 
 let load = +new Date();
 

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -267,6 +267,14 @@ tape('bin/carmen query autocomplete true', (t) => {
     });
 });
 
+tape('bin/carmen query autocomplete unspecified', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=braz', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+
 tape('bin/carmen query autocomplete false', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=braz --autocomplete="false"', (err, stdout, stderr) => {
         t.ifError(err);
@@ -277,6 +285,14 @@ tape('bin/carmen query autocomplete false', (t) => {
 
 tape('bin/carmen query fuzzyMatch true', (t) => {
     exec(bin + '/carmen.js ' + tmpindex + ' --query=brazol --fuzzyMatch="true"', (err, stdout, stderr) => {
+        t.ifError(err);
+        t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
+        t.end();
+    });
+});
+
+tape('bin/carmen query fuzzyMatch unspecified', (t) => {
+    exec(bin + '/carmen.js ' + tmpindex + ' --query=brazol', (err, stdout, stderr) => {
         t.ifError(err);
         t.equal(/\d+\.\d+ Brazil/.test(stdout), true, 'finds brazil');
         t.end();


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
When `autocomplete` and `fuzzyMatch` are not included as options, their values should be `undefined`, so that `geocode` can apply the appropriate default value here https://github.com/mapbox/carmen/blob/17a391aad6cdfa07c7256a3444a740997247dd62/lib/geocoder/geocode.js#L51-L52

### Summary of Changes
- [x] add failing test
- [x] using the `minimist` config, set the defaults for these params to `null`
- [x] convert `null` to `undefined` before submitting to `geocode`
- [x] pass test

cc @mapbox/search 