### PR TITLE
Add fallback behavior if tilecover fails to calculate covers for geometry

### DIFF
--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -9,6 +9,7 @@ const DEBUG = process.env.DEBUG;
 const extent = require('@turf/bbox').default;
 const point = require('@turf/helpers').point;
 const linestring = require('@turf/helpers').lineString;
+const buffer = require('@turf/buffer');
 const geojsonHint = require('@mapbox/geojsonhint');
 const feature = require('../util/feature');
 const center2zxy = require('../util/proximity').center2zxy;
@@ -214,13 +215,27 @@ function standardize(doc, zoom) {
         doc.properties['carmen:zxy'] = [];
         tiles = [];
         for (let feat_it = 0; feat_it < doc.geometry.geometries.length; feat_it++) {
-            tiles = tiles.concat(cover.tiles(doc.geometry.geometries[feat_it], { min_zoom: zoom, max_zoom: zoom }));
+            let feat_tiles;
+            try {
+                feat_tiles = cover.tiles(doc.geometry.geometries[feat_it], { min_zoom: zoom, max_zoom: zoom });
+            } catch (e) {
+                const repaired = buffer(doc.geometry.geometries[feat_it], 0);
+                feat_tiles = cover.tiles(repaired.geometry, { min_zoom: zoom, max_zoom: zoom });
+                console.warn('Geometry repair was necessary on id:' + doc.id);
+            }
+            tiles = tiles.concat(feat_tiles);
         }
         tiles.forEach((tile) => {
             doc.properties['carmen:zxy'].push(tile[2] + '/' + tile[0] + '/' + tile[1]);
         });
     } else if (!doc.properties['carmen:zxy']) {
-        tiles = cover.tiles(doc.geometry, { min_zoom: zoom, max_zoom: zoom });
+        try {
+            tiles = cover.tiles(doc.geometry, { min_zoom: zoom, max_zoom: zoom });
+        } catch (e) {
+            const repaired = buffer(doc, 0);
+            tiles = cover.tiles(repaired.geometry, { min_zoom: zoom, max_zoom: zoom });
+            console.warn('Geometry repair was necessary on id:' + doc.id);
+        }
         doc.properties['carmen:zxy'] = [];
         tiles.forEach((tile) => {
             doc.properties['carmen:zxy'].push(tile[2] + '/' + tile[0] + '/' + tile[1]);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "@turf/bearing": "^6.0.1",
+    "@turf/buffer": "^5.1.5",
     "@turf/center": "^6.0.1",
     "@turf/destination": "^6.0.1",
     "@turf/distance": "^6.0.1",

--- a/test/unit/indexer/indexdocs.test.js
+++ b/test/unit/indexer/indexdocs.test.js
@@ -4,6 +4,8 @@ const grid = require('../../../lib/util/grid.js');
 const tape = require('tape');
 const token = require('../../../lib/text-processing/token.js');
 const rewind = require('geojson-rewind');
+const fs = require('fs');
+const path = require('path');
 
 tape('indexdocs.loadDoc', (t) => {
     const simple_replacer = token.createSimpleReplacer({});
@@ -69,6 +71,21 @@ tape('indexdocs.standardize', (t) => {
         }, 6, {});
 
         q.deepEquals(res, { geometry: { coordinates: [0, 0], type: 'Point' }, id: 1, properties: { 'carmen:center': [0, 0], 'carmen:text': 'main street', 'carmen:zxy': ['6/32/32'] }, type: 'Feature' });
+        q.end();
+    });
+
+    t.test('indexdocs.standardize - geometry that breaks tilecover is fixed', (q) => {
+        const usaRow = fs.readFileSync(path.resolve(__dirname, '../../fixtures/docs.jsonl'), 'utf8').split('\n')[4];
+        const brokenUsa = JSON.parse(usaRow);
+        // push an empty polygon onto the end of the multypolygon
+        brokenUsa.geometry.coordinates[0].push([
+            [-100, 27],
+            [-100, 27],
+            [-100, 27],
+            [-100, 27]
+        ]);
+        q.doesNotThrow(() => indexdocs.standardize(brokenUsa, 6, {}));
+
         q.end();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,19 @@
     "@turf/helpers" "^5.1.5"
     "@turf/invariant" "^5.1.5"
 
+"@turf/buffer@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/buffer/-/buffer-5.1.5.tgz#841c9627cfb974b122ac4e1a956f0466bc0231c4"
+  integrity sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=
+  dependencies:
+    "@turf/bbox" "^5.1.5"
+    "@turf/center" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/projection" "^5.1.5"
+    d3-geo "1.7.1"
+    turf-jsts "*"
+
 "@turf/center@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-5.1.5.tgz#44ab2cd954f63c0d37757f7158a99c3ef5114b80"
@@ -413,6 +426,15 @@
     "@turf/explode" "^5.1.5"
     "@turf/helpers" "^5.1.5"
     "@turf/nearest-point" "^5.1.5"
+
+"@turf/projection@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-5.1.5.tgz#24517eeeb2f36816ba9f712e7ae6d6a368edf757"
+  integrity sha1-JFF+7rLzaBa6n3EueubWo2jt91c=
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
 
 JSONStream@^1.0.3:
   version "1.3.5"
@@ -2079,6 +2101,18 @@ currently-unhandled@^0.4.1:
   integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
+
+d3-array@1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-geo@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
+  integrity sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==
+  dependencies:
+    d3-array "1"
 
 d3-queue@3.0.x, d3-queue@^3.0.2:
   version "3.0.7"
@@ -6255,6 +6289,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+turf-jsts@*:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/turf-jsts/-/turf-jsts-1.2.3.tgz#59757f542afbff9a577bbf411f183b8f48d38aa4"
+  integrity sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
### Context
Tilecover seems to have trouble handling a particular kind of oddly formed geometry: a multipolygon where one of the component polygons has zero area (that is, all of its vertices are the same point). In current carmen, attempting to index such a geometry causes the indexer to crash.

Ordinarily, we would expect tools generating geojson to be indexed to handle these kinds of messy-data issues on their end before passing the data in to be indexed. Unfortunately, this kind of geometry is technically valid; as such, typical tools one might use to normalize this kind of geometry (Postgis's ST_makevalid, etc.) leave these zero-area polygons intact, so we'll clean it up on the Carmen side instead.

The approach is just to wrap the tile coverage operation in a try/catch, and if it fails, use turf.buffer to buffer out the geometry by 0. Unlike `ST_Buffer` in Postgis, turf's buffer *does* clean up geometries of this type, which allows tilecover to succeed.


### Summary of Changes
- [x] wrap tile coverage calculations within the indexer in try/catches, and fall back to buffering first on failure
- [x] add test ensuring a crash doesn't occur


### Next Steps
nope


cc @mapbox/search
