### PR TITLE
russian-style address numbers

### DIFF
--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -280,6 +280,7 @@ function address(token) {
             || /^(\d+)-(\d+)[a-z]?$/.test(token) // 10-19 or 10-19a Style
             || /^(\d+)([nsew])(\d+)[a-z]?$/.test(token) // 6N23 Style (ie Kane County, IL)
             || /^([nesw])(\d+)([nesw]\d+)?$/.test(token) // W350N5337 or N453 Style (ie Waukesha County, WI)
+            || /^\d+(к\d+)?(с\d+)?$/.test(token) // Russian style including korpus (cyrillic к) and stroenie (cyrillic с)
         )
     ) {
         return token;
@@ -581,8 +582,13 @@ function getMinimalIndexableText(simpleReplacer, complexReplacer, globalReplacer
  * @return {null|number} a number or null
  */
 function parseSemiNumber(_) {
-    // checks if things are like 9th, 10th etc
-    _ = parseInt((_ || '').replace(/[^\d]/g,''),10);
+    if (/[ск]/g.test(_)) {
+        // for russian style addresses, only return first \d+
+        _ = parseInt(_);
+    } else {
+        // checks if things are like 9th, 10th etc
+        _ = parseInt((_ || '').replace(/[^\d]/g,''),10);
+    }
     return isNaN(_) ? null : _;
 }
 

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -584,7 +584,7 @@ function getMinimalIndexableText(simpleReplacer, complexReplacer, globalReplacer
 function parseSemiNumber(_) {
     if (/[ск]/g.test(_)) {
         // for russian style addresses, only return first \d+
-        _ = parseInt(_);
+        _ = parseInt(_, 10);
     } else {
         // checks if things are like 9th, 10th etc
         _ = parseInt((_ || '').replace(/[^\d]/g,''),10);

--- a/test/unit/text-processing/termops.numTokenize.test.js
+++ b/test/unit/text-processing/termops.numTokenize.test.js
@@ -22,6 +22,9 @@ test('numTokenize', (t) => {
         withAddress(['500', 'main', 'street', 'apt', '2##', '20009'], { number: '205', position: 4 }),
         withAddress(['500', 'main', 'street', 'apt', '205', '20###'], { number: '20009', position: 5 }),
     ], 'three numbers');
+    t.deepEqual(termops.numTokenize(['697к4'],3), [withAddress(['6##'], { number: '697к4', position: 0 })], 'russian-style address numbers with korpus');
+    t.deepEqual(termops.numTokenize(['697с20'],3), [withAddress(['6##'], { number: '697с20', position: 0 })], 'russian-style address numbers with stroenie');
+    t.deepEqual(termops.numTokenize(['697к4с20'],3), [withAddress(['6##'], { number: '697к4с20', position: 0 })], 'russian-style address numbers with korpus and stroenie');
     t.end();
 });
 


### PR DESCRIPTION
### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->
This PR adds a new acceptable pattern for address numbers in order to support Russian korpus and stroenie numbers.  

| English | Russian | Abbreviations | Description |
|---|---|---|---|
| Corpus | корпус | k, кор, к  | Block number or substructure |
| Stroenie | строение | str, c, стр, с | Building, smaller than a block | 

That format variants that we're going to support are:

| parts | examples |
|---|---|
| number | 12 |
| number, korpus | 12к3 |
| number, stroenie | 12с4 |
| number, korpus, stroenie | 12к3с4 |

We're not going to support unit numbers, and `numTokenize` will remove everything after the first integer.

### Summary of Changes
- [x] add russian style address pattern to acceptable patterns
- [x] adjust `numTokenize` to disregard korpus and stroenie


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/search
