### PR TITLE
Rebalance tweak

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -502,14 +502,18 @@ function rebalance(query, stack) {
     }
 
     const garbage = (query.length === (stackMask.toString(2).split(1).length - 1)) ? 0 : 1;
-    const weightPerMatch = 1 / (garbage + stack.length);
+    const totalLengthBonus = .01 * (garbage + stack.length);
+    const weightPerMatch = (1 / (garbage + stack.length)) - 0.01;
 
     // shallow copy stack into stackClone to prevent cases where a stack's
     // index gets overwritten in deep copies.
     let totalWeight = 0;
     for (let k = 0; k < stack.length; k++) {
         stackClone[k] = stack[k].clone();
-        stackClone[k].weight = weightPerMatch * stack[k].editMultiplier;
+        stackClone[k].weight = (
+            weightPerMatch +
+            (totalLengthBonus * stack[k].weight)
+        ) * stack[k].editMultiplier;
         totalWeight += stackClone[k].weight;
     }
 

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -4,6 +4,7 @@ const queue = require('d3-queue').queue;
 const coalesce = require('@mapbox/carmen-cache').coalesce;
 const bbox = require('../util/bbox.js');
 const cheapRuler = require('cheap-ruler');
+const roundTo = require('../util/round-to.js');
 const termops = require('../text-processing/termops');
 const constants = require('../constants');
 const PREFIX_SCAN = require('@mapbox/carmen-cache').PREFIX_SCAN;
@@ -510,14 +511,14 @@ function rebalance(query, stack) {
     let totalWeight = 0;
     for (let k = 0; k < stack.length; k++) {
         stackClone[k] = stack[k].clone();
-        stackClone[k].weight = (
+        stackClone[k].weight = roundTo((
             weightPerMatch +
             (totalLengthBonus * stack[k].weight)
-        ) * stack[k].editMultiplier;
+        ) * stack[k].editMultiplier, 8);
         totalWeight += stackClone[k].weight;
     }
 
-    stackClone.relev = totalWeight;
+    stackClone.relev = Math.min(roundTo(totalWeight, 8), 1);
 
     return stackClone;
 }

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -8,6 +8,7 @@ const proximity = require('../util/proximity');
 const termops = require('../text-processing/termops');
 const closestLang = require('../text-processing/closest-lang');
 const bbox = require('../util/bbox');
+const roundTo = require('../util/round-to.js');
 const filter = require('./filter-sources');
 const routablePoints = require('./routablepoint');
 const MAX_QUERY_TOKENS = require('../constants').MAX_QUERY_TOKENS;
@@ -443,7 +444,8 @@ function verifyContexts(contexts, sets, indexes, options, geocoder) {
 
         const strictRelev = verifyContext(context, peers, verify, {}, indexes, options, geocoder);
         const looseRelev = verifyContext(context, peers, verify, sets, indexes, options, geocoder);
-        context._relevance = Math.max(strictRelev, looseRelev);
+        // round the relevance to six places to handle any accumulated rounding error
+        context._relevance = roundTo(Math.max(strictRelev, looseRelev), 6);
     }
     contexts.sort(sortContext);
     return contexts;

--- a/lib/util/round-to.js
+++ b/lib/util/round-to.js
@@ -1,5 +1,12 @@
 'use strict';
 
+/**
+ * roundTo - round a number to the specified number of places.
+ *
+ * @param {Number} num the number to round
+ * @param {Number} places the number of places
+ * @return {Number} the rounded number
+ */
 module.exports = (num, places) => {
     const mult = Math.pow(10, places);
     return Math.round(num * mult) / mult;

--- a/lib/util/round-to.js
+++ b/lib/util/round-to.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = (num, places) => {
+    const mult = Math.pow(10, places);
+    return Math.round(num * mult) / mult;
+};

--- a/test/acceptance/geocode-unit.address-alphanumeric.test.js
+++ b/test/acceptance/geocode-unit.address-alphanumeric.test.js
@@ -90,25 +90,25 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('70 WASHINGTON STREET 502', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with 502');
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.505);
         });
 
         c.geocode('70 WASHINGTON STREET #502', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with #502');
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.505);
         });
 
         c.geocode('70 WASHINGTON STREET # 502', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with # 502');
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.505);
         });
 
         c.geocode('70 WASHINGTON STREET UNIT 502', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '70 WASHINGTON STREET', 'Found 70 WASHINGTON STREET with UNIT 502');
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.502);
 
             t.end();
         });

--- a/test/acceptance/geocode-unit.address-format.test.js
+++ b/test/acceptance/geocode-unit.address-format.test.js
@@ -382,7 +382,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
     tape('test address index for relev', (t) => {
         c.geocode('9 fake street', { limit_verify: 1 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.503333);
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.address-preferred-order.test.js
+++ b/test/acceptance/geocode-unit.address-preferred-order.test.js
@@ -75,7 +75,7 @@ tape('full address first-preferred (541 + #522)', (t) => {
         t.equal(res.features.length, 1);
         t.equal(res.features[0].id, 'address.12345', 'found correct feature');
         t.equal(res.features[0].address, '541', 'selected first-position housenumber');
-        t.equal(res.features[0].relevance, 0.5, 'penalty from coverage');
+        t.equal(res.features[0].relevance, 0.506, 'penalty from coverage');
         t.end();
     });
 });
@@ -86,7 +86,7 @@ tape('full address first-preferred (522 + #541)', (t) => {
         t.equal(res.features.length, 1);
         t.equal(res.features[0].id, 'address.12345', 'found correct feature');
         t.equal(res.features[0].address, '522', 'selected first-position housenumber');
-        t.equal(res.features[0].relevance, 0.5, 'penalty from coverage');
+        t.equal(res.features[0].relevance, 0.506, 'penalty from coverage');
         t.end();
     });
 });
@@ -119,7 +119,7 @@ tape('full address last-preferred (541 + #522)', (t) => {
         t.equal(res.features.length, 1);
         t.equal(res.features[0].id, 'address.12345', 'found correct feature');
         t.equal(res.features[0].address, '541', 'selected last-position housenumber');
-        t.equal(res.features[0].relevance, 0.5, 'penalty from coverage');
+        t.equal(res.features[0].relevance, 0.506, 'penalty from coverage');
         t.end();
     });
 });
@@ -130,7 +130,7 @@ tape('full address last-preferred (522 + #541)', (t) => {
         t.equal(res.features.length, 1);
         t.equal(res.features[0].id, 'address.12345', 'found correct feature');
         t.equal(res.features[0].address, '522', 'selected last-position housenumber');
-        t.equal(res.features[0].relevance, 0.5, 'penalty from coverage');
+        t.equal(res.features[0].relevance, 0.506, 'penalty from coverage');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.backy.test.js
+++ b/test/acceptance/geocode-unit.backy.test.js
@@ -81,7 +81,7 @@ tape('lessingstrasse 50825 koln', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'lessingstrasse, koln, 50825');
         t.deepEqual(res.features[0].id, 'street.1');
-        t.deepEqual(res.features[0].relevance, 0.8333333333333333);
+        t.deepEqual(res.features[0].relevance, 0.833333);
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.fuzzy.test.js
+++ b/test/acceptance/geocode-unit.fuzzy.test.js
@@ -213,6 +213,7 @@ tape('100 main st washington dc - without fuzzy', (t) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, '100 Main St, Washington, DC', '100 Main St');
         t.deepEqual(res.features[0].id, 'address.100');
+        console.log(res.features[0].relevance);
         t.assert(res.features[0].relevance === 1, 'relevance = 1');
         t.assert(res.features.length === 1, '1 feature returned');
         t.end();

--- a/test/acceptance/geocode-unit.jp-order.test.js
+++ b/test/acceptance/geocode-unit.jp-order.test.js
@@ -99,7 +99,7 @@ tape('Check order, 632 中黒 Japan 岩出市', (t) => {
     c.geocode('632 中黒 Japan 岩出市', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].address, '632', 'Gets correct address');
-        t.equal(res.features[0].relevance, 0.8233333333333333, 'Mixed-up order lowers relevance');
+        t.equal(res.features[0].relevance, 0.82619, 'Mixed-up order lowers relevance');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.order.test.js
+++ b/test/acceptance/geocode-unit.order.test.js
@@ -116,7 +116,7 @@ tape('Log Cabin Ln North Carolina Winston-Salem', (t) => {
     c.geocode('Log Cabin Ln North Carolina Winston-Salem', { limit_verify: 2 }, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].text, 'Log Cabin Ln', 'ok when query order is mixed up');
-        t.equal(res.features[0].relevance, 0.8333333333333333, 'Mixed-up order lowers relevance');
+        t.equal(res.features[0].relevance, 0.834048, 'Mixed-up order lowers relevance');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.override.test.js
+++ b/test/acceptance/geocode-unit.override.test.js
@@ -160,7 +160,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('10C FAKE STREET 20003', { limit_verify: 2 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '10c fake street Parker 20003', 'found 10c fake street');
-            t.equals(res.features[0].relevance, 0.55);
+            t.equals(res.features[0].relevance, 0.555);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20003' }
@@ -173,7 +173,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('9B FAKE STREET 20002', { limit_verify: 10 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street Parker 20002', 'found 9b fake street 20002');
-            t.equals(res.features[0].relevance, 0.55);
+            t.equals(res.features[0].relevance, 0.555);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20002' }
@@ -186,7 +186,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('9B FAKE STREET 20001', { limit_verify: 10 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street Parker 20002', 'found 9b fake street 20002 w/ 20001 query');
-            t.equals(res.features[0].relevance, 0.50);
+            t.equals(res.features[0].relevance, 0.505);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20002' }
@@ -199,7 +199,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('9B FAKE STREET PARKER 20002', { limit_verify: 10 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street Parker 20002', 'found 9b fake street parker 20002');
-            t.equals(res.features[0].relevance, 2 / 3);
+            t.equals(res.features[0].relevance, 0.670667);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20002' }
@@ -212,7 +212,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('9B FAKE STREET PARKER 20001', { limit_verify: 10 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street Parker 20002', 'found 9b fake street parker 20002 w/ 20001 query');
-            t.equals(res.features[0].relevance, 2 / 3);
+            t.equals(res.features[0].relevance, 0.670667);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20002' }

--- a/test/acceptance/geocode-unit.promote-language.test.js
+++ b/test/acceptance/geocode-unit.promote-language.test.js
@@ -104,7 +104,7 @@ tape('find new york', (t) => {
 tape('find nueva york, language=es', (t) => {
     c.geocode('nueva york usa', { language: 'es' }, (err, res) => {
         t.equal(res.features[0].id, 'place.1');
-        t.equal(res.features[0].relevance, 0.98, "query has penalty applied because 'usa' has no es translation");
+        t.equal(res.features[0].relevance, 0.980133, "query has penalty applied because 'usa' has no es translation");
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.rebalance.test.js
+++ b/test/acceptance/geocode-unit.rebalance.test.js
@@ -91,7 +91,7 @@ tape('build queued features', (t) => {
 tape('Check relevance scoring', (t) => {
     c.geocode('11027 main st georgia 80138', { limit_verify: 10 }, (err, res) => {
         t.ifError(err);
-        t.equal(res.features.length, 2, 'got both results back')
+        t.equal(res.features.length, 2, 'got both results back');
         t.equal(res.features[0].id, 'address.1', 'address beats postcode even with lower score');
         t.equal(res.features[1].id, 'postcode.1', 'address beats postcode even with lower score');
         t.assert(res.features[0].relevance > res.features[1].relevance, 'address has a higher relevance than postcode');

--- a/test/acceptance/geocode-unit.rebalance.test.js
+++ b/test/acceptance/geocode-unit.rebalance.test.js
@@ -1,0 +1,105 @@
+'use strict';
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+const conf = {
+    region: new mem(null, () => {}),
+    postcode: new mem(null, () => {}),
+    address: new mem({
+        maxzoom: 6,
+        geocoder_address: 1,
+    }, () => {})
+};
+const c = new Carmen(conf);
+
+// the region contains both the postcode and the address, below, but the address
+// isn't in the postcode
+
+tape('index region', (t) => {
+    const region = {
+        id:1,
+        properties: {
+            'carmen:center': [0,0],
+            'carmen:score': 50,
+            'carmen:text':'georgia'
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,20],
+                [20,20],
+                [20,-20],
+                [-20,-20],
+            ]]
+        }
+    };
+    queueFeature(conf.region, region, t.end);
+});
+
+tape('index postcode', (t) => {
+    const postcode = {
+        id:1,
+        properties: {
+            'carmen:text':'80138',
+            'carmen:center': [0,0],
+            'carmen:score': 50
+        },
+        geometry: {
+            type: 'Polygon',
+            coordinates: [[
+                [-20,-20],
+                [-20,0],
+                [0,0],
+                [0,-20],
+                [-20,-20],
+            ]]
+        }
+    };
+    queueFeature(conf.postcode, postcode, t.end);
+});
+
+tape('index address', (t) => {
+    const address = {
+        id:1,
+        properties: {
+            'carmen:text':'Main St',
+            'carmen:center':[10,10],
+            'carmen:addressnumber': ['11027']
+        },
+        geometry: {
+            type: 'MultiPoint',
+            coordinates: [[10,10]]
+        }
+    };
+    queueFeature(conf.address, address, t.end);
+});
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('Check relevance scoring', (t) => {
+    c.geocode('11027 main st georgia 80138', { limit_verify: 10 }, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 2, 'got both results back')
+        t.equal(res.features[0].id, 'address.1', 'address beats postcode even with lower score');
+        t.equal(res.features[1].id, 'postcode.1', 'address beats postcode even with lower score');
+        t.assert(res.features[0].relevance > res.features[1].relevance, 'address has a higher relevance than postcode');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});

--- a/test/acceptance/geocode-unit.relevance.test.js
+++ b/test/acceptance/geocode-unit.relevance.test.js
@@ -97,7 +97,7 @@ tape('build queued features', (t) => {
 tape('Check relevance scoring', (t) => {
     c.geocode('11027 S. Pikes Peak Drive #201', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
-        t.equal(res.features[0].relevance, 0.50, 'Apt. number lowers relevance');
+        t.equal(res.features[0].relevance, 0.506667, 'Apt. number lowers relevance');
     });
     c.geocode('11027 S. Pikes Peak Drive', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);

--- a/test/unit/geocoder/spatialmatch.rebalance.test.js
+++ b/test/unit/geocoder/spatialmatch.rebalance.test.js
@@ -16,10 +16,10 @@ test('rebalance, no garbage', (t) => {
 
     const rebalanced = rebalance(query, stack);
     t.equal(rebalanced.relev, 1, 'relev = 1');
-    t.equal(rebalanced[0].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalanced[1].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalanced[2].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalanced[3].weight, 0.25, 'weight = 0.25');
+    t.equal(rebalanced[0].weight, 0.26, 'weight = 0.25');
+    t.equal(rebalanced[1].weight, 0.24666667, 'weight = 0.25');
+    t.equal(rebalanced[2].weight, 0.24666667, 'weight = 0.25');
+    t.equal(rebalanced[3].weight, 0.24666667, 'weight = 0.25');
     t.end();
 });
 
@@ -35,10 +35,10 @@ test('rebalance, with garbage', (t) => {
     stack.relev = 0.8333333333333333;
 
     const rebalanced = rebalance(query, stack);
-    t.equal(rebalanced.relev, 0.75, 'relev = 0.75');
-    t.equal(rebalanced[0].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalanced[1].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalanced[2].weight, 0.25, 'weight = 0.25');
+    t.equal(rebalanced.relev, 0.75333334, 'relev = 0.75');
+    t.equal(rebalanced[0].weight, 0.26, 'weight = 0.25');
+    t.equal(rebalanced[1].weight, 0.24666667, 'weight = 0.25');
+    t.equal(rebalanced[2].weight, 0.24666667, 'weight = 0.25');
     t.end();
 });
 
@@ -63,10 +63,10 @@ test('rebalance copies', (t) => {
     // Assert that the subqueries in rebalancedA are not affected by
     // the rebalance done to rebalancedB.
     t.equal(rebalancedA.relev, 1, 'relev = 1');
-    t.equal(rebalancedA[0].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalancedA[1].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalancedA[2].weight, 0.25, 'weight = 0.25');
-    t.equal(rebalancedA[3].weight, 0.25, 'weight = 0.25');
+    t.equal(rebalancedA[0].weight, 0.26, 'weight = 0.25');
+    t.equal(rebalancedA[1].weight, 0.24666667, 'weight = 0.25');
+    t.equal(rebalancedA[2].weight, 0.24666667, 'weight = 0.25');
+    t.equal(rebalancedA[3].weight, 0.24666667, 'weight = 0.25');
 
     // Vice versa.
     t.equal(rebalancedB.relev, 0.50, 'relev = 0.50');

--- a/test/unit/util/round-to.js
+++ b/test/unit/util/round-to.js
@@ -1,0 +1,14 @@
+'use strict';
+const roundTo = require('../../../lib/util/round-to.js');
+const test = require('tape');
+
+test('roundTo', (t) => {
+    t.equals(roundTo(1.1234, 0), 1);
+    t.equals(roundTo(1.1234, 1), 1.1);
+    t.equals(roundTo(1.1234, 2), 1.12);
+    t.equals(roundTo(1.1234, 3), 1.123);
+    t.equals(roundTo(1.1234, 4), 1.1234);
+    t.equals(roundTo(1.1234, 5), 1.1234);
+
+    t.end();
+});


### PR DESCRIPTION
### Context
Our current rebalancing strategy (introduced by #448) assigns equal weight to all matching components, regardless of the number of words in each component, where before components where assigned weights based on the number of words they contained as a fraction of the total number of words in the query.

After having this in production for awhile, we now want to tweak this a little. For the "Martin Luther King Blvd, Seattle, Washington" example from #448, we still want Seattle, Washington to win -- if we can't actually align the feature with the city and state, we want the city and state together to win, because there are more components there. But for examples where there are actual ties (the same number of components in each possible result), #448 results in us instead disambiguating by score, and we now think we should use number of words as a (very minor) hint. So, two components should always beat one component, but if it's one component to one component, length wins.

To do this, this branch keeps component weights approximately equal, but very slightly nudges longer ones over shorter ones.


### Summary of Changes
- [x] change the rebalancing algorithm slightly

### Next Steps
- [x] update all the hard-coded relevances in tests
- [x] (maybe) change the formula for the tweaking to generate nicer numbers -- it seems that the approach so far sometimes introduces undesirable rounding errors
- [x] add an explicit test of an address beating a postcode by token code rather than the postcode winning by score


cc @mapbox/search
