### PR TITLE
Try new scoredist calculation in carmen-cache

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -567,7 +567,7 @@ function sortContext(a, b) {
     const ar = a[0].properties['carmen:relevance'] || 0;
     const br = b[0].properties['carmen:relevance'] || 0;
     if (ar > br) return -1;
-    if (br < ar) return 1;
+    if (ar < br) return 1;
 
     // sort by scoredist
     const as = a[0].properties['carmen:scoredist'] || 0;

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -197,7 +197,7 @@ function distscore(dist, score) {
 function relevanceScore(relev, scoredist, address, omitted, ghost) {
     // add a slight penalty to features with carmen:address === null
     // omitted geometries, or scores of < 0
-    if (address === null) relev = Math.max(0, relev - 0.005);
+    if (address === null) relev = Math.max(0, relev - 0.0005);
     if (omitted) relev = Math.max(0, relev - 0.01);
     if (ghost) relev = Math.max(0, relev - 0.01);
     // scale scoredist to a value between 0 and 1, give a weight of 0.4

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -80,7 +80,7 @@ function center2zxy(center, z) {
  * @param {Number} maxScore The maximum score of all features in all indexes
  * @param {Number} dist The distance from the feature to the proximity point in miles.
  * @param {String} zoom The vector tile zoom level of the index the feature is part of.
- * @return {Number} proximity adjusted score value between 1 and 121
+ * @return {Number} proximity adjusted score value between 1 and 5,000
  */
 function scoredist(score, minScore, maxScore, dist, zoom) {
     const scoreVal = scoreWeight(score, minScore, maxScore);
@@ -89,7 +89,7 @@ function scoredist(score, minScore, maxScore, dist, zoom) {
 }
 
 /**
- * Weigh score to a value between 1 and 11. This value is combined with a dist value
+ * Weigh score to a value between 1 and 500. This value is combined with a dist value
  * to calculate scoredist. Score is scaled linearly to maintain proportional distances
  * between a given feature's score and the highest score of all features in all indexes.
  *
@@ -99,13 +99,13 @@ function scoredist(score, minScore, maxScore, dist, zoom) {
  * @return {Number} scaled score value
  */
 function scoreWeight(score, minScore, maxScore) {
-    // scale score to a value between 0 and 1
+    // scale score to a value between 1 and 500
     const normalizedScore = (score - minScore) / (maxScore - minScore);
-    return (normalizedScore * 10) + 1;
+    return (normalizedScore * 499) + 1;
 }
 
 /**
- * Weigh distance to a value between 1 and 11. This value is combined with a score value
+ * Weigh distance to a value between 1 and 10. This value is combined with a score value
  * to calculate scoredist. Dist is scaled along a gaussian curve so that features
  * close to the proximity point receive relatively the same weight, after which
  * distance weighting decays rapidly, then levels out towards the edge of the
@@ -115,10 +115,9 @@ function scoreWeight(score, minScore, maxScore) {
  * @return {Number} scaled score value
  */
 function distWeight(dist, zoom) {
-    const radius = scaleRadius(zoom);
-    // set gaussVal to 0.5 when normalized distance is 3/4 of the proximity radius (e.g. 75 / 100 miles)
-    const gaussVal = gauss(dist / radius, VARIANCE_CONSTANT);
-    return (10 * gaussVal) + 1;
+    const distRatio = dist / scaleRadius(zoom);
+    const gaussVal = gauss(distRatio * 3, VARIANCE_CONSTANT);
+    return (9 * gaussVal) + 1;
 }
 
 /**
@@ -187,7 +186,7 @@ function distscore(dist, score) {
  * Combine scoredist and relevance into a single score for sorting. Apply penalties.
  *
  * @param {Number} relev The score of the feature
- * @param {Number} scoredist proximity adjusted score value between 1 and 121
+ * @param {Number} scoredist proximity adjusted score value between 1 and 5000
  * @param {Number} address The carmen:address property of the feature. Equal to
  * the street number if the user's query matches an address number and point in
  * the address cluster.
@@ -202,7 +201,7 @@ function relevanceScore(relev, scoredist, address, omitted, ghost) {
     if (omitted) relev = Math.max(0, relev - 0.01);
     if (ghost) relev = Math.max(0, relev - 0.01);
     // scale scoredist to a value between 0 and 1, give a weight of 0.4
-    const scoreDistWeight = ((scoredist - 1) / (121 - 1)) * 0.4;
+    const scoreDistWeight = ((scoredist - 1) / (5000 - 1)) * 0.4;
     // give relevance score a weight of 0.6
     const relevWeight = relev * 0.6;
     return relevWeight + scoreDistWeight;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "mapbox/carmen-cache#cddbbe8f7f6ac87a5d03ef28f814af39711a10c3",
+    "@mapbox/carmen-cache": "0.25.0",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-cache": "0.24.0",
+    "@mapbox/carmen-cache": "mapbox/carmen-cache#cddbbe8f7f6ac87a5d03ef28f814af39711a10c3",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/acceptance/geocode-unit.proximity-polygon.test.js
+++ b/test/acceptance/geocode-unit.proximity-polygon.test.js
@@ -35,7 +35,7 @@ tape('index place', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'san francisco',
-            'carmen:score':'10000',
+            'carmen:score': 8033,
             'carmen:zxy':tiles1,
             'carmen:center':[2, -1]
         }
@@ -47,7 +47,7 @@ tape('index place', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'san diego',
-            'carmen:score':'1000',
+            'carmen:score': 7891,
             'carmen:zxy':tiles2,
             'carmen:center':[2, -1]
         }
@@ -59,7 +59,7 @@ tape('index place', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'san jose',
-            'carmen:score':'100',
+            'carmen:score': 3877,
             'carmen:zxy':tiles3,
             'carmen:center':[2, -1]
         }
@@ -73,10 +73,10 @@ tape('query', (t) => {
     context.getTile.cache.reset();
     addFeature.resetLogs(conf);
     c.geocode('san', { debug: true, proximity: [3, -3] }, (err, res) => {
-        t.equal(res.features[0].id, 'place.3', 'proximity boosts lower-scored place');
+        t.equal(res.features.map((v) => v.id).join(', '), 'place.2, place.3, place.1', 'proximity boosts lower-scored place');
         t.equal(res.features[0].properties['carmen:score'] < res.features[2].properties['carmen:score'], true, 'place.3 has a lower score than place.2');
         t.equal(res.features[0].properties['carmen:distance'] < res.features[2].properties['carmen:distance'], true, 'place.3 is closer than place.2 to proximity point');
-        t.equal(res.features[0].properties['carmen:scoredist'] > res.features[2].properties['carmen:scoredist'], true, 'place.2 has a higher scoredist than place.3');
+        t.equal(res.features[0].properties['carmen:scoredist'] > res.features[2].properties['carmen:scoredist'], true, 'place.3 has a higher scoredist than place.2');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.proximity-squishy.test.js
+++ b/test/acceptance/geocode-unit.proximity-squishy.test.js
@@ -10,9 +10,9 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 // instead prioritize the highest-index feature
 // but local feature should still return first with proximity enabled
 const conf = {
-    country: new mem({ maxzoom: 6, minscore: 0, maxscore: 10000 }, () => {}),
-    place: new mem({ maxzoom: 6, geocoder_inherit_score: true, minscore: 0, maxscore: 10000 }, () => {}),
-    poi: new mem({ maxzoom: 6, minscore: 0, maxscore: 10000 }, () => {})
+    country: new mem({ maxzoom: 6, minscore: 0, maxscore: 1e6 }, () => {}),
+    place: new mem({ maxzoom: 6, geocoder_inherit_score: true, minscore: 0, maxscore: 1e5 }, () => {}),
+    poi: new mem({ maxzoom: 6, minscore: 0, maxscore: 1e4 }, () => {})
 };
 
 const c = new Carmen(conf);

--- a/test/unit/util/proximity.relevanceScore.test.js
+++ b/test/unit/util/proximity.relevanceScore.test.js
@@ -38,23 +38,6 @@ test('calculate relevanceScore', (t) => {
 
 
 test('sort features based on relevanceScore', (t) => {
-    t.test('language penalty, planet near planet granite portland, oregon',  (t) => {
-        const input = [
-            { id: 8, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } },
-            { id: 1, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
-            { id: 2, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
-            { id: 3, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
-            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
-            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
-            { id: 6, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
-            { id: 7, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } }
-        ];
-
-        calculateRelevanceScore(input);
-        input.sort(compareRelevanceScore);
-        t.deepEqual(input.map((f) => { return f.id; }), [1,2,3,4,5,6,7,8]);
-        t.end();
-    });
 
     t.test('address = null, waupaca near madison, wisconsin', (t) => {
         const input = [

--- a/test/unit/util/proximity.relevanceScore.test.js
+++ b/test/unit/util/proximity.relevanceScore.test.js
@@ -58,14 +58,14 @@ test('sort features based on relevanceScore', (t) => {
 
     t.test('address = null, waupaca near madison, wisconsin', (t) => {
         const input = [
-            { id: 7, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
+            { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
             { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
             { id: 8, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
-            { id: 2, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
-            { id: 3, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
-            { id: 4, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
-            { id: 5, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
-            { id: 6, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
+            { id: 3, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
+            { id: 4, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
+            { id: 5, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
+            { id: 6, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
+            { id: 7, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
         ];
         calculateRelevanceScore(input);
         input.sort(compareRelevanceScore);

--- a/test/unit/util/proximity.relevanceScore.test.js
+++ b/test/unit/util/proximity.relevanceScore.test.js
@@ -23,7 +23,7 @@ test('calculate relevanceScore', (t) => {
     const minRelev = 0;
     const maxRelev = 1;
     const minScoredist = 1;
-    const maxScoredist = 121;
+    const maxScoredist = 5000;
     t.equal(proximity.relevanceScore(minRelev, minScoredist), 0, 'min relevanceScore value is 0');
     t.equal(proximity.relevanceScore(maxRelev, maxScoredist), 1, 'max relevanceScore value is 1');
     t.ok(proximity.relevanceScore(maxRelev, minScoredist, null) < proximity.relevanceScore(maxRelev, maxScoredist), 'features with carmen:address of null receive a lower relevanceScore');
@@ -40,14 +40,14 @@ test('calculate relevanceScore', (t) => {
 test('sort features based on relevanceScore', (t) => {
     t.test('language penalty, planet near planet granite portland, oregon',  (t) => {
         const input = [
-            { id: 8, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
-            { id: 1, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
-            { id: 2, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
-            { id: 3, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
-            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
-            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
-            { id: 6, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } },
-            { id: 7, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } }
+            { id: 8, properties: { 'carmen:text': 'Planet Street', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999999, 'carmen:address': null } },
+            { id: 1, properties: { 'carmen:text': 'Planetal', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 1 } },
+            { id: 2, properties: { 'carmen:text': 'Planet Granite', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.999139 } },
+            { id: 3, properties: { 'carmen:text': 'Planet Fitness,gym, fitness center', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.916823 } },
+            { id: 4, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.895406 } },
+            { id: 5, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.881766 } },
+            { id: 6, properties: { 'carmen:text': 'Planet Fitness', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.828728 } },
+            { id: 7, properties: { 'carmen:text': 'Planet Thai', 'carmen:spatialmatch': { relev: 0.96 }, 'carmen:scoredist': 10.774937 } }
         ];
 
         calculateRelevanceScore(input);
@@ -58,14 +58,14 @@ test('sort features based on relevanceScore', (t) => {
 
     t.test('address = null, waupaca near madison, wisconsin', (t) => {
         const input = [
-            { id: 2, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
+            { id: 7, properties: { 'carmen:text': 'Waupaca Court', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.976215, 'carmen:address': null } },
             { id: 1, properties: { 'carmen:text': 'Waupaca', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 10.788564 } },
-            { id: 3, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
-            { id: 4, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
-            { id: 5, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
-            { id: 6, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
-            { id: 7, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
-            { id: 8, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
+            { id: 8, properties: { 'carmen:text': 'Waupaca Street', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 5.954101, 'carmen:address': null } },
+            { id: 2, properties: { 'carmen:text': 'Waupaca High School,primary school, secondary', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.869482 } },
+            { id: 3, properties: { 'carmen:text': 'Waupaca Camping Park, LLC', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.826643 } },
+            { id: 4, properties: { 'carmen:text': 'Waupaca County Fairgrounds', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.810530 } },
+            { id: 5, properties: { 'carmen:text': 'Waupaca Bowl', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.802046 } },
+            { id: 6, properties: { 'carmen:text': 'Waupaca Ale House', 'carmen:spatialmatch': { relev: 1 }, 'carmen:scoredist': 4.794998 } }
         ];
         calculateRelevanceScore(input);
         input.sort(compareRelevanceScore);

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -42,10 +42,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'New York Frankfurter Co.', 'carmen:distance': 0.4914344651849769, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999837 } },
-            { properties: { 'carmen:text': 'New Yorker Buffalo Wings', 'carmen:distance': 0.6450163846417221, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.999757 } },
-            { properties: { 'carmen:text': 'New York,NY', 'carmen:distance': 2426.866703400975, 'carmen:score': 79161, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 3.064524 } },
-            { properties: { 'carmen:text': 'New York,NY,NYC,New York City', 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.190309 } }
+            { properties: { 'carmen:text': 'New York,NY', 'carmen:distance': 2426.866703400975, 'carmen:score': 79161, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 25.168365 } },
+            { properties: { 'carmen:text': 'New York,NY,NYC,New York City', 'carmen:distance': 2567.3550038898834, 'carmen:score': 31104, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.496437 } },
+            { properties: { 'carmen:text': 'New Yorker Buffalo Wings', 'carmen:distance': 0.6450163846417221, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.008055 } },
+            { properties: { 'carmen:text': 'New York Frankfurter Co.', 'carmen:distance': 0.4914344651849769, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.003694  } }
         ];
 
         calculateScoreDist(input);
@@ -61,8 +61,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Chicago Title', 'carmen:distance': 0.14084037845690478, 'carmen:score': 2, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 11.000177 } },
-            { properties: { 'carmen:text': 'Chicago', 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.104027 } }
+            { properties: { 'carmen:text': 'Chicago Title', 'carmen:distance': 0.14084037845690478, 'carmen:score': 2, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.008961 } },
+            { properties: { 'carmen:text': 'Chicago', 'carmen:distance': 1855.8900334142313, 'carmen:score': 16988, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 6.186786 } }
         ];
 
         calculateScoreDist(input);
@@ -80,12 +80,11 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'San Francisco', 'carmen:distance': 74.24466022598429, 'carmen:score': 8015, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.343406 } },
-            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442813 } },
-            { properties: { 'carmen:text': 'São Paulo', 'carmen:distance': 6547.831697209755, 'carmen:score': 36433, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.222914 } },
-            { properties: { 'carmen:text': 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:distance': 6023.053777668511, 'carmen:score': 26709, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.163419 } }
+            { properties: { 'carmen:text': 'San Francisco', 'carmen:distance': 74.24466022598429, 'carmen:score': 8015, 'carmen:zoom': 12, 'carmen:scoredist': 29.62751 } },
+            { properties: { 'carmen:text': 'São Paulo', 'carmen:distance': 6547.831697209755, 'carmen:score': 36433, 'carmen:zoom': 12, 'carmen:scoredist': 12.123395 } },
+            { properties: { 'carmen:text': 'Santiago Metropolitan,METROPOLITANA,Región Metropolitana de Santiago', 'carmen:distance': 6023.053777668511, 'carmen:score': 26709, 'carmen:zoom': 12, 'carmen:scoredist': 9.154632 } },
+            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': 12, 'carmen:scoredist': 7.293636 } }
         ];
-
         calculateScoreDist(input);
         t.deepEqual(input.sort(compareScoreDist), expected);
         t.end();
@@ -99,8 +98,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.442813 } },
-            { properties: { 'carmen:text': 'Santa Cruz de Tenerife', 'carmen:distance': 5811.283048403849, 'carmen:score': 3456, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.021151 } }
+            { properties: { 'carmen:text': 'Santa Cruz', 'carmen:distance': 133.8263938095184, 'carmen:score': 587, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 7.293636 } },
+            { properties: { 'carmen:text': 'Santa Cruz de Tenerife', 'carmen:distance': 5811.283048403849, 'carmen:score': 3456, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 2.055431 } }
         ];
 
         calculateScoreDist(input);
@@ -116,8 +115,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Washington,DC', 'carmen:distance': 34.81595024835296, 'carmen:score': 7400, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.454816 } },
-            { properties: { 'carmen:text': 'Washington,WA', 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 2.940307 } }
+            { properties: { 'carmen:text': 'Washington,DC', 'carmen:distance': 34.81595024835296, 'carmen:score': 7400, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 31.520181 } },
+            { properties: { 'carmen:text': 'Washington,WA', 'carmen:distance': 2256.6130314083157, 'carmen:score': 33373, 'carmen:zoom': ZOOM_LEVELS.region, 'carmen:scoredist': 11.189172 } }
         ];
 
         calculateScoreDist(input);
@@ -135,10 +134,10 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:distance': 36.12228253928214, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 9.514785 } },
-            { properties: { 'carmen:text': 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:distance': 188.29482550861198, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.126649 } },
-            { properties: { 'carmen:text': 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:distance': 246.29759329605977, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.005676 } },
-            { properties: { 'carmen:text': 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:distance': 3312.294287119006, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000024 } }
+            { properties: { 'carmen:text': 'Gilmour Ave, Runnymede, Toronto, M6P 3B5, Ontario, Canada, CA', 'carmen:distance': 36.12228253928214, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 3.118235 } },
+            { properties: { 'carmen:text': 'Gilmour Avenue, West Dunbartonshire, G81 6AN, West Dunbartonshire, United Kingdom', 'carmen:distance': 3312.294287119006, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.001221 } },
+            { properties: { 'carmen:text': 'Gilmour Ave, Hillendale, Kingston, K7M 2Y8, Ontario, Canada, CA', 'carmen:distance': 188.29482550861198, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000305 } },
+            { properties: { 'carmen:text': 'Gilmour Ave, Somerset, 15501, Pennsylvania, United States', 'carmen:distance': 246.29759329605977, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.address, 'carmen:scoredist': 1.000305 } }
         ];
 
         calculateScoreDist(input);
@@ -155,9 +154,9 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:distance': 10.73122383596493, 'carmen:score': 294, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 11.015906 } },
-            { properties: { 'carmen:text': 'Cambridge, 02139, Massachusetts, United States', 'carmen:distance': 464.50390088754625, 'carmen:score': 986, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 5.812961 } },
-            { properties: { 'carmen:text': 'Cambridgeshire, United Kingdom', 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.016654 } }
+            { properties: { 'carmen:text': 'Cambridge, N1R 6A9, Ontario, Canada, CA', 'carmen:distance': 10.73122383596493, 'carmen:score': 294, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 10.8659 } },
+            { properties: { 'carmen:text': 'Cambridgeshire, United Kingdom', 'carmen:distance': 3566.2969841802374, 'carmen:score': 2721, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.831034 }  },
+            { properties: { 'carmen:text': 'Cambridge, 02139, Massachusetts, United States', 'carmen:distance': 464.50390088754625, 'carmen:score': 986, 'carmen:zoom': ZOOM_LEVELS.place, 'carmen:scoredist': 1.316536 } }
         ];
 
         calculateScoreDist(input);
@@ -173,8 +172,8 @@ test('scoredist', (t) => {
         ];
 
         const expected = [
-            { properties: { 'carmen:text': 'United States of America, United States, America, USA, US', 'carmen:distance': 1117.3906777683906, 'carmen:score': 1634443, 'carmen:zoom': ZOOM_LEVELS.country, 'carmen:scoredist': 79.416753 } },
-            { properties: { 'carmen:text': 'United States Department of Treasury Annex', 'carmen:distance': 0.11774815645353183, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 11.00005 } }
+            { properties: { 'carmen:text': 'United States of America, United States, America, USA, US', 'carmen:distance': 1117.3906777683906, 'carmen:score': 1634443, 'carmen:zoom': ZOOM_LEVELS.country, 'carmen:scoredist': 562.681655 } },
+            { properties: { 'carmen:text': 'United States Department of Treasury Annex', 'carmen:distance': 0.11774815645353183, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:scoredist': 10.002915 } }
         ];
 
         calculateScoreDist(input);
@@ -185,26 +184,26 @@ test('scoredist', (t) => {
     t.test('missi near mission neighborhood san francisco', (t) => {
         // --query="missi" --proximity="-122.4213562,37.75234222"
         const input = [
-            { id: 13, properties: { 'carmen:text': 'Mission District', 'carmen:distance': 0.641155642372423, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 16, properties: { 'carmen:text': 'Mission Terrace', 'carmen:distance': 2.0543295828567985, 'carmen:score': 50, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 15, properties: { 'carmen:text': 'Mission District', 'carmen:distance': 0.641155642372423, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 2, properties: { 'carmen:text': 'Mission Terrace', 'carmen:distance': 2.0543295828567985, 'carmen:score': 50, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
             { id: 1, properties: { 'carmen:text': 'Mission', 'carmen:distance': 0.5365405586195869, 'carmen:score': 609, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 17, properties: { 'carmen:text': 'Mission Bay', 'carmen:distance': 2.083206525530076, 'carmen:score': 46, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 15, properties: { 'carmen:text': 'Mission Dolores', 'carmen:distance': 0.8734705397622807, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 5, properties: { 'carmen:text': 'Mission Branch Library', 'carmen:distance': 0.09171422623336412, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 9, properties: { 'carmen:text': 'Mission Tires & Service Center', 'carmen:distance': 0.41252770420569307, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 11, properties: { 'carmen:text': 'Mission Dental Care', 'carmen:distance': 0.47809299593103194, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 2, properties: { 'carmen:text': 'Mission Pie,cafe, coffee, tea, tea house', 'carmen:distance': 0.20888191032358838, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 3, properties: { 'carmen:text': 'Mission\'s Kitchen,fast food', 'carmen:distance': 0.1618230166173522, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 8, properties: { 'carmen:text': 'Mission Gastroclub', 'carmen:distance': 0.3514533005726089, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 10, properties: { 'carmen:text': 'Mission Skateboards', 'carmen:distance': 0.4633504101693179, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 4, properties: { 'carmen:text': 'Mission Cultural Center for Latino Arts,college, university', 'carmen:distance': 0.18621060494099984, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 7, properties: { 'carmen:text': 'Mission Critter', 'carmen:distance': 0.24892887064676822, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 6, properties: { 'carmen:text': 'Mission Wishing Tree', 'carmen:distance': 0.10633212084221495, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 3, properties: { 'carmen:text': 'Mission Bay', 'carmen:distance': 2.083206525530076, 'carmen:score': 46, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 16, properties: { 'carmen:text': 'Mission Dolores', 'carmen:distance': 0.8734705397622807, 'carmen:score': -1, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
+            { id: 7, properties: { 'carmen:text': 'Mission Branch Library', 'carmen:distance': 0.09171422623336412, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 11, properties: { 'carmen:text': 'Mission Tires & Service Center', 'carmen:distance': 0.41252770420569307, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 12, properties: { 'carmen:text': 'Mission Dental Care', 'carmen:distance': 0.47809299593103194, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 4, properties: { 'carmen:text': 'Mission Pie,cafe, coffee, tea, tea house', 'carmen:distance': 0.20888191032358838, 'carmen:score': 3, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 5, properties: { 'carmen:text': 'Mission\'s Kitchen,fast food', 'carmen:distance': 0.1618230166173522, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 10, properties: { 'carmen:text': 'Mission Gastroclub', 'carmen:distance': 0.3514533005726089, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 17, properties: { 'carmen:text': 'Mission Skateboards', 'carmen:distance': 1.4633504101693179, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 6, properties: { 'carmen:text': 'Mission Cultural Center for Latino Arts,college, university', 'carmen:distance': 0.18621060494099984, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 9, properties: { 'carmen:text': 'Mission Critter', 'carmen:distance': 0.24892887064676822, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 8, properties: { 'carmen:text': 'Mission Wishing Tree', 'carmen:distance': 0.10633212084221495, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 20, properties: { 'carmen:text': 'Mississippi', 'carmen:distance': 1873.3273481255542, 'carmen:score': 17955, 'carmen:zoom': ZOOM_LEVELS.region } },
             { id: 18, properties: { 'carmen:text': 'Mission Bay Mobile Home Park', 'carmen:distance': 15.112097493445267, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
             { id: 19, properties: { 'carmen:text': 'Mission-Foothill', 'carmen:distance': 19.97574371302543, 'carmen:score': 44, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
-            { id: 14, properties: { 'carmen:text': 'Mission Workshop,bicycle, bike, cycle', 'carmen:distance': 0.821663496329208, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
-            { id: 12, properties: { 'carmen:text': 'Mission Pet Hospital', 'carmen:distance': 0.6281933184839765, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 13, properties: { 'carmen:text': 'Mission Workshop,bicycle, bike, cycle', 'carmen:distance': 0.821663496329208, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { id: 14, properties: { 'carmen:text': 'Mission Pet Hospital', 'carmen:distance': 0.6281933184839765, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
         ];
 
         calculateScoreDist(input);
@@ -222,16 +221,16 @@ test('scoreWeight', (t) => {
     const minScore = 0;
     const maxScore = 1000;
     t.equal(proximity.scoreWeight(0, minScore, maxScore), 1, 'score minScore => scoreWeight 1');
-    t.equal(proximity.scoreWeight((maxScore - minScore) * 0.5, minScore, maxScore), 6, ' score of midpoint => scoreWeight 6');
-    t.equal(proximity.scoreWeight(maxScore, minScore, maxScore), 11, 'score maxScore => scoreWeight 11');
+    t.equal(proximity.scoreWeight((maxScore - minScore) * 0.5, minScore, maxScore), 250.5, ' score of midpoint => scoreWeight 500.5');
+    t.equal(proximity.scoreWeight(maxScore, minScore, maxScore), 500, 'score maxScore => scoreWeight 500');
     t.end();
 });
 
 test('distWeight', (t) => {
     t.equal(parseFloat(proximity.distWeight(400, 14).toFixed(4)), 1, 'dist 4x > scaleRadius => distWeight ~1');
-    t.equal(parseFloat(proximity.distWeight(100, 14).toFixed(4)), 3.9163, 'dist = scaleRadius => distWeight ~3.92s');
-    t.equal(proximity.distWeight(75, 14), 6, 'dist 3/4 scaleRadius => distWeight 6');
-    t.equal(proximity.distWeight(0, 14), 11, 'dist 0 => distWeight 11');
+    t.equal(parseFloat(proximity.distWeight(100, 14).toFixed(4)), 1.0001, 'dist = scaleRadius => distWeight ~1.0001');
+    t.equal(proximity.distWeight(75, 14).toFixed(4), '1.0176', 'dist 3/4 scaleRadius => distWeight ~1.0176');
+    t.equal(proximity.distWeight(0, 14), 10, 'dist 0 => distWeight 10');
     t.end();
 });
 

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -229,7 +229,7 @@ test('scoreWeight', (t) => {
 test('distWeight', (t) => {
     t.equal(parseFloat(proximity.distWeight(400, 14).toFixed(4)), 1, 'dist 4x > scaleRadius => distWeight ~1');
     t.equal(parseFloat(proximity.distWeight(100, 14).toFixed(4)), 1.0001, 'dist = scaleRadius => distWeight ~1.0001');
-    t.equal(proximity.distWeight(75, 14).toFixed(4), '1.0176', 'dist 3/4 scaleRadius => distWeight ~1.0176');
+    t.equal(proximity.distWeight(25, 14).toFixed(4), '5.5000', 'dist 1/4 scaleRadius => distWeight ~5.5');
     t.equal(proximity.distWeight(0, 14), 10, 'dist 0 => distWeight 10');
     t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,10 +97,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-cache@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.24.0.tgz#a79388e9015fdef095049b3e70d8fa3792e08bf0"
-  integrity sha512-BJvUMfOER/ewH7JES0lEWtp+sugxuGCb4Q52HN5fX1WQI21MDKKaXR/BSUR4orsUhtFKYTCU6CCGxqrCURELmA==
+"@mapbox/carmen-cache@mapbox/carmen-cache#cddbbe8f7f6ac87a5d03ef28f814af39711a10c3":
+  version "0.24.0-scoredist2"
+  resolved "https://codeload.github.com/mapbox/carmen-cache/tar.gz/cddbbe8f7f6ac87a5d03ef28f814af39711a10c3"
   dependencies:
     nan "~2.10.0"
     node-pre-gyp "~0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,9 +97,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-cache@mapbox/carmen-cache#cddbbe8f7f6ac87a5d03ef28f814af39711a10c3":
-  version "0.24.0-scoredist2"
-  resolved "https://codeload.github.com/mapbox/carmen-cache/tar.gz/cddbbe8f7f6ac87a5d03ef28f814af39711a10c3"
+"@mapbox/carmen-cache@0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/carmen-cache/-/carmen-cache-0.25.0.tgz#b7e359bbddd7b64ac9a938ae429e9fce59d95aa8"
+  integrity sha512-2Vpjh6ocZCEpCkoPQ3LsjMXFnS6qGb7zABHoSokZs5ay3bZqca72EESrymwRBmVTxQ6gm69fasUo8fE/dBFXuA==
   dependencies:
     nan "~2.10.0"
     node-pre-gyp "~0.10.1"


### PR DESCRIPTION
### Changes

* Pull in update to carmen-cache https://github.com/mapbox/carmen-cache/pull/139 which accounts for score when proximity scoring close results.
* Tighened the width of gaussian curved by factor of 3. Previously this overcompensated for the fact that carmen-cache was unlikely to return many relatively low scored results past 20-30 miles. New version of carmen-cache fixes this. 
* Rescaled distance and weight during proximity scoring. Previously both were put on a 1-11 scale. Now; distance is 1-10, score is 1-500. This is necessary because actual scores can vary huge amounts and minor difference would always lose out to distance.
* Fixed a bug (in `/lib/geocoder/verifymatch.js`) where the composite relevance + scoredist value was ignored during a sort if the `b` value was greater than `a`.

### Next Steps

- [x] Downstream tests
- [x] Depends on new version of carmen-cache
- [ ] Changelog entry

cc @mapbox/search
