### PR TITLE
Use Levenshtein distance for coarse resolution of ID collisions

### DIFF
--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -1,6 +1,7 @@
 'use strict';
 const queue = require('d3-queue').queue;
 const termops = require('../text-processing/termops');
+const leven = require('leven');
 
 module.exports = {};
 module.exports.normalize = normalize;
@@ -315,16 +316,27 @@ function matchScore(features, cover, source) {
 
 // If score isn't enought to match a cover to a single feature, look at text properties.
 function matchText(features, cover) {
-    features = features.filter((feature) => {
-        let matches = false;
+    const featuresWithRatio = [];
+    for (const feature of features) {
+        let bestRatio = 0;
         for (const key of Object.keys(feature.properties)) {
             if (!feature.properties[key] || !/^carmen:text/.exec(key)) continue;
             feature.properties[key].split(',').forEach((label) => {
-                if (label.indexOf(cover.text) !== -1) matches = true;
+                label = label.trim().toLowerCase();
+                const dist = leven(cover.text, label);
+                const lenSum = cover.text.length + label.length;
+                const ratio = dist === 0 ? 1 : ((lenSum - dist) / lenSum);
+                if (ratio > bestRatio) bestRatio = ratio;
             });
-            break;
         }
-        return matches;
-    });
-    return features;
+        // make it be a pretty good match
+        if (bestRatio >= 0.75) {
+            featuresWithRatio.push({
+                ratio: bestRatio,
+                feature: feature
+            });
+        }
+    }
+    featuresWithRatio.sort((a, b) => b.ratio - a.ratio);
+    return featuresWithRatio.map((f) => f.feature);
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fs-extra": "^7.0.0",
     "geojson-rewind": "^0.3.1",
     "iter-tools": "^6.1.6",
+    "leven": "^3.1.0",
     "mapnik": "^4.0.2",
     "minimist": "1.2.0",
     "model-un": "0.0.3",

--- a/test/unit/util/feature.putFeatures.test.js
+++ b/test/unit/util/feature.putFeatures.test.js
@@ -139,6 +139,13 @@ tape('getFeatureByCover, collision', (t) => {
     });
 });
 
+tape('getFeatureByCover, text collision', (t) => {
+    feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000, text:'street a' }, (err, data) => {
+        t.equal(data.id, 3333333333499326);
+        t.end();
+    });
+});
+
 tape('getFeatureByCover, intersection collision', (t) => {
     feature.getFeatureByCover(conf.source, { id:187838, x:32, y:32, score:2000, text:'+intersection street a , b' }, (err, data) => {
         t.pass('doesn\'t crash');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3896,6 +3896,11 @@ lead@^1.0.0:
   dependencies:
     flush-write-stream "^1.0.2"
 
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"


### PR DESCRIPTION
### Context
#845 touched the `matchText` function in `lib/util/feature.js`, which tries to resolve ID collisions in fetch results from the feature table. That function was crashing, and we made it not crash, but it still didn't work; see #847 for more info. The plan was to fix this behavior with a series of changes in carmen-core and its equivalent carmen branch that would make ID collisions both less likely and easier to disambiguate, but that work has stalled due to unrelated carmen-core performance concerns.

This branch is a band-aid in the meantime. As noted in #847, the previous code almost never worked because it was broken with respect to case (input data was usually mixed case but equality tests were against lowercase cover text), and also didn't handle things like token replacement or other phrase normalization correctly. This branch fixes the case issue, and also uses Levenshtein distance rather than exact text to decide which feature to pick, comparing the cover text with the case-normalized phrase text.

Because we don't have much information to go on here (as compared to in carmen-core), we're conservative: we'll only consider matches with a Levenshtein ratio (`(lensum - ldist) / lensum`) of at least .75. This means the strings will still have to be pretty similar to match: aggressive token replacements on short strings still probably won't work, intersections probably won't work, and address numbers combined with short street names might not work either. Still, in no circumstance are the results worse than they are now, and in many cases they're better. Carmen-core, if/when that ships, will be more reliable.



### Summary of Changes
- [x] tweak the `matchText` function to be less broken


### Next Steps
Nope


cc @mapbox/search
