### PR TITLE
Drop frequent words while indexing

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ function Geocoder(indexes, options) {
             source.geocoder_intersection_token = info.geocoder_intersection_token || '';
             source.geocoder_coalesce_radius = info.geocoder_coalesce_radius;
 
+            source.geocoder_frequent_word_list = info.geocoder_frequent_word_list;
             source.categorized_replacement_words = token.categorizeTokenReplacements(info.geocoder_tokens);
             source.simple_replacer = token.createSimpleReplacer(source.categorized_replacement_words.simple);
             source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex);

--- a/index.js
+++ b/index.js
@@ -195,7 +195,13 @@ function Geocoder(indexes, options) {
             source.geocoder_intersection_token = info.geocoder_intersection_token || '';
             source.geocoder_coalesce_radius = info.geocoder_coalesce_radius;
 
-            source.geocoder_frequent_word_list = info.geocoder_frequent_word_list;
+            source.geocoder_frequent_word_list = false;
+            if (info.geocoder_frequent_word_list) {
+                source.geocoder_frequent_word_list = new Set();
+                for (const word of info.geocoder_frequent_word_list) {
+                    source.geocoder_frequent_word_list.add(word.toLowerCase());
+                }
+            }
             source.categorized_replacement_words = token.categorizeTokenReplacements(info.geocoder_tokens);
             source.simple_replacer = token.createSimpleReplacer(source.categorized_replacement_words.simple);
             source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex);

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -397,7 +397,7 @@ function loadDoc(freq, patch, doc, source, zoom, simple_replacer, complex_replac
     const allPhrases = new Map();
 
     for (let x = 0; x < texts.length; x++) {
-        const phrases = termops.getIndexablePhrases(texts[x], freq);
+        const phrases = termops.getIndexablePhrases(texts[x], freq, source.geocoder_frequent_word_list);
 
         for (let y = 0; y < phrases.length; y++) {
             const phrase = phrases[y].phrase;

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -716,9 +716,9 @@ function getIndexablePhrases(text, freq, frequentWords) {
     for (let i = 0; i < perms.length; i++) {
         // Indexing optimization.
         const relev = perms[i].relev;
-        const text = perms[i].join(' ');
-
         if (relev < 0.8) break;
+
+        const text = perms[i].join(' ');
         const etext = normalizeText(text);
 
         // Encode canonical phrase.

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -759,7 +759,6 @@ function getWeights(tokens, freq, frequentWords) {
     let weightsum = 0;
     const weights = [];
     const totalfreq = freq['__COUNT__'][0] || 1;
-    const regex = frequentWords ?  new RegExp(frequentWords.join('|').toLowerCase()) : false;
     let numTokens = false;
 
     // Determine weights of all terms relative to one another.
@@ -768,14 +767,15 @@ function getWeights(tokens, freq, frequentWords) {
         if (/#/.test(tokens[i])) {
             numTokens = true;
             weights[i] = -1;
-        } else if (regex) {
-            termWeight = regex.test(tokens[i]) ? 0.2 : 1;
-            weights[i] = Math.log(1 + termWeight);
-            weightsum += weights[i];
         } else {
             const term = tokens[i];
             termfreq = freq[term] ? freq[term][0] : 1;
-            weights[i] = Math.log(1 + totalfreq / termfreq);
+            if (frequentWords) {
+                termWeight = frequentWords.has(tokens[i]) ? 0.2 : 1;
+                weights[i] = Math.log(1 + termWeight);
+            } else {
+                weights[i] = Math.log(1 + totalfreq / termfreq);
+            }
             weightsum += weights[i];
         }
     }

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -697,7 +697,7 @@ function addressPermutations(permutations) {
 * @param {freq} freq - TODO
 * @return {Array<Object>} List of phrase objects { relev, text, phrase }
 */
-function getIndexablePhrases(text, freq) {
+function getIndexablePhrases(text, freq, frequentWords) {
     const uniq = {};
     const phrases = [];
     let obj = {};
@@ -709,16 +709,25 @@ function getIndexablePhrases(text, freq) {
             phrase: etext
         }];
     }
-    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true);
 
+    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true);
     perms.sort(sortByRelev);
 
     for (let i = 0; i < perms.length; i++) {
         // Indexing optimization.
-        const relev = perms[i].relev;
-        if (relev < 0.8) break;
-
+        let relev = perms[i].relev;
         const text = perms[i].join(' ');
+        if (frequentWords) {
+            const regex  = new RegExp(frequentWords.join('|').toLowerCase(), 'g');
+            const found = text.match(regex);
+            if (found) {
+                if (found.length === 1 && text.split(' ').length > 1) {
+                    relev = 0.8;
+                }
+            }
+        }
+
+        if (relev < 0.8) continue;
         const etext = normalizeText(text);
 
         // Encode canonical phrase.

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -607,12 +607,13 @@ function parseSemiNumber(_) {
  *        - mask: {number}
  *        - relev: {number}
  */
-function permutations(terms, weights, all) {
+function permutations(terms, weights, all, frequentWords) {
     const length = terms.length;
     const masks = all && length <= 8 ? permute.all(length) : permute.continuous(length);
 
     const permutations = [];
     for (let i = 0; i < masks.length; i++) {
+        let wordDropped = false;
         const mask = masks[i];
         const permutation = [];
 
@@ -624,7 +625,12 @@ function permutations(terms, weights, all) {
 
         let relev = 0;
         for (let j = 0; j < length; j++) {
-            if (!(mask & (1 << j))) continue;
+            if (!(mask & (1 << j))) {
+                if (frequentWords && frequentWords.has(terms[j])) {
+                    wordDropped = true;
+                }
+                continue;
+            }
             permutation.push(terms[j]);
             if (terms.address && j === terms.address.position) {
                 permutation.address = {
@@ -636,7 +642,7 @@ function permutations(terms, weights, all) {
             if (weights) relev += (weights[j] || 0);
         }
         if (weights) {
-            permutation.relev = Math.round(relev * 5) / 5;
+            permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(0.8, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
         }
 
         // If it's a trailing numToken swap it to the front.
@@ -710,7 +716,7 @@ function getIndexablePhrases(text, freq, frequentWords) {
         }];
     }
 
-    const perms = permutations(text.tokens, getWeights(text.tokens, freq, frequentWords), true);
+    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true, frequentWords);
     perms.sort(sortByRelev);
 
     for (let i = 0; i < perms.length; i++) {
@@ -752,10 +758,9 @@ function sortByRelev(a, b) {
  * @param {Object} freq - frequencies of terms in the index
  * @return {Array<number>} array of weights
  */
-function getWeights(tokens, freq, frequentWords) {
+function getWeights(tokens, freq) {
     let i = 0;
     let termfreq = 0;
-    let termWeight = 0;
     let weightsum = 0;
     const weights = [];
     const totalfreq = freq['__COUNT__'][0] || 1;
@@ -770,12 +775,7 @@ function getWeights(tokens, freq, frequentWords) {
         } else {
             const term = tokens[i];
             termfreq = freq[term] ? freq[term][0] : 1;
-            if (frequentWords) {
-                termWeight = frequentWords.has(tokens[i]) ? 0.2 : 1;
-                weights[i] = Math.log(1 + termWeight);
-            } else {
-                weights[i] = Math.log(1 + totalfreq / termfreq);
-            }
+            weights[i] = Math.log(1 + totalfreq / termfreq);
             weightsum += weights[i];
         }
     }

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -607,7 +607,7 @@ function parseSemiNumber(_) {
  *        - mask: {number}
  *        - relev: {number}
  */
-function permutations(terms, weights, all) {
+function permutations(terms, weights, all, frequentWords) {
     const length = terms.length;
     const masks = all && length <= 8 ? permute.all(length) : permute.continuous(length);
 
@@ -638,6 +638,18 @@ function permutations(terms, weights, all) {
         if (weights) {
             permutation.relev = Math.round(relev * 5) / 5;
         }
+
+        if (frequentWords) {
+            const regex  = new RegExp(frequentWords.join('|').toLowerCase(), 'g');
+            const text = permutation.join(' ');
+            const found = text.match(regex);
+            if (found) {
+                if (found.length === 1 && permutation.length > 1) {
+                    permutation.relev = 0.8;
+                }
+            }
+        }
+
 
         // If it's a trailing numToken swap it to the front.
         // This is an optimization letting us index only the
@@ -710,24 +722,15 @@ function getIndexablePhrases(text, freq, frequentWords) {
         }];
     }
 
-    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true);
+    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true, frequentWords);
     perms.sort(sortByRelev);
 
     for (let i = 0; i < perms.length; i++) {
         // Indexing optimization.
         let relev = perms[i].relev;
         const text = perms[i].join(' ');
-        if (frequentWords) {
-            const regex  = new RegExp(frequentWords.join('|').toLowerCase(), 'g');
-            const found = text.match(regex);
-            if (found) {
-                if (found.length === 1 && text.split(' ').length > 1) {
-                    relev = 0.8;
-                }
-            }
-        }
 
-        if (relev < 0.8) continue;
+        if (relev < 0.8) break;
         const etext = normalizeText(text);
 
         // Encode canonical phrase.

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -727,7 +727,7 @@ function getIndexablePhrases(text, freq, frequentWords) {
 
     for (let i = 0; i < perms.length; i++) {
         // Indexing optimization.
-        let relev = perms[i].relev;
+        const relev = perms[i].relev;
         const text = perms[i].join(' ');
 
         if (relev < 0.8) break;

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -607,7 +607,7 @@ function parseSemiNumber(_) {
  *        - mask: {number}
  *        - relev: {number}
  */
-function permutations(terms, weights, all, frequentWords) {
+function permutations(terms, weights, all) {
     const length = terms.length;
     const masks = all && length <= 8 ? permute.all(length) : permute.continuous(length);
 
@@ -638,18 +638,6 @@ function permutations(terms, weights, all, frequentWords) {
         if (weights) {
             permutation.relev = Math.round(relev * 5) / 5;
         }
-
-        if (frequentWords) {
-            const regex  = new RegExp(frequentWords.join('|').toLowerCase(), 'g');
-            const text = permutation.join(' ');
-            const found = text.match(regex);
-            if (found) {
-                if (found.length === 1 && permutation.length > 1) {
-                    permutation.relev = 0.8;
-                }
-            }
-        }
-
 
         // If it's a trailing numToken swap it to the front.
         // This is an optimization letting us index only the
@@ -722,7 +710,7 @@ function getIndexablePhrases(text, freq, frequentWords) {
         }];
     }
 
-    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true, frequentWords);
+    const perms = permutations(text.tokens, getWeights(text.tokens, freq, frequentWords), true);
     perms.sort(sortByRelev);
 
     for (let i = 0; i < perms.length; i++) {
@@ -764,12 +752,14 @@ function sortByRelev(a, b) {
  * @param {Object} freq - frequencies of terms in the index
  * @return {Array<number>} array of weights
  */
-function getWeights(tokens, freq) {
+function getWeights(tokens, freq, frequentWords) {
     let i = 0;
     let termfreq = 0;
+    let termWeight = 0;
     let weightsum = 0;
     const weights = [];
     const totalfreq = freq['__COUNT__'][0] || 1;
+    const regex = frequentWords ?  new RegExp(frequentWords.join('|').toLowerCase()) : false;
     let numTokens = false;
 
     // Determine weights of all terms relative to one another.
@@ -778,6 +768,10 @@ function getWeights(tokens, freq) {
         if (/#/.test(tokens[i])) {
             numTokens = true;
             weights[i] = -1;
+        } else if (regex) {
+            termWeight = regex.test(tokens[i]) ? 0.2 : 1;
+            weights[i] = Math.log(1 + termWeight);
+            weightsum += weights[i];
         } else {
             const term = tokens[i];
             termfreq = freq[term] ? freq[term][0] : 1;
@@ -785,6 +779,7 @@ function getWeights(tokens, freq) {
             weightsum += weights[i];
         }
     }
+
     // When numTokens are present, numTokens are a constant 0.2 weight.
     // Adjust other weights to fit within a 0-0.8 range.
     i = weights.length;

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -412,7 +412,9 @@ module.exports.replaceGlobalTokens = function(replacers, text) {
  * @return {string} simplified string
  */
 function simplify(s) {
-    return removeDiacritics(s.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
+    if (typeof s === 'object') {
+        return removeDiacritics(s.text.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
+    } else return removeDiacritics(s.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
 }
 
 /**

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -412,9 +412,7 @@ module.exports.replaceGlobalTokens = function(replacers, text) {
  * @return {string} simplified string
  */
 function simplify(s) {
-    if (typeof s === 'object') {
-        return removeDiacritics(s.text.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
-    } else return removeDiacritics(s.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
+    return removeDiacritics(s.toLowerCase().replace(/[\u2018\u2019\u02BC\u02BB\uFF07'\.\^]/g, ''));
 }
 
 /**

--- a/test/acceptance/geocode-unit.tokens.test.js
+++ b/test/acceptance/geocode-unit.tokens.test.js
@@ -518,24 +518,62 @@ tape('teardown', (t) => {
         };
         queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
     });
-    tape('test frequency word list - capitol street', (t) => {
+    tape('north capitol street; frequentWords = [Street, North]', (t) => {
         c.geocode('capitol street', {}, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance, 0.8, 'capitol street indexed with lower relevance');
+            t.equals(res.features[0].relevance, 0.8, 'capitol street indexed with lower relevance (0.8)');
             t.end();
         });
     });
-    tape('test frequency word list - north capitol street', (t) => {
+    tape('north capitol street; frequentWords = [Street, North]', (t) => {
         c.geocode('north capitol street', {}, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].relevance, 1, 'north capitol street indexed with relevance of 1');
             t.end();
         });
     });
-    tape('test frequency word list - north street', (t) => {
+    tape('north capitol street; frequentWords = [Street, North]', (t) => {
         c.geocode('north street', {}, (err, res) => {
             t.ifError(err);
-            t.equals(res.features.length, 0, 'reduce relevance for features that have more than 1 frequent word');
+            t.equals(res.features.length, 0, 'north street not indexed');
+            t.end();
+        });
+    });
+})();
+
+(() => {
+    const conf = {
+        address: new mem({
+            maxzoom: 6,
+            geocoder_frequent_word_list: ['North']
+        }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('index address', (t) => {
+        const address = {
+            id:1,
+            properties: {
+                'carmen:text':'North Capitol Street',
+                'carmen:center':[0,0],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+    tape('north capitol street; frequentWords = [North]', (t) => {
+        c.geocode('capitol street', {}, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 0.8, 'capitol street indexed with reduced relevance (0.8)');
+            t.end();
+        });
+    });
+    tape('north capitol street; frequentWords = [North]', (t) => {
+        c.geocode('north capitol street', {}, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 1, 'north capitol street indexed with relevance of 1');
             t.end();
         });
     });

--- a/test/unit/text-processing/termops.getIndexablePhrases.test.js
+++ b/test/unit/text-processing/termops.getIndexablePhrases.test.js
@@ -26,7 +26,7 @@ test('termops.getIndexablePhrases', (t) => {
 
 test('termops.getIndexablePhrases - frequentWords', (t) => {
     const tokens = ['main', 'st', 'nw'];
-    const frequentWords = ['st', 'nw'];
+    const frequentWords = new Set(['st', 'nw']);
     const freq = {};
     freq['__COUNT__'] = [10];
 

--- a/test/unit/text-processing/termops.getIndexablePhrases.test.js
+++ b/test/unit/text-processing/termops.getIndexablePhrases.test.js
@@ -21,10 +21,35 @@ test('termops.getIndexablePhrases', (t) => {
             'phrase': 'main'
         }
     ]);
-
     t.end();
 });
 
+test('termops.getIndexablePhrases - frequentWords', (t) => {
+    const tokens = ['main', 'st', 'nw'];
+    const frequentWords = ['st', 'nw'];
+    const freq = {};
+    freq['__COUNT__'] = [10];
+
+    t.deepEqual(termops.getIndexablePhrases({ tokens } , freq, frequentWords), [
+        {
+            'relev': 1,
+            'text': 'main st nw',
+            'phrase': 'main st nw',
+        },
+        {
+            'relev': 0.8,
+            'text': 'main st',
+            'phrase': 'main st'
+        },
+        {
+            'relev': 0.8,
+            'text': 'main nw',
+            'phrase': 'main nw'
+        }
+    ]);
+
+    t.end();
+});
 
 test('termops.getIndexablePhrases (weight sieve)', (t) => {
     const tokens = ['jose', 'de', 'la', 'casa'];


### PR DESCRIPTION
### Context
From a recent address triage sprint we found out that 7% of the failures was because of `missing_input` which meant that the user didn't add information like the cardinal direction such as `NW`, `SW` or they left out the ordinal such as `3` instead of `3rd` or they didn't add the way type such as `street` or `Avenue`. 

Currently the way we identify and drop frequent words like the `way type` or the `cardinal directions` is by using a version of the [tf-idf](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) logic. Given that we only index a few 1000 documents at a time, this method is not always great for identifying common words.

In the new indexing strategy the idea is that we're going to provide carmen with a list of frequent words which we will use while indexing. The idea is to use the list of frequent words, dropping them while indexing and bumping the relevance. For example:

Consider the following feature: 
```
const address = {
            id:1,
            properties: {
                'carmen:text':'North Capitol Street',
                'carmen:center':[0,0],
            },
            geometry: {
                type: 'Point',
                coordinates: [0,0]
            }
        };
```
_North and Street here are cardinals and way types respectively_ 

If we index this feature without `North` or `Street` and bump the relevance of the phrases `North Capitol` and `Capitol Street` to `0.8` while indexing - we should be able to surface the feature even if the user does not type `North` or `Street`.


### Summary of Changes
- [x] Changes index.js to take add frequent word list on the source 
- [x] Changes to getIndexablePhrases to index words without frequent words from the list
- [x] tests


### Next Steps
- [x] Review 
- [ ] merge 


cc @mapbox/search
