### PR TITLE
Stop early

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -60,14 +60,15 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen, startPos } = featureOpts;
 
         let spatialmatchesChunk = [];
+        let stopEarly = false;
         const backfill = [];
+        let batchPartialNumberCount = 0;
         // Limit initial feature check.
         if (spatialmatches.length > batchSize) {
             // Set the partialNumber limit to be up to 80% of the total stack limit,
             // depending on how many partial number results there already are
             const partialNumberLimit = (0.8 * options.verifymatch_stack_limit) - partialNumberCount;
 
-            let batchPartialNumberCount = 0;
             for (let i = 0; i < spatialmatches.length; i++) {
                 // Skip covers if their source isn't allowed by types & stacks filters.
                 if (options.types || options.stacks) {
@@ -77,13 +78,19 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                     if (!source) console.error(new Error('Misuse: source undefined for idx ' + firstCover.idx));
                     if (!source || !filter.sourceAllowed(source, options)) continue;
                 }
+
+                if (verified.length && spatialmatches[i].relev < verified[0].properties['carmen:spatialmatch'].relev) {
+                    stopEarly = true;
+                    break;
+                }
+
                 // Enforce partialnumber limit
                 if (spatialmatches[i].partialNumber) {
-                    batchPartialNumberCount++;
                     if (batchPartialNumberCount > partialNumberLimit) {
                         backfill.push(spatialmatches[i]);
                         continue;
                     }
+                    batchPartialNumberCount++;
                     spatialmatchesChunk.push(spatialmatches[i]);
                 }
                 else {
@@ -108,7 +115,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
             verified.push(...verifiedChunk);
             // Base cases
-            if (backfill.length === 0 ||
+            if (stopEarly ||
+                backfill.length === 0 ||
                 verified.length >= options.verifymatch_stack_limit ||
                 matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT
             ) {
@@ -121,7 +129,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 verified: verified,
                 spatialmatches: backfill,
                 batchSize: options.verifymatch_stack_limit - verified.length,
-                partialNumberCount : 0, // TODO: handle this
+                partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -128,7 +128,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             const verifyFeatureOpts = {
                 verified: verified,
                 spatialmatches: backfill,
-                batchSize: options.verifymatch_stack_limit - verified.length,
+                batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
+                    VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
                 partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -113,7 +113,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
-            verified.push(...verifiedChunk.verified);
+            verified.push(...verifiedChunk);
             // Base cases
             if (stopEarly ||
                 backfill.length === 0 ||
@@ -130,7 +130,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 spatialmatches: backfill,
                 batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
                     VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
-                partialNumberCount : partialNumberCount + verifiedChunk.partialNumberCount,
+                partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };
@@ -170,10 +170,10 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
  * @param {Object} geocoder - a geocoder datasource
  * @param {Array} spatialmatches - a chunk of spatialmatches
  * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
- * @returns {{verified: Array, partialNumberCount: number}} result - An object with an array of verified features and the partialNumberCount
+ * @returns {Array} verified - An array of verified features
  */
 function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
-    let result = {};
+    let verified;
 
     // Limit each feature based on whether it is allowed by types & stacks filters.
     if (options.types || options.stacks || options.languageMode === 'strict') {
@@ -187,12 +187,13 @@ function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPo
                 filteredLoaded.push(loaded[i]);
             }
         });
-        result = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
+        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
     // No filters specified, go straight to verify
     } else {
-        result = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
+        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
     }
-    return result;
+
+    return verified;
 }
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
@@ -241,13 +242,10 @@ function countGoodContexts(batch) {
 * @param {Object} loaded - features that are loaded from the carmen index
 * @param {Object} options - passed through the geocode function in geocode.js
 * @param {Number} startPos - the index of the first feature from the original spatialmatches array
-* @returns {{verified: Array, partialNumberCount: number}} result - object with sorted and verified features, and partial number count
+* @returns {Array} filtered - sorted and verified features
 */
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos) {
-    const result = {
-        verified: [],
-        partialNumberCount: 0
-    };
+    const result = [];
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
@@ -370,6 +368,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             });
         }
 
+        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -391,13 +390,13 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             feat.properties['carmen:relev'] = cover.relev;
             feat.properties['carmen:geocoder_address_order'] = source.geocoder_address_order;
             feat.properties['carmen:zoom'] = cover.zoom;
-            result.verified.push(feat);
+            result.push(feat);
         }
     }
 
     // Set a score + distance combined heuristic.
-    for (let k = 0; k < result.verified.length; k++) {
-        const feat = result.verified[k];
+    for (let k = 0; k < result.length; k++) {
+        const feat = result[k];
         if (options.proximity) {
             feat.properties['carmen:scoredist'] = proximity.scoredist(
                 feat.properties['carmen:score'],
@@ -420,25 +419,23 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
 
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
-    result.verified.sort(sortFeature);
+    result.sort(sortFeature);
 
     // Eliminate any score < 0 results if there are better-scored results
     // with identical text.
     const filtered = [];
     const byText = {};
-    for (let i = 0; i < result.verified.length; i++) {
-        const feat = result.verified[i];
+    for (let i = 0; i < result.length; i++) {
+        const feat = result[i];
         const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
         const text = languageText || feat.properties['carmen:text'];
         if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
             filtered.push(feat);
             byText[text] = true;
-            if (feat.properties['carmen:spatialmatch'].partialNumber) result.partialNumberCount++;
         }
     }
     // TODO: or maybe this is where partialnumbercount needs to be calculated
-    result.verified = filtered;
-    return result;
+    return filtered;
 }
 
 /**

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -113,7 +113,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
-            verified.push(...verifiedChunk);
+            verified.push(...verifiedChunk.verified);
             // Base cases
             if (stopEarly ||
                 backfill.length === 0 ||
@@ -130,7 +130,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 spatialmatches: backfill,
                 batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
                     VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
-                partialNumberCount : 0, // TODO
+                partialNumberCount : partialNumberCount + verifiedChunk.partialNumberCount,
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };
@@ -170,10 +170,10 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
  * @param {Object} geocoder - a geocoder datasource
  * @param {Array} spatialmatches - a chunk of spatialmatches
  * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
- * @returns {Array} verified - An array of verified features
+ * @returns {{verified: Array, partialNumberCount: number}} result - An object with an array of verified features and the partialNumberCount
  */
 function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
-    let verified;
+    let result = {};
 
     // Limit each feature based on whether it is allowed by types & stacks filters.
     if (options.types || options.stacks || options.languageMode === 'strict') {
@@ -187,13 +187,12 @@ function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPo
                 filteredLoaded.push(loaded[i]);
             }
         });
-        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
+        result = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
     // No filters specified, go straight to verify
     } else {
-        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
+        result = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
     }
-
-    return verified;
+    return result;
 }
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
@@ -242,10 +241,13 @@ function countGoodContexts(batch) {
 * @param {Object} loaded - features that are loaded from the carmen index
 * @param {Object} options - passed through the geocode function in geocode.js
 * @param {Number} startPos - the index of the first feature from the original spatialmatches array
-* @returns {Array} filtered - sorted and verified features
+* @returns {{verified: Array, partialNumberCount: number}} result - object with sorted and verified features, and partial number count
 */
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos) {
-    const result = [];
+    const result = {
+        verified: [],
+        partialNumberCount: 0
+    };
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
@@ -368,7 +370,6 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             });
         }
 
-        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -390,13 +391,13 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             feat.properties['carmen:relev'] = cover.relev;
             feat.properties['carmen:geocoder_address_order'] = source.geocoder_address_order;
             feat.properties['carmen:zoom'] = cover.zoom;
-            result.push(feat);
+            result.verified.push(feat);
         }
     }
 
     // Set a score + distance combined heuristic.
-    for (let k = 0; k < result.length; k++) {
-        const feat = result[k];
+    for (let k = 0; k < result.verified.length; k++) {
+        const feat = result.verified[k];
         if (options.proximity) {
             feat.properties['carmen:scoredist'] = proximity.scoredist(
                 feat.properties['carmen:score'],
@@ -419,23 +420,25 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
 
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
-    result.sort(sortFeature);
+    result.verified.sort(sortFeature);
 
     // Eliminate any score < 0 results if there are better-scored results
     // with identical text.
     const filtered = [];
     const byText = {};
-    for (let i = 0; i < result.length; i++) {
-        const feat = result[i];
+    for (let i = 0; i < result.verified.length; i++) {
+        const feat = result.verified[i];
         const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
         const text = languageText || feat.properties['carmen:text'];
         if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
             filtered.push(feat);
             byText[text] = true;
+            if (feat.properties['carmen:spatialmatch'].partialNumber) result.partialNumberCount++;
         }
     }
     // TODO: or maybe this is where partialnumbercount needs to be calculated
-    return filtered;
+    result.verified = filtered;
+    return result;
 }
 
 /**

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -106,7 +106,7 @@ tape('verifymatch.verifyFeatures', (t) => {
         ]
     };
     doc.properties['carmen:types'] = ['address'];
-    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {});
+    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {}).verified;
     t.ok(filtered.length <= 10, 'limit dupe address numbers to 10');
     t.end();
 

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -106,7 +106,7 @@ tape('verifymatch.verifyFeatures', (t) => {
         ]
     };
     doc.properties['carmen:types'] = ['address'];
-    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {}).verified;
+    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {});
     t.ok(filtered.length <= 10, 'limit dupe address numbers to 10');
     t.end();
 


### PR DESCRIPTION
### Context
This PR applies a heuristic that if there are some results in the verified features that have higher spatialmatch relevance than the list of additional spatialmatch candidates, it is not worth it to load more features.

There was an attempt to keep track of the true partialNumberCount, but this resulted in repeatedly looping through the spatialmatch candidates after the first batch or two, only to load one more feature each time. As a result, the effective partialNumberLimit only applies to the first chunk of features loaded.


### Summary of Changes
- [x] Stop the feature backfill process if the spatiamatch relevance is lower than any of th verified features' spatialmatch relevance


cc @mapbox/search
