### PR TITLE
Properly handle ampersand replacement

### DIFF
--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -846,7 +846,7 @@ function intersectionPermutations(tokens, intersectionToken) {
                 // we can assume the mask starts at the first token. We get the
                 // correct bits set by taking two's compliment of one bit past
                 // our desired end.
-                permutation.mask = (1 << tokens.owner[j - 1] + 1) - 1;
+                permutation.mask = (1 << (j)) - 1;
                 // need to do weights?
                 permutation.relev = 0;
                 ret.push(permutation);

--- a/test/unit/geocoder/phrasematch.test.js
+++ b/test/unit/geocoder/phrasematch.test.js
@@ -650,10 +650,11 @@ tape('fuzzyMatchMulti - masks for intersection queries', (t) => {
         fuzzyMatchMulti: (a, b, c, d) => {
             const results = fakeFuzzyMatches(a);
             const expected = [
-                [ { phrase: [ '1st', 'and', 'main', 'st' ], edit_distance: 0, ending_type: 0 } ],
-                [ { phrase: [ '1st', 'and', 'main' ], edit_distance: 0, ending_type: 0 } ],
-                [ { phrase: [ 'st' ], edit_distance: 0, ending_type: 0 } ],
-                [ { phrase: [ '+intersection', '1st', ',', 'main', 'st' ], edit_distance: 0, ending_type: 0 } ]
+                [{ phrase: ['1st', 'and', 'main', 'st'], edit_distance: 0, ending_type: 0 }],
+                [{ phrase: ['1st', 'and', 'main'], edit_distance: 0, ending_type: 0 }],
+                [{ phrase: ['st'], edit_distance: 0, ending_type: 0 }],
+                [{ phrase: ['+intersection', '1st', ',', 'main'], edit_distance: 0, ending_type: 0 }],
+                [{ phrase: ['+intersection', '1st', ',', 'main', 'st'], edit_distance: 0, ending_type: 0 }]
             ];
             t.deepEqual(results, expected);
             return results;
@@ -672,14 +673,15 @@ tape('fuzzyMatchMulti - masks for intersection queries', (t) => {
     const clone = JSON.parse(JSON.stringify(query));
     phrasematch(c, query, {}, (err, results, source) => {
         t.error(err);
-        t.equal(results.phrasematches.length, 7);
+        t.equal(results.phrasematches.length, 8);
         const expected = new Set([
             'st - 4 - 0.3333333333333333',
             'st - 6 - 0.6666666666666666',
             '1st and main - 1 - 0.3333333333333333',
             '1st and main - 3 - 0.6666666666666666',
             '1st and main st - 7 - 1',
-            '+intersection 1st , main st - 1 - 0.3333333333333333',
+            '+intersection 1st , main - 1 - 0.3333333333333333',
+            '+intersection 1st , main - 3 - 0.6666666666666666',
             '+intersection 1st , main st - 7 - 1'
         ]);
         results.phrasematches.forEach((v) => {

--- a/test/unit/text-processing/termops.intersectionPermutation.test.js
+++ b/test/unit/text-processing/termops.intersectionPermutation.test.js
@@ -42,5 +42,18 @@ test('termops.intersectionPermutations', (t) => {
         { phrase: ['+intersection', 'hermann', 'str', ',', 'aller', 'str', 'berlin'], mask: 15, ender: true, relev: 0 },
     ];
     t.deepEqual(bearablePermutations(results), expected);
+
+    // tokens: 'first & main st'
+    results = termops.intersectionPermutations({
+        tokens: ['first', 'and', 'main', 'st'],
+        separators: ['', ' ', ' '],
+        owner: [0, 0, 0, 2]
+    }, 'and');
+    expected = [
+        { phrase: ['+intersection', 'first', ',', 'main'], mask: 1, ender: false, relev: 0 },
+        { phrase: ['+intersection', 'first', ',', 'main', 'st'], mask: 7, ender: true, relev: 0 },
+    ];
+    t.deepEqual(bearablePermutations(results), expected);
+
     t.end();
 });

--- a/test/unit/text-processing/termops.intersectionPermutation.test.js
+++ b/test/unit/text-processing/termops.intersectionPermutation.test.js
@@ -34,24 +34,24 @@ test('termops.intersectionPermutations', (t) => {
     results = termops.intersectionPermutations({
         tokens: ['hermann', 'str', 'und', 'aller', 'str', 'berlin'],
         separators: ['', ' ', ' ', ' ', ' ', ''],
-        owner: [0, 0, 1, 2, 2, 3]
+        // owner: [0, 0, 1, 2, 2, 3]
     }, 'und');
     expected = [
-        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller'], mask: 7, ender: false, relev: 0 },
-        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller', 'str'], mask: 7, ender: false, relev: 0 },
-        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller', 'str', 'berlin'], mask: 15, ender: true, relev: 0 },
+        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller'], mask: 15, ender: false, relev: 0 },
+        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller', 'str'], mask: 31, ender: false, relev: 0 },
+        { phrase: ['+intersection', 'hermann', 'str', ',', 'aller', 'str', 'berlin'], mask: 63, ender: true, relev: 0 },
     ];
     t.deepEqual(bearablePermutations(results), expected);
 
     // tokens: 'first & main st'
     results = termops.intersectionPermutations({
         tokens: ['first', 'and', 'main', 'st'],
-        separators: ['', ' ', ' '],
-        owner: [0, 0, 0, 2]
+        separators: [' ', ' ', ' ', ''],
+        // owner: [0, 0, 0, 2]
     }, 'and');
     expected = [
-        { phrase: ['+intersection', 'first', ',', 'main'], mask: 1, ender: false, relev: 0 },
-        { phrase: ['+intersection', 'first', ',', 'main', 'st'], mask: 7, ender: true, relev: 0 },
+        { phrase: ['+intersection', 'first', ',', 'main'], mask: 7, ender: false, relev: 0 },
+        { phrase: ['+intersection', 'first', ',', 'main', 'st'], mask: 15, ender: true, relev: 0 },
     ];
     t.deepEqual(bearablePermutations(results), expected);
 


### PR DESCRIPTION
### Context

Refs #858 Presently just a sets of test that capture where a `&` -> `and`  works fine and where it's broken.

**Update** I think I've figured out the underlying issue - `intersectionPermutations` was generating a mask that used the `owners` of the tokens, this yielded a final mask that made sense against the actual user input. That seemed great at the time, but the problem is the surrounding code expects a local mask (one that doesn't account for cardinality changing replacements), and translates what it's given it into a final mask. This PR now generates a naive local mask and the surrounding code correctly translates it.

### Next Steps

- [x] Resolve the issue in phasematch that gets us a broken mask & weight.
- [x] Downstream testing.

cc @mapbox/search
