### PR TITLE
Update test to ensure non-string input

### DIFF
--- a/lib/text-processing/closest-lang.js
+++ b/lib/text-processing/closest-lang.js
@@ -319,6 +319,8 @@ function getLanguageCode(str) {
  */
 function getText(language, properties) {
     if (!properties['carmen:text']) throw new Error('Feature has no carmen:text');
+    properties['carmen:text'] = String(properties['carmen:text']);
+
     if (!language) return { text: properties['carmen:text'].split(',')[0].trim() };
     const languageLabel = closestLang.closestLangLabel(language, properties, 'carmen:text_');
     const languageText = languageLabel ? properties['carmen:text_' + languageLabel] : false;

--- a/test/acceptance/geocode-unit.override.test.js
+++ b/test/acceptance/geocode-unit.override.test.js
@@ -79,7 +79,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'carmen:addressprops': {
                     // Addresses that differ from the default postcode
                     // live in the addressprops fields
-                    'override:postcode': { 0: '20002', 1: '20003' }
+                    'override:postcode': { 0: '20002', 1: 20003 }
                     // After the address
                     // parsing section of verifymatch - the correct postcode will be populated
                     // in the `override:<type>` field. Do not access carmenaddressprops directly


### PR DESCRIPTION
### Context

@miccolis identified a query that led to an error for one of our queries.

> TypeError: properties.carmen:text.split is not a function
> carmen/lib/text-processing/closest-lang.js:322:61

This section of the code is responsible for helping pick the correct language (if there are multiple) and formatting the place_name field for output. The error occurred as on of the text fields that was attempting to be processed was a numeric instead of a string.

### Root Cause

The query was for an address level result with an `override:postcode` property. Generally, these properties are expected to be Strings, however there is currently no hard rule against these being numeric. This particular address was introduced via our JOSM=>Hecate Shim API as a result of a manual edit.

Since JOSM does not store or care about type (it assumes `HashMap<String, String>` type values), while hecate supports the full GeoJSON spec, hecate attempts to process each value as a numeric, string, array or JSON value. Since the override value could be encoded as a Numeric, it was chosen over a string.

### Potential Next Actions

None of these are technically required as this has been fixed but may prevent a similar bug in the future

- Add strong type checks as part of the JSON Schema validation in hecate
- Add stronger input checks on the carmen side

cc @mapbox/search
