### PR TITLE
Fix matching_text for addresses

### DIFF
--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -402,7 +402,14 @@ function getMatchingText(item, geocoder, requestedLanguage) {
         });
     }
 
-    const query = termops.normalizeQuery(termops.tokenize(item.properties['carmen:query_text'])).tokens.join(' ');
+    const tokenized = termops.normalizeQuery(termops.tokenize(item.properties['carmen:query_text']));
+    let query;
+    if (tokenized.separators.length && tokenized.separators[0].match(/^#/)) {
+        // if the first token is an address number, there will be # signs in its separator, so skip it
+        query = tokenized.tokens.slice(1).join(' ');
+    } else {
+        query = tokenized.tokens.join(' ');
+    }
     const regex = new RegExp('^' + query + (item.properties['carmen:prefix'] ? '' : '$'));
 
     const matches = {};
@@ -410,18 +417,6 @@ function getMatchingText(item, geocoder, requestedLanguage) {
         if (regex.exec(candidate)) {
             for (const phraseKey of allPhrases.get(candidate)) {
                 if (!matches.hasOwnProperty(phraseKey)) matches[phraseKey] = candidate;
-            }
-        }
-    }
-
-    // Fallback Behavior to match addresses ie: 12## Main st
-    if (!Object.keys(matches).length) {
-        const regex = new RegExp('^' + query.replace(/^[0-9]*#+ /, '') + (item.properties['carmen:prefix'] ? '' : '$'));
-        for (const candidate of allPhrases.keys()) {
-            if (regex.exec(candidate)) {
-                for (const phraseKey of allPhrases.get(candidate)) {
-                    if (!matches.hasOwnProperty(phraseKey)) matches[phraseKey] = candidate;
-                }
             }
         }
     }

--- a/test/acceptance/geocode-unit.matching-text.test.js
+++ b/test/acceptance/geocode-unit.matching-text.test.js
@@ -205,6 +205,15 @@ const buildQueued = addFeature.buildQueued;
             t.end();
         });
     });
+    tape('243 Main St East', (t) => {
+        c.geocode('243 Main St East', {}, (err, res) => {
+            t.ifError(err);
+            t.equal(res.features[0].place_name, '243 US Highway 123');
+            t.equal(res.features[0].matching_text, 'Main St East');
+            t.equal(res.features[0].matching_place_name, '243 Main St East');
+            t.end();
+        });
+    });
 })();
 
 tape('teardown', (t) => {


### PR DESCRIPTION
### Context
Our matching text finder currently reruns part of the indexing process to generate all the indexable phrases from a feature to determine which source phrase produced a given query match. To avoid generating very large numbers of phrases for addresses due to address number expansion, it calls getIndexableText on a synthetic feature consisting only of the text field and not the address numbers, so when we *do* match a phrase that contains an address number, we won't generate it in getMatchingText, so we won't match it unless we strip the address number from the query side.

The current code attempts to do this: if on the first pass, we didn't find anything, we try again removing an initial address number from the beginning of the query; we recognize address numbers as zero or more numbers followed by one or more `#` signs. Unfortunately, when #826 landed, we changed our tokenization and normalization logic such that `#` became a word boundary, so our number-stripping silently broke. This PR fixes it.

Also: we actually had a test for this, sort of, but it only looks for a two-digit address number, and two-digit address numbers become *all* `#` signs, and the tokenizers strips them entirely along with their trailing whitespace as a leading separator. So those still work in master, which is why we didn't notice.


### Summary of Changes
- [x] change how we detect numbers: look for a first separator that starts with a pound sign -- the only way pound signs can occur is by having been introduced through the address number process (they'd otherwise get tokenized away) so if we see one, assume the preceding token is the rest of a house number and skip that token for purposes of phrase matching. This also gets rid of the two-pass process where getting rid of the building number is part of a fallback; we now always strip it if it's present, right from the get-go.
- [x] add a three-digit test that actually breaks master, and works here


### Next Steps
None

cc @mapbox/search (@ingalls and @miccolis in particular)
