### PR TITLE
Don't interpret unit numbers as addresses

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -124,6 +124,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
         if (source.geocoder_address) {
             if (address && (feats[0].properties['carmen:addressnumber'] || feats[0].properties['carmen:rangetype'])) {
                 feats[0].properties['carmen:address'] = address.addr;
+                feats[0].properties['carmen:addresspos'] = address.pos;
 
                 let addressPoints = [];
 

--- a/test/acceptance/geocode-unit.address-alphanumeric.test.js
+++ b/test/acceptance/geocode-unit.address-alphanumeric.test.js
@@ -87,10 +87,23 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('test address index with double number', (t) => {
-        c.geocode('70 WASHINGTON STREET #501', {}, (err, res) => {
+        c.geocode('70 WASHINGTON STREET #502', {}, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found: 70 WASHINGTON STREET');
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with #502');
             t.equals(res.features[0].relevance, 0.50);
+        });
+
+        c.geocode('70 WASHINGTON STREET UNIT 502', {}, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with UNIT 502');
+            t.equals(res.features[0].relevance, 0.50);
+        });
+
+        c.geocode('70 WASHINGTON STREET 502', {}, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with 502');
+            t.equals(res.features[0].relevance, 0.50);
+
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.address-alphanumeric.test.js
+++ b/test/acceptance/geocode-unit.address-alphanumeric.test.js
@@ -87,21 +87,27 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 
     tape('test address index with double number', (t) => {
+        c.geocode('70 WASHINGTON STREET 502', {}, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with 502');
+            t.equals(res.features[0].relevance, 0.50);
+        });
+
         c.geocode('70 WASHINGTON STREET #502', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with #502');
             t.equals(res.features[0].relevance, 0.50);
         });
 
-        c.geocode('70 WASHINGTON STREET UNIT 502', {}, (err, res) => {
+        c.geocode('70 WASHINGTON STREET # 502', {}, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with UNIT 502');
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with # 502');
             t.equals(res.features[0].relevance, 0.50);
         });
 
-        c.geocode('70 WASHINGTON STREET 502', {}, (err, res) => {
+        c.geocode('70 WASHINGTON STREET UNIT 502', {}, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with 502');
+            t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with UNIT 502');
             t.equals(res.features[0].relevance, 0.50);
 
             t.end();


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/809

### Summary of Changes
- [x] set `carmen:addresspos` property using `pos` calculated in `maskAddress`

### Next Steps
- [x] update passrates downstream
- [x] review
- [ ] merge

cc @miccolis @aarthykc @apendleton 
