### PR TITLE
Fixes fatal aborts that occur because of Invalid regular expression 

### DIFF
--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -315,16 +315,12 @@ function matchScore(features, cover, source) {
 
 // If score isn't enought to match a cover to a single feature, look at text properties.
 function matchText(features, cover) {
-    let re;
     features = features.filter((feature) => {
         let matches = false;
         for (const key of Object.keys(feature.properties)) {
             if (!feature.properties[key] || !/^carmen:text/.exec(key)) continue;
             feature.properties[key].split(',').forEach((label) => {
-                re = new RegExp(cover.text);
-                if (re.exec(label)) {
-                    matches = true;
-                }
+                if (label.indexOf(cover.text) === 0) matches = true;
             });
             break;
         }

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -320,7 +320,7 @@ function matchText(features, cover) {
         for (const key of Object.keys(feature.properties)) {
             if (!feature.properties[key] || !/^carmen:text/.exec(key)) continue;
             feature.properties[key].split(',').forEach((label) => {
-                if (label.indexOf(cover.text) === 0) matches = true;
+                if (label.indexOf(cover.text) !== -1) matches = true;
             });
             break;
         }

--- a/test/unit/util/feature.putFeatures.test.js
+++ b/test/unit/util/feature.putFeatures.test.js
@@ -95,6 +95,21 @@ tape('putFeatures', (t) => {
                 coordinates: [0, 0]
             }
         },
+        {
+            id: 28889879879028,
+            type: 'Feature',
+            properties: {
+                'carmen:text': 'Street A',
+                'carmen:center': [0, 0],
+                'carmen:intersection': ['Street B'],
+                'carmen:zxy': ['6/32/32'],
+                'carmen:score': 0
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0, 0]
+            }
+        }
     ], (err) => {
         t.ifError(err);
         t.equal(source._shards.feature[1], '{"1":{"id":1,"type":"Feature","properties":{"carmen:text":"a","carmen:center":[0,0],"carmen:zxy":["6/32/32"]},"geometry":{"type":"Point","coordinates":[0,0]}},"1048577":{"id":1048577,"type":"Feature","properties":{"carmen:text":"c","carmen:center":[5.626,0],"carmen:zxy":["6/33/32"]},"geometry":{"type":"Point","coordinates":[5.626,0]}}}', 'has feature shard 1');
@@ -124,10 +139,16 @@ tape('getFeatureByCover, collision', (t) => {
     });
 });
 
+tape('getFeatureByCover, collision', (t) => {
+    feature.getFeatureByCover(conf.source, { id:466292, x:32, y:32, score:2000, text:'+intersection street a , b' }, (err, data) => {
+        t.equal(data.id, 28889879879028);
+        t.end();
+    });
+});
+
 tape('getFeatureById', (t) => {
     feature.getFeatureById(conf.source, 1, (err, data) => {
         t.equal(data.id, 1);
         t.end();
     });
 });
-

--- a/test/unit/util/feature.putFeatures.test.js
+++ b/test/unit/util/feature.putFeatures.test.js
@@ -96,14 +96,14 @@ tape('putFeatures', (t) => {
             }
         },
         {
-            id: 28889879879028,
+            id: 3333333333499326,
             type: 'Feature',
             properties: {
                 'carmen:text': 'Street A',
                 'carmen:center': [0, 0],
                 'carmen:intersection': ['Street B'],
                 'carmen:zxy': ['6/32/32'],
-                'carmen:score': 0
+                'carmen:score': 1000
             },
             geometry: {
                 type: 'Point',
@@ -139,9 +139,9 @@ tape('getFeatureByCover, collision', (t) => {
     });
 });
 
-tape('getFeatureByCover, collision', (t) => {
-    feature.getFeatureByCover(conf.source, { id:466292, x:32, y:32, score:2000, text:'+intersection street a , b' }, (err, data) => {
-        t.equal(data.id, 28889879879028);
+tape('getFeatureByCover, intersection collision', (t) => {
+    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000, text:'+intersection street a , b' }, (err, data) => {
+        t.pass('doesn\'t crash');
         t.end();
     });
 });


### PR DESCRIPTION
### Context
Seeing a few fatal aborts because of "Invalid regular expression". If this function is just for checking the occurrence of a string, we should avoid using regexes. This PR replaces the regex approach with `indexOf`.


### Summary of Changes
- [x] Changes to `feature.js`


### Next Steps
- [x] reviewed
- [ ] merged and deployed after coordinating with @ingalls 


cc @mapbox/search
