### PR TITLE
No matching text categories

### DIFF
--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -195,7 +195,6 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
                         context[k].matching_language = matched.matching_language;
                         if (k === 0) feature.matching_text = matched.matching_text;
                         feature.matching_place_name = getPlaceName(context, formatString, language, languageMode, !!matched, geocoder);
-                        // break;
                     }
                 }
             }
@@ -383,7 +382,6 @@ function getMatchingText(item, geocoder, requestedLanguage) {
     const allPhrases = new Map();
     const original = new Map();
     for (const key of Object.keys(item.properties)) {
-        // If the key isn't carmen:text or something like carmen:text_{language}, skip this key
         if (!item.properties[key] || !/^carmen:text/.exec(key)) continue;
 
         item.properties[key].split(',').forEach((sourceText) => {
@@ -455,6 +453,15 @@ function getMatchingText(item, geocoder, requestedLanguage) {
     const match_key = matches[best] + '/' + best;
     const matching_set = original.has(match_key) ? Array.from(original.get(match_key)) : [];
     const matching_text = matching_set.length ? matching_set[0] : null;
+
+    // Determine if matching_text is from a category match, and if so, don't add matching text
+    // Categories are stored in the carmen:text field, so don't check for category matches if the matching_text was a translation
+    if (best === 'carmen:text') {
+        const index = item.properties['carmen:index'];
+        const indexCategories = geocoder.indexes[index].categories;
+        const categoryMatch = indexCategories ? indexCategories.has(matching_text) : null;
+        if (categoryMatch) return;
+    }
 
     if (!matching_text || matching_text === closestText) {
         // this was all for nothing :(

--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -452,7 +452,7 @@ function getMatchingText(item, geocoder, requestedLanguage) {
     const matching_language = best === 'carmen:text' ? null : best.replace('carmen:text_', '');
     const match_key = matches[best] + '/' + best;
     const matching_set = original.has(match_key) ? Array.from(original.get(match_key)) : [];
-    const matching_text = matching_set.length ? matching_set[0] : null;
+    const matching_text = matching_set.length ? matching_set[0].trim() : null;
 
     // Determine if matching_text is from a category match, and if so, don't add matching text
     // Categories are stored in the carmen:text field, so don't check for category matches if the matching_text was a translation

--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -195,7 +195,7 @@ function toFeature(context, format, languages, languageMode, debug, geocoder, cl
                         context[k].matching_language = matched.matching_language;
                         if (k === 0) feature.matching_text = matched.matching_text;
                         feature.matching_place_name = getPlaceName(context, formatString, language, languageMode, !!matched, geocoder);
-                        break;
+                        // break;
                     }
                 }
             }
@@ -383,6 +383,7 @@ function getMatchingText(item, geocoder, requestedLanguage) {
     const allPhrases = new Map();
     const original = new Map();
     for (const key of Object.keys(item.properties)) {
+        // If the key isn't carmen:text or something like carmen:text_{language}, skip this key
         if (!item.properties[key] || !/^carmen:text/.exec(key)) continue;
 
         item.properties[key].split(',').forEach((sourceText) => {

--- a/test/acceptance/geocode-unit.matching-text.test.js
+++ b/test/acceptance/geocode-unit.matching-text.test.js
@@ -65,7 +65,7 @@ const buildQueued = addFeature.buildQueued;
             properties: {
                 'carmen:center': [0,0],
                 'carmen:zxy': ['14/8192/8192'],
-                'carmen:text': 'Cool Beans,coffee'
+                'carmen:text': 'Cool Beans,CB cafe,coffee'
             },
             id: 1,
             geometry: {
@@ -111,11 +111,12 @@ const buildQueued = addFeature.buildQueued;
             t.end();
         });
     });
-    tape('coffee, Jayhawks', (t) => {
-        c.geocode('coffee, Jayhawks', { limit_verify: 1 }, (err, res) => {
+    tape('CB Cafe, Jayhawks - poi synonym and place synonym', (t) => {
+        c.geocode('CB cafe, Jayhawks', { limit_verify: 1 }, (err, res) => {
             t.ifError(err, 'No errors');
-            t.equal(res.features[0].place_name, 'Cool Beans, Kansas, United States', 'Place name should be the poi name and context');
-            t.equal(res.features[0].matching_place_name, 'coffee, Jayhawks, United States', 'Matching place name should be the poi name and matching context');
+            t.equal(res.features[0].place_name, 'Cool Beans, Kansas, United States', 'Place name should be the primary poi name and primary context name');
+            t.equal(res.features[0].matching_text, 'CB cafe', 'matching_text should be the matching poi synonym.');
+            t.equal(res.features[0].matching_place_name, 'CB cafe, Jayhawks, United States', 'matching_place_name should be the poi name and matching context');
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.matching-text.test.js
+++ b/test/acceptance/geocode-unit.matching-text.test.js
@@ -66,7 +66,7 @@ const buildQueued = addFeature.buildQueued;
             properties: {
                 'carmen:center': [0,0],
                 'carmen:zxy': ['14/8192/8192'],
-                'carmen:text': 'Cool Beans,CB cafe,coffee'
+                'carmen:text': 'Cool Beans,CB cafe, coffee'
             },
             id: 1,
             geometry: {

--- a/test/acceptance/geocode-unit.matching-text.test.js
+++ b/test/acceptance/geocode-unit.matching-text.test.js
@@ -16,7 +16,8 @@ const buildQueued = addFeature.buildQueued;
         poi: new mem({
             maxzoom: 14,
             geocoder_categories: [
-                'coffee'
+                'coffee',
+                'arena'
             ],
         }, () => {})
     };
@@ -73,7 +74,24 @@ const buildQueued = addFeature.buildQueued;
                 coordinates: [0,0]
             }
         };
-        queueFeature(conf.poi, poi, t.end);
+        const poi2 = {
+            type: 'Feature',
+            properties: {
+                'carmen:center': [0,0],
+                'carmen:zxy': ['14/8192/8192'],
+                'carmen:text': 'Sand,restaurant',
+                'carmen:text_es': 'arena'
+            },
+            id: 2,
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        const q = queue();
+        q.defer(queueFeature, conf.poi, poi);
+        q.defer(queueFeature, conf.poi, poi2);
+        q.awaitAll(t.end);
     });
     tape('build queued features', (t) => {
         const q = queue();
@@ -84,39 +102,57 @@ const buildQueued = addFeature.buildQueued;
         });
         q.awaitAll(t.end);
     });
-    tape('kansas america', (t) => {
+    tape('kansas america - region primary name and country synonym', (t) => {
         c.geocode('kansas america', { limit_verify:1 }, (err, res) => {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'Kansas United States');
-            t.equal(res.features[0].matching_text, undefined, 'feature.matching_text');
-            t.equal(res.features[0].matching_place_name, 'Kansas America');
+            t.equal(res.features[0].place_name, 'Kansas United States', 'place_name should be the primary region name and country name');
+            t.equal(res.features[0].matching_text, undefined, 'matching_text should be empty');
+            t.equal(res.features[0].matching_place_name, 'Kansas America', 'matching_place_name should include matching context name');
             t.end();
         });
     });
-    tape('america', (t) => {
+    tape('america - country synonym', (t) => {
         c.geocode('america', { limit_verify:1 }, (err, res) => {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'United States');
-            t.equal(res.features[0].matching_text, 'America');
+            t.equal(res.features[0].place_name, 'United States', 'place_name should be the primary country name');
+            t.equal(res.features[0].matching_text, 'America', 'matching_text should be the country synonym');
             t.equal(res.features[0].matching_place_name, 'America');
             t.end();
         });
     });
-    tape('jayhawks', (t) => {
+    tape('jayhawks - region synonym', (t) => {
         c.geocode('jayhawks', { limit_verify:1 }, (err, res) => {
             t.ifError(err);
-            t.equal(res.features[0].place_name, 'Kansas United States');
-            t.equal(res.features[0].matching_text, 'Jayhawks');
-            t.equal(res.features[0].matching_place_name, 'Jayhawks United States');
+            t.equal(res.features[0].place_name, 'Kansas United States', 'place_name should be the primary region and context name');
+            t.equal(res.features[0].matching_text, 'Jayhawks', 'matching_text should be the region synonym');
+            t.equal(res.features[0].matching_place_name, 'Jayhawks United States', 'matching_place_name should be the matching region synonym and primary context name');
             t.end();
         });
     });
-    tape('CB Cafe, Jayhawks - poi synonym and place synonym', (t) => {
+    tape('CB Cafe, Jayhawks - poi synonym and region synonym', (t) => {
         c.geocode('CB cafe, Jayhawks', { limit_verify: 1 }, (err, res) => {
             t.ifError(err, 'No errors');
             t.equal(res.features[0].place_name, 'Cool Beans, Kansas, United States', 'Place name should be the primary poi name and primary context name');
             t.equal(res.features[0].matching_text, 'CB cafe', 'matching_text should be the matching poi synonym.');
-            t.equal(res.features[0].matching_place_name, 'CB cafe, Jayhawks, United States', 'matching_place_name should be the poi name and matching context');
+            t.equal(res.features[0].matching_place_name, 'CB cafe, Jayhawks, United States', 'matching_place_name should be the matching poi synonym and matching context');
+            t.end();
+        });
+    });
+    tape('coffee, Jayhawks - poi category and region synonym', (t) => {
+        c.geocode('coffee, Jayhawks', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err, 'No errors');
+            t.equal(res.features[0].place_name, 'Cool Beans, Kansas, United States', 'Place name should be the primary poi name and primary context name');
+            t.equal(res.features[0].matching_text, undefined, 'matching_text should be undefined for category matches');
+            t.equal(res.features[0].matching_place_name, 'Cool Beans, Jayhawks, United States', 'matching_place_name should be the primary poi name and matching context');
+            t.end();
+        });
+    });
+    tape('arena, Jayhawks - poi translation that looks like a category and region synonym', (t) => {
+        c.geocode('arena, Jayhawks', { limit_verify: 1 }, (err, res) => {
+            t.ifError(err, 'No errors');
+            t.equal(res.features[0].place_name, 'Sand, Kansas, United States', 'Place name should be the primary poi name and primary context name');
+            t.equal(res.features[0].matching_text, 'arena', 'matching_text should be the matching translation, even if the translation is the same as a category name');
+            t.equal(res.features[0].matching_place_name, 'arena, Jayhawks, United States', 'matching_place_name should be the primary poi name and matching context');
             t.end();
         });
     });


### PR DESCRIPTION
## Context
### No matching text for categories
The `matching_text` and `matching_place_name` properties are intended to surface feature names that most closely match the query, and are often used as the label for a feature in an api consumer's UI. Since categories are not distinguishable from synonyms, a feature that matched replace the primary feature name with the category in `matching_text` and `matching_place_name`, leading to confusing and indistinguishable results. For example a search for `coffee, washington, DC` would return `matching_text` of `coffee` and `matching_place_name` of `coffee, washington DC` for all features in the result set that matched the `coffee` category.

With this PR, if the matching text also matches a category configured on the index, the category will not replace the primary place name of a feature or it's context.

✅ **Cases that are handled:**
- If the matching_text is the same as a category specified in the index that feature is from, don't add matching_text to the feature
- If the matching_text is a translation that happens to match a category specified on the index, do add matching_text to the feature

❌ **Cases that aren't handled:**
- If a synonym of a feature happens to match a category specified on the index, the synonym will not be added to matching_text. This is because it is impossible to distinguish synonyms from categories, since they are both stored in the `carmen:text` property.


### Add to matching_place_name for all features in context with matching text
There was also a bug with matching_place_name, where matching text for the context was not getting added to the matching_place_name if a more specific part of the context, or the feature itself, had matching_text. This was [fixed in `toFeature`](https://github.com/mapbox/carmen/pull/855/commits/e43033a902a2cd38100ffa6941d9c5033c19380c#diff-a6b7f06c105beb5fb302175ee6ca3449L198) by continuing to loop through all of the features in the context even after one matching_text was found.

Issue: #828 

## Summary of Changes
- [x] Fix bug with matching_text for contexts in matching_place_name
- [x] Don't add matching_text to a feature or contexts if it appears to be a category

cc @mapbox/search
