### PR TITLE
Override invert prop

### DIFF
--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -20,9 +20,13 @@ function properties(feat, idx) {
     for (const prop of Object.keys(feat.properties["carmen:addressprops"])) {
         if (
             feat.properties['carmen:addressprops'][prop]
-            && feat.properties['carmen:addressprops'][prop][idx]
+            && feat.properties['carmen:addressprops'][prop][idx] !== undefined
         ) {
-            feat.properties[prop] = feat.properties['carmen:addressprops'][prop][idx];
+            if (feat.properties['carmen:addressprops'][prop][idx] === null) {
+                delete feat.properties[prop];
+            } else {
+                feat.properties[prop] = feat.properties['carmen:addressprops'][prop][idx];
+            }
         }
     }
 

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -15,12 +15,11 @@ const proximity = require('../util/proximity');
  * @returns Object GeoJSON Feature
  */
 function properties(feat, idx) {
-    for (const prop of Object.keys(feat.properties)) {
-        if (prop.split(':')[0] === 'carmen') continue;
+    if (!feat.properties['carmen:addressprops']) return feat;
 
+    for (const prop of Object.keys(feat.properties["carmen:addressprops"])) {
         if (
-            feat.properties['carmen:addressprops']
-            && feat.properties['carmen:addressprops'][prop]
+            feat.properties['carmen:addressprops'][prop]
             && feat.properties['carmen:addressprops'][prop][idx]
         ) {
             feat.properties[prop] = feat.properties['carmen:addressprops'][prop][idx];

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -17,7 +17,7 @@ const proximity = require('../util/proximity');
 function properties(feat, idx) {
     if (!feat.properties['carmen:addressprops']) return feat;
 
-    for (const prop of Object.keys(feat.properties["carmen:addressprops"])) {
+    for (const prop of Object.keys(feat.properties['carmen:addressprops'])) {
         if (
             feat.properties['carmen:addressprops'][prop]
             && feat.properties['carmen:addressprops'][prop][idx] !== undefined

--- a/test/acceptance/geocode-unit.address-properties.test.js
+++ b/test/acceptance/geocode-unit.address-properties.test.js
@@ -103,6 +103,161 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 })();
 
+(() => {
+    const conf = {
+        address: new mem({ maxzoom: 6, geocoder_address: 1 }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('index alphanum address', (t) => {
+        const address = {
+            id: 1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0, 0],
+                'carmen:addressnumber': ['9B', '10C', '7', '3452'],
+                'carmen:addressprops': {
+                    'accuracy': {
+                        1: 'driveway',
+                        2: 'parcel',
+                        3: 'partial'
+                    }
+                }
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[1,1],[2,2],[3,3]]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+
+    tape('test address index for 9B', (t) => {
+        c.geocode('9B FAKE STREET', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, undefined);
+            t.end();
+        });
+    });
+
+    tape('test address index for 10C', (t) => {
+        c.geocode('10C FAKE STREET', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'driveway');
+            t.end();
+        });
+    });
+
+    tape('test address index for 7', (t) => {
+        c.geocode('7 FAKE STREET', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'parcel');
+            t.end();
+        });
+    });
+
+    tape('test address index for 3452 (partial)', (t) => {
+        c.geocode('34', {
+            proximity: [3, 3]
+        }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'partial');
+            t.end();
+        });
+    });
+
+    tape('test address index for 0,0', (t) => {
+        c.geocode('0,0', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, undefined);
+            t.end();
+        });
+    });
+
+    tape('test address index for 1,1', (t) => {
+        c.geocode('1,1', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'driveway');
+            t.end();
+        });
+    });
+
+    tape('test address index for 2,2', (t) => {
+        c.geocode('2,2', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'parcel');
+            t.end();
+        });
+    });
+
+    tape('test address index for 3,3', (t) => {
+        c.geocode('3,3', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'partial');
+            t.end();
+        });
+    });
+})();
+
+(() => {
+    const conf = {
+        address: new mem({ maxzoom: 6, geocoder_address: 1 }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('index alphanum address', (t) => {
+        const address = {
+            id: 1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0, 0],
+                'carmen:addressnumber': ['9B', '10C'],
+                accuracy: 'driveway',
+                'carmen:addressprops': {
+                    'accuracy': {
+                        1: null
+                    }
+                }
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[1,1]]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+
+    tape('test address index for 9B', (t) => {
+        c.geocode('9B FAKE STREET', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'driveway');
+            t.end();
+        });
+    });
+
+    tape('test address index for 10C', (t) => {
+        c.geocode('10C FAKE STREET', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, undefined);
+            t.end();
+        });
+    });
+
+    tape('test address index for 0,0', (t) => {
+        c.geocode('0,0', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, 'driveway');
+            t.end();
+        });
+    });
+
+    tape('test address index for 1,1', (t) => {
+        c.geocode('1,1', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].properties.accuracy, undefined);
+            t.end();
+        });
+    });
+})();
+
 tape('teardown', (t) => {
     context.getTile.cache.reset();
     t.end();


### PR DESCRIPTION
### Context

Tighten expectations around `null`/`undefined` properties in the address property passthrough code

Full explanation here: https://github.com/ingalls/pt2itp/pull/432#issue-262950290

This code flips the property passthrough code to iterate over `feat.properties.carmen:addressprops` and update the property instead of the current iteration over `feat.properties`

This is necessary as carmen does not allow storage of top level properties with a value of `null` or `undefined`


cc @mapbox/search
