### PR TITLE
Preference non-interpolated address results

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -654,6 +654,10 @@ function sortContext(a, b) {
         // for address results, prefer those from point clusters
         if (a[0].properties['carmen:addressnumber'] && !b[0].properties['carmen:addressnumber']) return -1;
         if (b[0].properties['carmen:addressnumber'] && !a[0].properties['carmen:addressnumber']) return 1;
+
+        // prefer non-interpolated address results
+        if ((a[0].geometry && !a[0].geometry.interpolated) && (b[0].geometry && b[0].geometry.interpolated)) return -1;
+        if ((b[0].geometry && !b[0].geometry.interpolated) && (a[0].geometry && a[0].geometry.interpolated)) return 1;
     }
 
     // omitted difference

--- a/test/acceptance/geocode-unit.address-sort-interpolated.test.js
+++ b/test/acceptance/geocode-unit.address-sort-interpolated.test.js
@@ -1,0 +1,118 @@
+'use strict';
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+// Test that non-interpolated results are returned before interpolated results
+// with the same relevance. Note that features must have different
+// `place_name`s to avoid being deduped in dedupe.js.
+(() => {
+    const conf = {
+        address: new mem({ maxzoom: 6,  geocoder_address:1, geocoder_tokens: { 'Street': 'St' } }, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index address cluster to interpolate', (t) => {
+        const address = {
+            id: 1,
+            properties: {
+                'carmen:text': 'Main St',
+                'carmen:center': [-97.2, 37.3],
+                'carmen:rangetype': 'tiger',
+                'carmen:lfromhn': [['100'], []],
+                'carmen:ltohn': [['200'], []],
+                'carmen:rfromhn': [['101'], []],
+                'carmen:rtohn': [['199'], []],
+                'carmen:parityl': [['E'], []],
+                'carmen:parityr': [['O'], []],
+                'carmen:addressnumber': [null, ['100', '200']]
+            },
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [
+                    {
+                        type: 'MultiLineString',
+                        coordinates: [
+                            [
+                                [-97.2, 37.2],
+                                [-97.2, 37.4]
+                            ]
+                        ]
+                    },
+                    {
+                        type: 'MultiPoint',
+                        coordinates: [[-97.2, 37.2],[-97.2, 37.4]]
+                    }
+                ]
+            }
+        };
+        queueFeature(conf.address, address, t.end);
+    });
+
+    tape('index address cluster with real address feature', (t) => {
+        const address = {
+            id: 2,
+            properties: {
+                'carmen:text': 'Main Street',
+                'carmen:center': [-97.2, 37.3],
+                'carmen:rangetype': 'tiger',
+                'carmen:lfromhn': [['100'], []],
+                'carmen:ltohn': [['200'], []],
+                'carmen:rfromhn': [['101'], []],
+                'carmen:rtohn': [['199'], []],
+                'carmen:parityl': [['E'], []],
+                'carmen:parityr': [['O'], []],
+                'carmen:addressnumber': [null, ['150']]
+            },
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [
+                    {
+                        type: 'MultiLineString',
+                        coordinates: [
+                            [
+                                [-97.2, 37.2],
+                                [-97.2, 37.4]
+                            ]
+                        ]
+                    },
+                    {
+                        type: 'MultiPoint',
+                        coordinates: [[-97.2, 37.3]]
+                    }
+                ]
+            }
+        };
+        queueFeature(conf.address, address, t.end);
+    });
+
+    tape('build queued features', (t) => {
+        const q = queue();
+        Object.keys(conf).forEach((c) => {
+            q.defer((cb) => {
+                buildQueued(conf[c], cb);
+            });
+        });
+        q.awaitAll(t.end);
+    });
+
+
+    tape('Return non-interpolated address before interpolated address', (t) => {
+        c.geocode('150 Main St', { limit_verify: 2 }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features.length, 2);
+            t.deepEquals(res.features[0].id, 'address.2');
+            t.deepEquals(res.features[0].geometry.interpolated, undefined);
+            t.deepEquals(res.features[1].id, 'address.1');
+            t.deepEquals(res.features[1].geometry.interpolated, true);
+            t.end();
+        });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
+})();

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -20,122 +20,69 @@ tape('verifymatch.sortFeature', (t) => {
     t.end();
 });
 
-tape('verifymatch.sortContext (no distance)', (t) => {
+tape('verifymatch.sortContext', (t) => {
     let c;
     const arr = [];
 
-    c = [{ id: 10, properties: {} }];
+    c = [{ id: 11, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1, 'carmen:position': 1 }, geometry: { interpolated: true, omitted: true } }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 10, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1, 'carmen:position': 1 }, geometry: { interpolated: true, omitted: true } }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 9, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1, 'carmen:position': 0 }, geometry: { interpolated: true, omitted: true } }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 8, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1 }, geometry: { interpolated: true, omitted: true } }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 7, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1 }, geometry: { interpolated: true } }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 6, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1 }, geometry: {} }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 5, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 1, 'carmen:addressnumber': [] }, geometry: {} }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 4, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9, 'carmen:address': '26', 'carmen:addresspos': 0 }, geometry: {} }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 3, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 9 }, geometry: {} }];
+    c._relevance = 0.9;
+    c._typeindex = 1;
+    arr.push(c);
+
+    c = [{ id: 2, properties: { 'carmen:relevance': 0.9, 'carmen:scoredist': 10 }, geometry: {} }];
     c._relevance = 0.9;
     arr.push(c);
 
-    c = [{ id: 9, properties: { 'carmen:address': '26' } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 8, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: { omitted: true } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 7, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: {} }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 6, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 1 }, geometry: {} }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 5, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, _geometry: {} }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 4, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 2;
-    arr.push(c);
-
-    c = [{ id: 3, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    c._distance = 20;
-    arr.push(c);
-
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    c._distance = 10;
-    arr.push(c);
-
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2, 'carmen:position': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    c = [{ id: 0, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2, 'carmen:position': 1 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    arr.sort(verifymatch.sortContext);
-    t.deepEqual(arr.map((c) => { return c[0].id; }), [0,1,2,3,4,5,6,7,8,9,10]);
-
-    t.end();
-});
-
-tape('verifymatch.sortContext (with distance)', (t) => {
-    let c;
-    const arr = [];
-
-    c = [{ id: 6 }];
+    c = [{ id: 1, properties: { 'carmen:relevance': 1.0 }, geometry: {} }];
     c._relevance = 0.9;
     arr.push(c);
 
-    c = [{ id: 5, properties: { 'carmen:address': '26' } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 4, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: { omitted: true } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 3, properties: { 'carmen:address': '26', 'carmen:addressnumber': [] }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 2;
-    arr.push(c);
-
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 1 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:addressnumber': [], 'carmen:scoredist': 2 }, geometry: {} }];
-    c._relevance = 1.0;
-    c._typeindex = 1;
-    arr.push(c);
-
-    arr.sort(verifymatch.sortContext);
-    t.deepEqual(arr.map((c) => { return c[0].id; }), [1,2,3,4,5,6]);
-
-    t.end();
-});
-
-tape('verifymatch.sortContext (distance vs addresstype)', (t) => {
-    let c;
-    const arr = [];
-
-    c = [{ id: 3 }];
-    c._relevance = 0.9;
-    arr.push(c);
-
-    c = [{ id: 2, properties: { 'carmen:address': '26', 'carmen:scoredist': 1, 'carmen:addressnumber': [] } }];
-    c._relevance = 1.0;
-    arr.push(c);
-
-    c = [{ id: 1, properties: { 'carmen:address': '26', 'carmen:scoredist': 2 } }];
+    c = [{ id: 0, properties: {}, geometry: {} }];
     c._relevance = 1.0;
     arr.push(c);
 
     arr.sort(verifymatch.sortContext);
-    t.deepEqual(arr.map((c) => { return c[0].id; }), [1,2,3]);
+    t.deepEqual(arr.map((c) => { return c[0].id; }), [0,1,2,3,4,5,6,7,8,9,10,11]);
 
     t.end();
 });


### PR DESCRIPTION
### Context
Ref https://github.com/mapbox/carmen/issues/821

### Summary of Changes
- [x] add a interpolation sort criteria in verifyMatch for address results

### Next Steps
This is a simple change but revealed some other behavior around how we handle interpolation and deduplication I'd like to dig into.

cc @mapbox/search
