### PR TITLE
Use new match opts format for coalesce proximity option

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -90,9 +90,9 @@ function spatialmatch(query, phrasematchResults, options, callback) {
                     point: proximity.center2zxy(
                         options.proximity,
                         maxZoom
-                    ).slice(1)
+                    ).slice(1),
+                    radius: stack[stack.length - 1].radius || constants.COALESCE_PROXIMITY_RADIUS
                 };
-                coalesceOpts.proximity.radius = stack[stack.length - 1].radius || constants.COALESCE_PROXIMITY_RADIUS;
             }
 
             if (partialNumber && options.proximity) {

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -86,11 +86,13 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         coalesceOpts.zoom = maxZoom;
         if (options) {
             if (options.proximity) {
-                coalesceOpts.centerzxy = proximity.center2zxy(
-                    options.proximity,
-                    maxZoom
-                ).slice(1);
-                coalesceOpts.radius = stack[stack.length - 1].radius || constants.COALESCE_PROXIMITY_RADIUS;
+                coalesceOpts.proximity = {
+                    point: proximity.center2zxy(
+                        options.proximity,
+                        maxZoom
+                    ).slice(1)
+                };
+                coalesceOpts.proximity.radius = stack[stack.length - 1].radius || constants.COALESCE_PROXIMITY_RADIUS;
             }
 
             if (partialNumber && options.proximity) {

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -78,7 +78,7 @@ function center2zxy(center, z) {
     ];
 
     const px = merc.px(center, z);
-    return [z, px[0] / tileSize, px[1] / tileSize];
+    return [z, Math.round(px[0] / tileSize), Math.round(px[1] / tileSize)];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#39cdd300a756974f2a35c42599a0a26c7a38227d",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#3a224532abefd1d67a0d07e6e45a8a84153b6422",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#ed3160689c6df60f78105eb4f38da348a4f4dea6",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#57dc89930936dcf2a6817af629f4005d8c176741",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#57dc89930936dcf2a6817af629f4005d8c176741",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#39cdd300a756974f2a35c42599a0a26c7a38227d",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/acceptance/geocode-unit.proximity-cutoff.test.js
+++ b/test/acceptance/geocode-unit.proximity-cutoff.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const addFeature = require('../../lib/indexer/addfeature');
+const queueFeature = addFeature.queueFeature;
+const buildQueued = addFeature.buildQueued;
+
+const conf = {
+    place: new mem({ maxzoom: 12, maxscore: 1670000 }, () => {})
+};
+const c = new Carmen(conf);
+
+
+tape('index places', (t) => {
+    const docs = [];
+
+    for (let i = 1980; i < 2080; i++) {
+        docs.push({
+            id: i,
+            type: 'Feature',
+            properties: {
+                'carmen:text':'san francisco',
+                'carmen:score': 4,
+                'carmen:zxy':[`12/${i}/${i}`],
+                'carmen:center':[0, 0]
+            }
+        });
+    }
+
+    // Add the closest feature to the proximity point but with a lower score,
+    // so it will only make the cutoff is proximity is correctly set
+    docs.push({
+        id: 2080,
+        type: 'Feature',
+        properties: {
+            'carmen:text':'san francisco',
+            'carmen:score': 3,
+            'carmen:zxy':['12/2080/2080'],
+            'carmen:center':[0, 0]
+        }
+    });
+    queueFeature(conf.place, docs, () => { buildQueued(conf.place, t.end); });
+});
+
+tape('query', (t) => {
+    c.geocode('san', { debug: true, proximity: [3, -3] }, (err, res) => {
+        t.equal(res.features[0].id, 'place.2080', 'The closest feature makes it past coalesce cutoffs and is the first result');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});
+
+
+

--- a/test/unit/util/proximity.test.js
+++ b/test/unit/util/proximity.test.js
@@ -6,7 +6,7 @@ const test = require('tape');
 
 test('proximity.center2zxy', (t) => {
     t.deepEqual(proximity.center2zxy([0,0],5), [5,16,16]);
-    t.deepEqual(proximity.center2zxy([-90,45],5), [5,8,11.51171875]);
+    t.deepEqual(proximity.center2zxy([-90,45],5), [5,8,12]);
     t.deepEqual(proximity.center2zxy([-181,90.1],5), [5,0,0], 'respects world extents');
     t.deepEqual(proximity.center2zxy([181,-90.1],5), [5,32,32], 'respects world extents');
     t.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,9 +797,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#39cdd300a756974f2a35c42599a0a26c7a38227d":
-  version "0.1.0-prox-radius-dedupe-3"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/39cdd300a756974f2a35c42599a0a26c7a38227d"
+"@mapbox/carmen-core@github:mapbox/carmen-core#3a224532abefd1d67a0d07e6e45a8a84153b6422":
+  version "0.1.0-prox-radius-dedupe-4"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/3a224532abefd1d67a0d07e6e45a8a84153b6422"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,9 +797,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#57dc89930936dcf2a6817af629f4005d8c176741":
-  version "0.1.0-prox-radius-dedupe-1"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/57dc89930936dcf2a6817af629f4005d8c176741"
+"@mapbox/carmen-core@github:mapbox/carmen-core#39cdd300a756974f2a35c42599a0a26c7a38227d":
+  version "0.1.0-prox-radius-dedupe-3"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/39cdd300a756974f2a35c42599a0a26c7a38227d"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,9 +797,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#ed3160689c6df60f78105eb4f38da348a4f4dea6":
-  version "0.1.0-dev"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/ed3160689c6df60f78105eb4f38da348a4f4dea6"
+"@mapbox/carmen-core@github:mapbox/carmen-core#57dc89930936dcf2a6817af629f4005d8c176741":
+  version "0.1.0-prox-radius-dedupe-1"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/57dc89930936dcf2a6817af629f4005d8c176741"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This updates the format of the proximity option that the carmen-core version of coalesce requires.


### Summary of Changes
- [x] Updates the format of the proximity option passed to carmen-core
- [x] Updates `center2zxy` to return rounded tile coordinates because fractions of tile coordinates don't make sense, and coalesce expects u16-compatible numbers
- [x] Updates the carmen-core dependency to a version that has real deduping by feature id in coalesce, and that fixes the comparison of distance to proximity radius for applying the language penalty https://github.com/mapbox/carmen-core/pull/43
- [x] Add test that will fail if the proximity option isn't set correctly


### Next Steps
- [x] Fix test failures that are visible now that proximity is actually being passed to coalesce


cc @mapbox/search
