### PR TITLE
Don't aggressively dedupe numerical autocomplete or short address query results

### DIFF
--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -288,7 +288,7 @@ function toFeatures(geocoder, contexts, options) {
 
             // Dedupe by place name, prefer feature with non-omitted, non-interpolated geom
             const keys = [feature.place_name];
-            if (context[0].properties['carmen:spatialmatch'] !== undefined && context[0].properties['carmen:address'] !== undefined) {
+            if (context[0].properties['carmen:spatialmatch'] !== undefined && context[0].properties['carmen:address'] !== undefined && !isShortAddressQuery(context)) {
                 keys.push(uniqueAddressId(geocoder, types, context));
             }
 
@@ -361,6 +361,39 @@ function uniqueAddressId(geocoder, types, context) {
     return '_' + Array.from(coverText.values()).join(':');
 }
 
+/**
+ * Tests if text that matched a query is a numerical autocomplete or other short address autocomplete.
+ *
+ * This is used to determine when to skip generating a dedupe key based on the spatialmatch text + context,
+ * to avoid overly deduping results that could have similar matching text but actually be different.
+ *
+ * Examples that will return true:
+ * - 100 ma
+ * - 100 m
+ * - 1## ma
+ * - 1## m
+ * - 1# 11
+ * - 1 11
+ * - #
+ * - 1
+ *
+ * Examples that will return false:
+ * - 100 main st
+ * - 1## main
+ * - 1# 11t
+ * - 1# 111
+ * - 1# 111th
+ *
+ * @param {Array<object>} context - context array
+ * @returns {boolean}
+ */
+function isShortAddressQuery(context) {
+    // Match digits or #s, space, and up to 2 non-whitespace characters
+    const shortAddressPattern = /^[\d#]+\s*\S{0,2}$/;
+    const firstCover = context[0].properties['carmen:spatialmatch'].covers[0];
+
+    return shortAddressPattern.test(firstCover.text);
+}
 
 /**
  * Attempt to locate text that closely matches the user's query

--- a/test/unit/geocoder/format-features.test.js
+++ b/test/unit/geocoder/format-features.test.js
@@ -675,3 +675,70 @@ test('toFeatures - Consider full context with format and dedupe', (t) => {
     t.equal(results.features[0].place_name, 'Main Street');
     t.end();
 });
+
+
+test('toFeatures - Dont consider full context and spatialmatch text for short address queries', (t) => {
+    const fakeAddressIndex = { simple_replacer: [], complex_query_replacer: [], geocoder_format: {}, type: 'address' };
+    const fakePlaceIndex = { simple_replacer: [], complex_query_replacer: [], geocoder_format: {}, type: 'place' };
+    const fakeCarmen = {
+        indexes: { address: fakeAddressIndex, place: fakePlaceIndex },
+        byidx: { 1: fakeAddressIndex, 2: fakePlaceIndex }
+    };
+    const results = format.toFeatures(fakeCarmen, [
+        [
+            {
+                properties: {
+                    'carmen:index': 'address',
+                    'carmen:idx': 1,
+                    'carmen:address': '100',
+                    'carmen:spatialmatch': { covers: [
+                        { text: '1## ma' }
+                    ] },
+                    'carmen:text': 'Main Street',
+                    'carmen:types': ['address'],
+                    'carmen:center': [0, 0],
+                    'carmen:extid': 'address.1'
+                },
+                geometry: {}
+            },
+            {
+                properties: {
+                    'carmen:index': 'place',
+                    'carmen:idx': 2,
+                    'carmen:text': 'Springfield',
+                    'carmen:types': ['place'],
+                    'carmen:center': [0, 0],
+                    'carmen:extid': 'place.3'
+                }
+            }
+        ], [
+            {
+                properties: {
+                    'carmen:index': 'address',
+                    'carmen:idx': 1,
+                    'carmen:address': '100',
+                    'carmen:spatialmatch': { covers: [
+                        { text: '1## ma' }
+                    ] },
+                    'carmen:text': 'Market st',
+                    'carmen:types': ['address'],
+                    'carmen:center': [0, 0],
+                    'carmen:extid': 'address.2'
+                },
+                geometry: {}
+            },
+            {
+                properties: {
+                    'carmen:index': 'place',
+                    'carmen:idx': 2,
+                    'carmen:text': 'Springfield',
+                    'carmen:types': ['place'],
+                    'carmen:center': [0, 0],
+                    'carmen:extid': 'place.3'
+                }
+            }
+        ]
+    ], {});
+    t.equal(results.features.length, 2, 'Short address queries with the same spatialmatch text should not be deduped');
+    t.end();
+});


### PR DESCRIPTION
### Context
In #846, logic was added to dedupe results based on the text that a query matched in spatialmatch, combined with the geo context. This deduping logic is over-aggressive for address autocomplete queries that are very short, such as numerical-autocomplete or queries that have an address number + ~2 characters. It's possible for there to be several distinct features that match those queries that are in the same postcode, place and region.

This adds some logic to skip that extra deduping step if the address queries are particularly short.

### Summary of Changes
- [x] Adds isShortAddressQuery util to skip deduping if the query is a short address query


### Next Steps
- [x] Add some tests to confirm this behavior


cc @mapbox/search
