### PR TITLE
Fix empty-phrasematch issue

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -247,7 +247,7 @@ module.exports = function phrasematch(source, query, options, callback) {
 
     for (const subquery of subqueries) {
         const phrase = subquery.join(' ');
-        if (!phrase) continue;
+        if (phrase.length === 0) continue;
         // Adjust weight relative to input query.
         const b = findMaskBounds(subquery.mask, MAX_QUERY_TOKENS);
         const weight = (b[1] - b[0] + 1) / query.tokens.length;

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -247,6 +247,7 @@ module.exports = function phrasematch(source, query, options, callback) {
 
     for (const subquery of subqueries) {
         const phrase = subquery.join(' ');
+        if (!phrase) continue;
         // Adjust weight relative to input query.
         const b = findMaskBounds(subquery.mask, MAX_QUERY_TOKENS);
         const weight = (b[1] - b[0] + 1) / query.tokens.length;

--- a/test/acceptance/geocode-unit.emoji.test.js
+++ b/test/acceptance/geocode-unit.emoji.test.js
@@ -7,7 +7,8 @@ const queue = require('d3-queue').queue;
 const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
 const conf = {
-    country: new mem({ maxzoom: 6 }, () => {})
+    country: new mem({ maxzoom: 6 }, () => {}),
+    region: new mem({ maxzoom: 6 }, () => {})
 };
 
 const c = new Carmen(conf);
@@ -40,6 +41,22 @@ tape('index non-emoji country', (t) => {
         }
     }, t.end);
 });
+
+tape('index region', (t) => {
+    queueFeature(conf.region, {
+        id: 3,
+        geometry: {
+            type: 'Point',
+            coordinates: [10,10]
+        },
+        properties: {
+            // Line smiley
+            'carmen:text': 'whatever',
+            'carmen:center': [10,10]
+        }
+    }, t.end);
+});
+
 tape('build queued features', (t) => {
     const q = queue();
     Object.keys(conf).forEach((c) => {
@@ -74,6 +91,16 @@ tape('should handle a query including emoji', (t) => {
     c.geocode(query, {}, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].id, 'country.2', 'finds Anarres');
+        t.end();
+    });
+});
+
+tape('should handle a CJK query including emoji that triggers stacking', (t) => {
+    // Black star
+    const query = 'Anarres 南🗾';
+    c.geocode(query, {}, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 0, 'finds no features');
         t.end();
     });
 });


### PR DESCRIPTION
### Context
A funny interaction occurs between CJK tokenization and emoji removal. It seems that a query that ends in a CJK character followed by an emoji can lead to a set of tokenization/normalization steps that results in a token set in which the final token (where the emoji was originally) is an empty string instead. If instead the query is a Latin-letter word followed by a space followed by an emoji, there's no extra blank token, so apparently something about opting into the alternative tokenization path for CJK makes this happen. (Also: if there are Latin letters immediately next to the emoji, the last token is just those letters, with the emoji removed).

For non-address, indexes, which use windowed search, this presents a problem for autocomplete searches, because the empty string is a prefix for every word, so we're virtually guaranteed to produce a window with a phrase consisting only of the empty string if the empty string is in the final position. If we generate that phrasematch, and also some other phrasematch in a different index elsewhere in the query such that the two can stack and together exceed the 0.5 relevance threshold, we end up creating a stack with one phrasematch with `''` as the phrase.

If *that* happens and we pass it into `coalesce`, it barfs: empty phrases aren't allowed, and we get a `TypeError: encountered invalid phrase` back.

This PR fixes it in a relatively clunky way: just skip generating Phrasematch objects if the phrase is empty, for whatever reason. There might be some reason to instead change the tokenization behavior so that CJK and non-CJK tokenization behavior is consistent, and the former doesn't generate these empty-string tokens in the first place in the presence of emoji, but I think this is probably fine for now -- it solves the immediate problem, anyway.


### Summary of Changes
- [x] modify the emoji test so it allows for stacking and tests a CJK-pattern query
- [x] fix it by adding a check that the phrase being generated is non-empty


### Next Steps
No


cc @mapbox/search
