### PR TITLE
Feature backfill

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,7 +18,7 @@ module.exports = {
     // after stackable, the stackable limit should be higehr to leave some
     // headroom as this step does not include type filtering.
     STACKABLE_LIMIT: 100,
-    SPATIALMATCH_STACK_LIMIT: 30,
+    SPATIALMATCH_STACK_LIMIT: 40,
     MAX_CORRECTION_LENGTH: 8,
     VERIFYMATCH_STACK_LIMIT: 20, // The number of good stacks to load features for
     VERIFYMATCH_MAX_FEATURES_LIMIT: 50, // The max number of features to load to get to the verifymatch_stack_limit

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@ module.exports = {
     STACKABLE_LIMIT: 100,
     SPATIALMATCH_STACK_LIMIT: 30,
     MAX_CORRECTION_LENGTH: 8,
-    VERIFYMATCH_STACK_LIMIT: 50,
-    MAX_CONTEXTS_LIMIT: 20
+    VERIFYMATCH_STACK_LIMIT: 20, // The number of good stacks to load features for
+    VERIFYMATCH_MAX_FEATURES_LIMIT: 50, // The max number of features to load to get to the verifymatch_stack_limit
+    MAX_CONTEXTS_LIMIT: 20 // The max number of contexts to load to get to 10 good ones
 };

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -60,14 +60,15 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen, startPos } = featureOpts;
 
         let spatialmatchesChunk = [];
+        let stopEarly = false;
         const backfill = [];
+        let batchPartialNumberCount = 0;
         // Limit initial feature check.
         if (spatialmatches.length > batchSize) {
             // Set the partialNumber limit to be up to 80% of the total stack limit,
             // depending on how many partial number results there already are
             const partialNumberLimit = (0.8 * options.verifymatch_stack_limit) - partialNumberCount;
 
-            let batchPartialNumberCount = 0;
             for (let i = 0; i < spatialmatches.length; i++) {
                 // Skip covers if their source isn't allowed by types & stacks filters.
                 if (options.types || options.stacks) {
@@ -77,13 +78,19 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                     if (!source) console.error(new Error('Misuse: source undefined for idx ' + firstCover.idx));
                     if (!source || !filter.sourceAllowed(source, options)) continue;
                 }
+
+                if (verified.length && spatialmatches[i].relev < verified[0].properties['carmen:spatialmatch'].relev) {
+                    stopEarly = true;
+                    break;
+                }
+
                 // Enforce partialnumber limit
                 if (spatialmatches[i].partialNumber) {
-                    batchPartialNumberCount++;
                     if (batchPartialNumberCount > partialNumberLimit) {
                         backfill.push(spatialmatches[i]);
                         continue;
                     }
+                    batchPartialNumberCount++;
                     spatialmatchesChunk.push(spatialmatches[i]);
                 }
                 else {
@@ -108,7 +115,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
             verified.push(...verifiedChunk);
             // Base cases
-            if (backfill.length === 0 ||
+            if (stopEarly ||
+                backfill.length === 0 ||
                 verified.length >= options.verifymatch_stack_limit ||
                 matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT
             ) {
@@ -121,7 +129,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 verified: verified,
                 spatialmatches: backfill,
                 batchSize: options.verifymatch_stack_limit - verified.length,
-                partialNumberCount : 0, // TODO: handle this
+                partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -40,7 +40,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         spatialmatches: spatialmatches,
         batchSize: options.verifymatch_stack_limit,
         partialNumberCount: 0,
-        matchesSeen: 0
+        matchesSeen: 0,
+        startPos: 0
     };
 
     verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, (err, verified) => {
@@ -56,7 +57,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
 
 
     function verifyFeatureChunk(query, geocoder, featureOpts, options, done) {
-        const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen } = featureOpts;
+        const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen, startPos } = featureOpts;
 
         let spatialmatchesChunk = [];
         const backfill = [];
@@ -104,7 +105,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         for (let i = 0; i < spatialmatchesChunk.length; i++) q.defer(loadFeature, spatialmatchesChunk[i]);
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
-            const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk);
+            const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
             verified.push(...verifiedChunk);
             // Base cases
             if (backfill.length === 0 ||
@@ -114,12 +115,15 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 return done(null, verified);
             }
 
+            const totalSeen = matchesSeen + loaded.length;
+
             const verifyFeatureOpts = {
                 verified: verified,
                 spatialmatches: backfill,
                 batchSize: options.verifymatch_stack_limit - verified.length,
                 partialNumberCount : 0, // TODO: handle this
-                matchesSeen: matchesSeen + loaded.length
+                matchesSeen: totalSeen,
+                startPos: totalSeen - 1
             };
 
             verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, done);
@@ -147,13 +151,19 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     }
 }
 
+
 /**
  * Once all features are loaded, filter, verify, and load contexts
  *
  * @param {Array<object>} loaded array of GeoJSON fetures
- * @returns {Array} verified features
+ * @param {Object} options
+ * @param {Array} query - a list of terms composing the query to Carmen
+ * @param {Object} geocoder - a geocoder datasource
+ * @param {Array} spatialmatches - a chunk of spatialmatches
+ * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
+ * @returns {Array} verified - An array of verified features
  */
-function afterFeatures(loaded, options, query, geocoder, spatialmatches) {
+function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
     let verified;
 
     // Limit each feature based on whether it is allowed by types & stacks filters.
@@ -168,10 +178,10 @@ function afterFeatures(loaded, options, query, geocoder, spatialmatches) {
                 filteredLoaded.push(loaded[i]);
             }
         });
-        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options);
+        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
     // No filters specified, go straight to verify
     } else {
-        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options);
+        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
     }
 
     return verified;
@@ -222,9 +232,10 @@ function countGoodContexts(batch) {
 * @param {Object} spatialmatches - resultant indexes that could be spatially stacked
 * @param {Object} loaded - features that are loaded from the carmen index
 * @param {Object} options - passed through the geocode function in geocode.js
+* @param {Number} startPos - the index of the first feature from the original spatialmatches array
 * @returns {Array} filtered - sorted and verified features
 */
-function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
+function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos) {
     const result = [];
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
@@ -363,7 +374,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             feat.properties['carmen:inside_radius'] = options.proximity ?
                 feat.properties['carmen:distance'] < proximity.scaleRadius(cover.zoom) :
                 null;
-            feat.properties['carmen:position'] = pos;
+            feat.properties['carmen:position'] = startPos + pos;
             feat.properties['carmen:spatialmatch'] = spatialmatch;
 
             // Apply a small penalty to addresses that failed to match an address number

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -128,7 +128,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             const verifyFeatureOpts = {
                 verified: verified,
                 spatialmatches: backfill,
-                batchSize: options.verifymatch_stack_limit - verified.length,
+                batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
+                    VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
                 partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -20,7 +20,7 @@ module.exports.sortContext = sortContext;
 
 /**
 * verifymatch - results from spatialmatch are now verified by querying real geometries in vector tiles
-*q
+*
 * @access public
 * @param {Array} query - a list of terms composing the query to Carmen
 * @param {Object} stats - ?
@@ -32,32 +32,149 @@ module.exports.sortContext = sortContext;
 function verifymatch(query, stats, geocoder, matched, options, callback) {
     const spatialmatches = matched.results;
     const sets = matched.sets;
-
     options.limit_verify = options.limit_verify || 10;
 
-    const verifyFeatureOpts = {
+    // Initialize first batch of features to verify
+    const featureOpts = {
         verified: [],
         spatialmatches: spatialmatches,
         batchSize: options.verifymatch_stack_limit,
-        partialNumberCount: 0,
         matchesSeen: 0,
         startPos: 0
     };
+    verifyFeatureChunk(query, geocoder, featureOpts, options, doneVerifyingFeatures);
 
-    verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, (err, verified) => {
+    /**
+     * Callback to call after loading and verifying features.
+     * This calls the verifyContextChunk function, which ultimately calls the original callback passed to verifymatch
+     *
+     * @param {Object} err - Error object
+     * @param {Array<Object>} verified - Array of verified features
+     * @returns {undefined}
+     */
+    function doneVerifyingFeatures(err, verified) {
         if (err) return callback(err);
-        const verifiedContexts = {
+
+        // Initialize first batch of contexts to verify
+        const verifyContextOpts = {
             results:  [],
             goodFeatureCount: 0,
             batch: verified.slice(0, options.limit_verify),
             backfill: verified.slice(options.limit_verify)
         };
-        verifyContextChunk(geocoder, verifiedContexts, sets, options, callback);
-    });
+        verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback);
+    }
 
+    /**
+     * Loads feature json and verifies the features for a chunk of spatialmatch results.
+     * If there are fewer results than the verifymatch_stack_limit, this calls itself to "backfill"
+     * as many times as needed to get to the verifymatch_stack_limit,
+     * without exceeding the VERIFYMATCH_MAX_FEATURES_LIMIT
+     *
+     * @param {Array} query - a list of terms composing the query to Carmen
+     * @param {Object} geocoder  - a geocoder datasource
+     * @param {Object} featureOpts - FeatureOpts object
+     * @param {Array<Object>} featureOpts.verified - Array of features that have been loaded and verified
+     * @param {Array<Object>} featureOpts.spatialmatches - Array of spatialmatch results to load feature json for and verify
+     * @param {Number} featureOpts.batchSize - Number of spatialmatches to look at in a given iteration
+     * @param {Number} featureOpts.startPos - The original index of the first spatialmatch in the batch
+     * @param {Object} options - passed through the geocode function in geocode.js
+     * @param {Function} doneVerifyingFeatures - the callback to call when done loading and verifying features
+     */
+    function verifyFeatureChunk(query, geocoder, featureOpts, options, doneVerifyingFeatures) {
+        const { spatialmatchesChunk, backfill, stopEarly } = getSpatialmatchesChunk(featureOpts, options);
+        featureOpts.stopEarly = stopEarly;
 
-    function verifyFeatureChunk(query, geocoder, featureOpts, options, done) {
-        const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen, startPos } = featureOpts;
+        const q = queue(10);
+        for (let i = 0; i < spatialmatchesChunk.length; i++) q.defer(loadFeature, spatialmatchesChunk[i], geocoder);
+        q.awaitAll((err, loaded) => {
+            if (err) return callback(err);
+            afterFeatureChunk(loaded, spatialmatchesChunk, backfill, query, geocoder, featureOpts, doneVerifyingFeatures);
+        });
+    }
+
+    /**
+     * After loading features, filters by type again and verifies features.
+     * If there aren't as many verified features as expected, sends another batch
+     * of spatialmatches to verifyFeatureChunk.
+     *
+     * @param {Array} loaded - Current batch of features loaded
+     * @param {Array} spatialmatchesChunk - Array of spatialmatches that were loaded for this batch
+     * @param {Array} backfill - Array of spatialmatches to load if necessary
+     * @param {Array} query - A list of terms composing the query to Carmen
+     * @param {Object} geocoder - The carmen {@link Geocoder} instance
+     * @param {Object} featureOpts - FeatureOpts object
+     * @param {Array<Object>} featureOpts.verified - Array of features that have been loaded and verified
+     * @param {Array<Object>} featureOpts.spatialmatches - Array of spatialmatch results to load feature json for and verify
+     * @param {Number} featureOpts.batchSize - Number of spatialmatches to look at in a given iteration
+     * @param {Number} featureOpts.startPos - The original index of the first spatialmatch in the batch
+     * @param {Function} doneVerifyingFeatures - Callback after verifying all features
+     * @returns {undefined}
+     */
+    function afterFeatureChunk(loaded, spatialmatchesChunk, backfill, query, geocoder, featureOpts, doneVerifyingFeatures) {
+        const {
+            verified,
+            matchesSeen,
+            startPos
+        } = featureOpts;
+
+        let verifiedChunk;
+
+        // Limit each feature based on whether it is allowed by types & stacks filters.
+        if (options.types || options.stacks || options.languageMode === 'strict') {
+            const filteredSpatialmatches = [];
+            const filteredLoaded = [];
+            loaded.forEach((feature, i) => {
+                if (!feature || !feature.properties) return;
+                const source = geocoder.indexes[feature.properties['carmen:index']];
+                if (source && filter.featureAllowed(source, feature, options)) {
+                    filteredSpatialmatches.push(spatialmatchesChunk[i]);
+                    filteredLoaded.push(loaded[i]);
+                }
+            });
+            verifiedChunk = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
+            // No filters specified, go straight to verify
+        } else {
+            verifiedChunk = verifyFeatures(query, geocoder, spatialmatchesChunk, loaded, options, startPos);
+        }
+
+        verified.push(...verifiedChunk);
+        // Base cases
+        if (featureOpts.stopEarly ||
+            backfill.length === 0 ||
+            verified.length >= options.verifymatch_stack_limit ||
+            matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT
+        ) {
+            return doneVerifyingFeatures(null, verified);
+        }
+
+        // Otherwise, load and verify another feature chunk
+        const totalSeen = matchesSeen + loaded.length;
+        const verifyFeatureOpts = {
+            verified: verified,
+            spatialmatches: backfill,
+            batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
+                VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
+            matchesSeen: totalSeen,
+            startPos: totalSeen - 1 // TODO: should this not be -1?
+        };
+        verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, doneVerifyingFeatures);
+    }
+
+    /**
+     * Generates a chunk of spatialmatches to load the full feature json for and verify,
+     * and separates out remaining spatialmatches into "backfill" for future iterations
+     *
+     * @param {Object} featureOpts -
+     * @param {Object} options - passed through the geocode function in geocode.js
+     * @returns {Object} result
+     * @returns {Array} result.spatialmatchesChunk - Array of spatialmatches to load
+     * @returns {Array} result.backfill - Array of spatialmatches to save for backfill
+     * @returns {boolean} result.stopEarly - whether the backfill process should stop
+     * because the spatialmatches have lower relevance than previously loaded features
+     */
+    function getSpatialmatchesChunk(featureOpts, options) {
+        const { spatialmatches, verified, batchSize } = featureOpts;
 
         let spatialmatchesChunk = [];
         let stopEarly = false;
@@ -65,9 +182,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         let batchPartialNumberCount = 0;
         // Limit initial feature check.
         if (spatialmatches.length > batchSize) {
-            // Set the partialNumber limit to be up to 80% of the total stack limit,
-            // depending on how many partial number results there already are
-            const partialNumberLimit = (0.8 * options.verifymatch_stack_limit) - partialNumberCount;
+            // Set the partialNumber limit to be up to 80% of the total stack limit
+            const partialNumberLimit = (0.8 * options.verifymatch_stack_limit);
 
             for (let i = 0; i < spatialmatches.length; i++) {
                 // Skip covers if their source isn't allowed by types & stacks filters.
@@ -96,8 +212,8 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 else {
                     spatialmatchesChunk.push(spatialmatches[i]);
                 }
-                // TODO: this should never be >, so could switch to ==
-                if (spatialmatchesChunk.length >= batchSize) {
+
+                if (spatialmatchesChunk.length === batchSize) {
                     backfill.push(...spatialmatches.slice(i + 1));
                     break;
                 }
@@ -106,122 +222,97 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         else {
             spatialmatchesChunk = spatialmatches;
         }
-
-
-        const q = queue(10);
-        for (let i = 0; i < spatialmatchesChunk.length; i++) q.defer(loadFeature, spatialmatchesChunk[i]);
-        q.awaitAll((err, loaded) => {
-            if (err) return callback(err);
-            const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
-            verified.push(...verifiedChunk);
-            // Base cases
-            if (stopEarly ||
-                backfill.length === 0 ||
-                verified.length >= options.verifymatch_stack_limit ||
-                matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT
-            ) {
-                return done(null, verified);
-            }
-
-            const totalSeen = matchesSeen + loaded.length;
-
-            const verifyFeatureOpts = {
-                verified: verified,
-                spatialmatches: backfill,
-                batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
-                    VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
-                partialNumberCount : 0, // TODO
-                matchesSeen: totalSeen,
-                startPos: totalSeen - 1
-            };
-
-            verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, done);
-        });
-    }
-
-
-    /**
-     * For each result, load the feature from its Carmen index.
-     *
-     * @param {Object} spatialmatch - Spatialmatch instance
-     * @param {callback} callback - accepts error and GeoJSON object
-     * @returns {undefined}
-     */
-    function loadFeature(spatialmatch, callback) {
-        const cover = spatialmatch.covers[0];
-        const source = geocoder.byidx[cover.idx];
-
-        // Currently unclear why this might be undefined.
-        // For now, catch and return error to try to learn more.
-        if (!source) return callback(new Error('Misuse: source undefined for idx ' + cover.idx));
-
-        // getFeatureByCover() uses `getGeocoderData` to fetch a carmen record
-        feature.getFeatureByCover(source, cover, callback);
+        return { spatialmatchesChunk, backfill, stopEarly };
     }
 }
-
 
 /**
- * Once all features are loaded, filter, verify, and load contexts
+ * For each result, load the feature from its Carmen index.
  *
- * @param {Array<object>} loaded array of GeoJSON fetures
- * @param {Object} options
- * @param {Array} query - a list of terms composing the query to Carmen
- * @param {Object} geocoder - a geocoder datasource
- * @param {Array} spatialmatches - a chunk of spatialmatches
- * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
- * @returns {Array} verified - An array of verified features
+ * @param {Object} spatialmatch - Spatialmatch instance
+ * @param {Object} geocoder - geocoder source
+ * @param {callback} callback - accepts error and GeoJSON object
+ * @returns {undefined}
  */
-function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
-    let verified;
+function loadFeature(spatialmatch, geocoder, callback) {
+    const cover = spatialmatch.covers[0];
+    const source = geocoder.byidx[cover.idx];
 
-    // Limit each feature based on whether it is allowed by types & stacks filters.
-    if (options.types || options.stacks || options.languageMode === 'strict') {
-        const filteredSpatialmatches = [];
-        const filteredLoaded = [];
-        loaded.forEach((feature, i) => {
-            if (!feature || !feature.properties) return;
-            const source = geocoder.indexes[feature.properties['carmen:index']];
-            if (source && filter.featureAllowed(source, feature, options)) {
-                filteredSpatialmatches.push(spatialmatches[i]);
-                filteredLoaded.push(loaded[i]);
-            }
-        });
-        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
-    // No filters specified, go straight to verify
-    } else {
-        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
-    }
+    // Currently unclear why this might be undefined.
+    // For now, catch and return error to try to learn more.
+    if (!source) return callback(new Error('Misuse: source undefined for idx ' + cover.idx));
 
-    return verified;
+    // getFeatureByCover() uses `getGeocoderData` to fetch a carmen record
+    feature.getFeatureByCover(source, cover, callback);
 }
 
-function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
-    loadContexts(geocoder, verifiedContexts.batch, sets, options, (err, contextResults) => {
+/**
+ * Takes loaded features and loads and verifies contexts, in chunks as needed.
+ *
+ * @param {Object} geocoder - the carmen {@link Geocoder} instance
+ * @param {Object} verifyContextOpts - Opts to keep track of context results, backfill features etc
+ * @param {Array} verifyContextOpts.results - Array of already loaded and verified contexts
+ * @param {Array} verifyContextOpts.batch - The current batch of features to load contexts for
+ * @param {Array} verifyContextOpts.backfill - Array of features to load contexts for if necessary
+ * @param {Number} verifyContextOpts.goodFeatureCount - Number of features with expected relevance
+ * @param {Array} sets - covers for the features that have been verified
+ * @param {Object} options - passed through the geocode function in geocode.js
+ * @param {Function} callback - the callback passed to verifyMatch
+ */
+function verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback) {
+    const q = queue(5);
+    const features = verifyContextOpts.batch;
+
+    for (let i = 0; i < features.length; i++) {
+        q.defer(loadContext, geocoder, features[i], sets, options);
+    }
+
+    q.awaitAll((err, contexts) =>  {
         if (err) return callback(err);
-        verifiedContexts.results.push(...contextResults);
+        afterContextChunk(err, contexts); });
+
+    /**
+     * After contexts are loaded, verify them and determine whether it's necessary to load
+     * another chunk of contexts.
+     * Calls the verifymatch callback when finished if no more contexts will be loaded.
+     *
+     * @param {Object} err - Error from loading contexts
+     * @param {Array<Object>} contexts - Array of loaded contexts
+     * @returns {undefined}
+     */
+    function afterContextChunk(err, contexts) {
+        if (err) return callback(err);
+
+        const contextResults = verifyContexts(contexts, sets, geocoder.indexes, options, geocoder);
+
+        verifyContextOpts.results.push(...contextResults);
         // If there are no more potential candidates, return early
-        if (verifiedContexts.backfill.length === 0) {
-            const result = verifiedContexts.results.sort(sortContext).slice(0, options.limit_verify);
+        if (verifyContextOpts.backfill.length === 0) {
+            const result = verifyContextOpts.results.sort(sortContext).slice(0, options.limit_verify);
             return callback(null, result);
         }
 
         // Count how many contexts have the expected relevance from spatialmatch
-        verifiedContexts.goodFeatureCount += countGoodContexts(contextResults);
+        verifyContextOpts.goodFeatureCount += countGoodContexts(contextResults);
         // If there aren't enough features with the expected relevance,
         // and the max number of contexts hasn't been reached, load and verify some more contexts
-        if (verifiedContexts.goodFeatureCount <= options.limit_verify && verifiedContexts.results.length < MAX_CONTEXTS_LIMIT) {
-            verifiedContexts.batch = verifiedContexts.backfill.slice(0, options.limit_verify);
-            verifiedContexts.backfill = verifiedContexts.backfill.slice(options.limit_verify);
-            verifyContextChunk(geocoder, verifiedContexts, sets, options, callback);
-        }
-        else {
-            const result = verifiedContexts.results.sort(sortContext).slice(0, options.limit_verify);
+        if (verifyContextOpts.goodFeatureCount <= options.limit_verify && verifyContextOpts.results.length < MAX_CONTEXTS_LIMIT) {
+            verifyContextOpts.batch = verifyContextOpts.backfill.slice(0, options.limit_verify);
+            verifyContextOpts.backfill = verifyContextOpts.backfill.slice(options.limit_verify);
+            return verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback);
+        } else {
+            const result = verifyContextOpts.results.sort(sortContext).slice(0, options.limit_verify);
             return callback(null, result);
         }
-    });
+    }
 }
 
+/**
+ * Counts the number of verified contexts that have the expected relev from spatialmatch
+ *
+ * @param {Array<Object>} batch - Array of loaded and verified contexts
+ * @returns {Number} goodContextCount - The number of contexts with expected relev
+ */
 function countGoodContexts(batch) {
     let goodContextCount = 0;
     batch.forEach((context) => {
@@ -368,7 +459,6 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             });
         }
 
-        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -436,44 +526,37 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             byText[text] = true;
         }
     }
-    // TODO: or maybe this is where partialnumbercount needs to be calculated
     return filtered;
 }
 
 /**
-* loadContexts returns the heirachy of the features that make up each result's
-* geographic context, as provided by {@link context}
-*
-* @param {Object} geocoder - a geocoder datasource
-* @param {Object} features - geojson feature
-* @param {Object} sets - covers for the features that have been verified
-* @param {Object} options -  passed through the geocode function in geocode.js
-* @param {Function} callback - callback called with the features in the the appropriate heirachical order
-*/
-function loadContexts(geocoder, features, sets, options, callback) {
-    const q = queue(5);
-
-    for (let i = 0; i < features.length; i++) q.defer((f, done) => {
-        const name = geocoder.indexes[f.properties['carmen:index']].name;
-        const firstidx = geocoder.byname[name][0].idx;
-        context(geocoder, f.properties['carmen:center'], {
-            maxtype: f.properties['carmen:extid'].split('.')[0],
-            maxidx: firstidx,
-            matched: sets,
-            language: options.language
-        }, (err, context) => {
-            if (err) return done(err);
-            // Push feature onto the top level.
-            context.unshift(f);
-            return done(null, context);
-        });
-    }, features[i]);
-
-    q.awaitAll((err, contexts) => {
-        if (err) return callback(err);
-        callback(null, verifyContexts(contexts, sets, geocoder.indexes, options, geocoder));
+ * loadContext returns the heirachy of the a that makes up each result's
+ * geographic context, as provided by {@link context}
+ *
+ * @param {Object} geocoder - a geocoder datasource
+ * @param {Object} feature - geojson feature
+ * @param {Object} sets - covers for the features that have been verified
+ * @param {Object} options -  passed through the geocode function in geocode.js
+ * @param {Function} afterContextChunk - callback called after all features are loaded
+ * with the features in the the appropriate heirachical order
+ * @returns {undefined}
+ */
+function loadContext(geocoder, feature, sets, options, afterContextChunk) {
+    const name = geocoder.indexes[feature.properties['carmen:index']].name;
+    const firstidx = geocoder.byname[name][0].idx;
+    context(geocoder, feature.properties['carmen:center'], {
+        maxtype: feature.properties['carmen:extid'].split('.')[0],
+        maxidx: firstidx,
+        matched: sets,
+        language: options.language
+    }, (err, context) => {
+        if (err) return afterContextChunk(err);
+        // Push feature onto the top level.
+        context.unshift(feature);
+        return afterContextChunk(null, context);
     });
 }
+
 
 /**
  * verifyContexts - Create lookup for peer contexts to use real loaded feature
@@ -633,7 +716,7 @@ function verifyContexts(contexts, sets, indexes, options, geocoder) {
  *
  * @access public
  *
- * @param {Array} context - created in {@link loadContexts} the target feature to be returned is context[0] and context[1:] are the features in which the target is contained, ordered by hierarchy of their layers
+ * @param {Array} context - created in {@link loadContext} the target feature to be returned is context[0] and context[1:] are the features in which the target is contained, ordered by hierarchy of their layers
  * @param {Map} peers - A mapping from `carmen:tmpid`s to features, used when applying the "squishy" logic for nested, identically-named features.
  * @param {Object} strict - A mapping from `carmen:tmpid`s to covers matched by some substring of the query
  * @param {Object} loose - A mapping from `carmen:tmpid`s to the cover with that tmpid whose `relev` value is greatest (across all result contexts).

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -11,8 +11,7 @@ const bbox = require('../util/bbox');
 const roundTo = require('../util/round-to.js');
 const filter = require('./filter-sources');
 const routablePoints = require('./routablepoint');
-const MAX_QUERY_TOKENS = require('../constants').MAX_QUERY_TOKENS;
-const MAX_CONTEXTS_LIMIT = require('../constants').MAX_CONTEXTS_LIMIT;
+const { MAX_QUERY_TOKENS, VERIFYMATCH_MAX_FEATURES_LIMIT, MAX_CONTEXTS_LIMIT } = require('../constants');
 
 module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
@@ -31,39 +30,103 @@ module.exports.sortContext = sortContext;
 * @param {Function} callback - callback function which is called with the verified indexes in the correct hierarchical order
 */
 function verifymatch(query, stats, geocoder, matched, options, callback) {
-    let spatialmatches = matched.results;
+    const spatialmatches = matched.results;
     const sets = matched.sets;
 
     options.limit_verify = options.limit_verify || 10;
-    // Limit covers based on whether their source is allowed by types & stacks filters.
-    if (options.types || options.stacks) {
-        spatialmatches = spatialmatches.filter((spatialmatch) => {
-            const firstCover = spatialmatch.covers[0];
-            const source = geocoder.byidx[firstCover.idx];
-            // Currently unclear why this might be undefined.
-            if (!source) console.error(new Error('Misuse: source undefined for idx ' + firstCover.idx));
-            return source && filter.sourceAllowed(source, options);
+
+    const verifyFeatureOpts = {
+        verified: [],
+        spatialmatches: spatialmatches,
+        batchSize: options.verifymatch_stack_limit,
+        partialNumberCount: 0,
+        matchesSeen: 0
+    };
+
+    verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, (err, verified) => {
+        if (err) return callback(err);
+        const verifiedContexts = {
+            results:  [],
+            goodFeatureCount: 0,
+            batch: verified.slice(0, options.limit_verify),
+            backfill: verified.slice(options.limit_verify)
+        };
+        verifyContextChunk(geocoder, verifiedContexts, sets, options, callback);
+    });
+
+
+    function verifyFeatureChunk(query, geocoder, featureOpts, options, done) {
+        const { spatialmatches, verified, batchSize, partialNumberCount, matchesSeen } = featureOpts;
+
+        let spatialmatchesChunk = [];
+        const backfill = [];
+        // Limit initial feature check.
+        if (spatialmatches.length > batchSize) {
+            // Set the partialNumber limit to be up to 80% of the total stack limit,
+            // depending on how many partial number results there already are
+            const partialNumberLimit = (0.8 * options.verifymatch_stack_limit) - partialNumberCount;
+
+            let batchPartialNumberCount = 0;
+            for (let i = 0; i < spatialmatches.length; i++) {
+                // Skip covers if their source isn't allowed by types & stacks filters.
+                if (options.types || options.stacks) {
+                    const firstCover = spatialmatches[i].covers[0];
+                    const source = geocoder.byidx[firstCover.idx];
+                    // Currently unclear why this might be undefined.
+                    if (!source) console.error(new Error('Misuse: source undefined for idx ' + firstCover.idx));
+                    if (!source || !filter.sourceAllowed(source, options)) continue;
+                }
+                // Enforce partialnumber limit
+                if (spatialmatches[i].partialNumber) {
+                    batchPartialNumberCount++;
+                    if (batchPartialNumberCount > partialNumberLimit) {
+                        backfill.push(spatialmatches[i]);
+                        continue;
+                    }
+                    spatialmatchesChunk.push(spatialmatches[i]);
+                }
+                else {
+                    spatialmatchesChunk.push(spatialmatches[i]);
+                }
+                // TODO: this should never be >, so could switch to ==
+                if (spatialmatchesChunk.length >= batchSize) {
+                    backfill.push(...spatialmatches.slice(i));
+                    break;
+                }
+            }
+        }
+        else {
+            spatialmatchesChunk = spatialmatches;
+        }
+
+
+        const q = queue(10);
+        for (let i = 0; i < spatialmatchesChunk.length; i++) q.defer(loadFeature, spatialmatchesChunk[i]);
+        q.awaitAll((err, loaded) => {
+            if (err) return callback(err);
+            const verifiedChunk = afterFeatures(loaded);
+            verified.push(...verifiedChunk);
+            // Base cases
+            if (verified.length >= options.verifymatch_stack_limit ||
+                matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT ||
+                backfill.length === 0) {
+                return done(null, verified);
+            }
+
+            if (backfill.length >= 0) {
+                const verifyFeatureOpts = {
+                    verified: verified,
+                    spatialmatches: backfill,
+                    batchSize: options.verifymatch_stack_limit - verified.length,
+                    partialNumberCount : 0, // TODO: handle this
+                    matchesSeen: matchesSeen + loaded.length
+                };
+                verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, done);
+            }
         });
     }
 
-    // Limit initial feature check to the best 100 max.
-    if (spatialmatches.length > options.verifymatch_stack_limit) {
-        let partialNumberCount = 0;
-        const partialNumberLimit = 0.8 * options.verifymatch_stack_limit;
-        spatialmatches = spatialmatches
-            .filter((match) => {
-                if (match.partialNumber) {
-                    partialNumberCount++;
-                    return partialNumberCount < partialNumberLimit;
-                } else {
-                    return true;
-                }
-            }).slice(0, options.verifymatch_stack_limit);
-    }
 
-    const q = queue(10);
-    for (let i = 0; i < spatialmatches.length; i++) q.defer(loadFeature, spatialmatches[i]);
-    q.awaitAll(afterFeatures);
 
     /**
      * For each result, load the feature from its Carmen index.
@@ -87,13 +150,10 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
     /**
      * Once all features are loaded, filter, verify, and load contexts
      *
-     * @param {Error} err - error
      * @param {Array<object>} loaded array of GeoJSON fetures
-     * @returns {undefined}
+     * @returns {Array} verified features
      */
-    function afterFeatures(err, loaded) {
-        if (err) return callback(err);
-
+    function afterFeatures(loaded) {
         let verified;
 
         // Limit each feature based on whether it is allowed by types & stacks filters.
@@ -114,16 +174,11 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
             verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options);
         }
 
-        // Limit verify results before loading contexts
-        const verifiedContexts = {
-            results: [],
-            goodFeatureCount: 0,
-            batch: verified.slice(0, options.limit_verify),
-            backfill: verified.slice(options.limit_verify)
-        };
-        verifyContextChunk(geocoder, verifiedContexts, sets, options, callback);
+        return verified;
     }
 }
+
+
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
     loadContexts(geocoder, verifiedContexts.batch, sets, options, (err, contextResults) => {
@@ -296,6 +351,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             });
         }
 
+        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -363,6 +419,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
             byText[text] = true;
         }
     }
+    // TODO: or maybe this is where partialnumbercount needs to be calculated
     return filtered;
 }
 
@@ -378,6 +435,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options) {
 */
 function loadContexts(geocoder, features, sets, options, callback) {
     const q = queue(5);
+
     for (let i = 0; i < features.length; i++) q.defer((f, done) => {
         const name = geocoder.indexes[f.properties['carmen:index']].name;
         const firstidx = geocoder.byname[name][0].idx;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -113,7 +113,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
-            verified.push(...verifiedChunk.verified);
+            verified.push(...verifiedChunk);
             // Base cases
             if (stopEarly ||
                 backfill.length === 0 ||
@@ -130,7 +130,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 spatialmatches: backfill,
                 batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
                     VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
-                partialNumberCount : partialNumberCount + verifiedChunk.partialNumberCount,
+                partialNumberCount : 0, // TODO
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };
@@ -170,10 +170,10 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
  * @param {Object} geocoder - a geocoder datasource
  * @param {Array} spatialmatches - a chunk of spatialmatches
  * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
- * @returns {{verified: Array, partialNumberCount: number}} result - An object with an array of verified features and the partialNumberCount
+ * @returns {Array} verified - An array of verified features
  */
 function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
-    let result = {};
+    let verified;
 
     // Limit each feature based on whether it is allowed by types & stacks filters.
     if (options.types || options.stacks || options.languageMode === 'strict') {
@@ -187,12 +187,13 @@ function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPo
                 filteredLoaded.push(loaded[i]);
             }
         });
-        result = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
+        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
     // No filters specified, go straight to verify
     } else {
-        result = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
+        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
     }
-    return result;
+
+    return verified;
 }
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
@@ -241,13 +242,10 @@ function countGoodContexts(batch) {
 * @param {Object} loaded - features that are loaded from the carmen index
 * @param {Object} options - passed through the geocode function in geocode.js
 * @param {Number} startPos - the index of the first feature from the original spatialmatches array
-* @returns {{verified: Array, partialNumberCount: number}} result - object with sorted and verified features, and partial number count
+* @returns {Array} filtered - sorted and verified features
 */
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos) {
-    const result = {
-        verified: [],
-        partialNumberCount: 0
-    };
+    const result = [];
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
@@ -370,6 +368,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             });
         }
 
+        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -394,13 +393,13 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             feat.properties['carmen:relev'] = cover.relev;
             feat.properties['carmen:geocoder_address_order'] = source.geocoder_address_order;
             feat.properties['carmen:zoom'] = cover.zoom;
-            result.verified.push(feat);
+            result.push(feat);
         }
     }
 
     // Set a score + distance combined heuristic.
-    for (let k = 0; k < result.verified.length; k++) {
-        const feat = result.verified[k];
+    for (let k = 0; k < result.length; k++) {
+        const feat = result[k];
         if (options.proximity) {
             feat.properties['carmen:scoredist'] = proximity.scoredist(
                 feat.properties['carmen:score'],
@@ -422,25 +421,23 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
 
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
-    result.verified.sort(sortFeature);
+    result.sort(sortFeature);
 
     // Eliminate any score < 0 results if there are better-scored results
     // with identical text.
     const filtered = [];
     const byText = {};
-    for (let i = 0; i < result.verified.length; i++) {
-        const feat = result.verified[i];
+    for (let i = 0; i < result.length; i++) {
+        const feat = result[i];
         const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
         const text = languageText || feat.properties['carmen:text'];
         if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
             filtered.push(feat);
             byText[text] = true;
-            if (feat.properties['carmen:spatialmatch'].partialNumber) result.partialNumberCount++;
         }
     }
     // TODO: or maybe this is where partialnumbercount needs to be calculated
-    result.verified = filtered;
-    return result;
+    return filtered;
 }
 
 /**

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -113,7 +113,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
             const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk, startPos);
-            verified.push(...verifiedChunk);
+            verified.push(...verifiedChunk.verified);
             // Base cases
             if (stopEarly ||
                 backfill.length === 0 ||
@@ -130,7 +130,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 spatialmatches: backfill,
                 batchSize: Math.min(options.verifymatch_stack_limit - verified.length,
                     VERIFYMATCH_MAX_FEATURES_LIMIT - totalSeen),
-                partialNumberCount : 0, // TODO
+                partialNumberCount : partialNumberCount + verifiedChunk.partialNumberCount,
                 matchesSeen: totalSeen,
                 startPos: totalSeen - 1
             };
@@ -170,10 +170,10 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
  * @param {Object} geocoder - a geocoder datasource
  * @param {Array} spatialmatches - a chunk of spatialmatches
  * @param {Number} startPos - The start position from the original spatialmatches array of this chunk of features
- * @returns {Array} verified - An array of verified features
+ * @returns {{verified: Array, partialNumberCount: number}} result - An object with an array of verified features and the partialNumberCount
  */
 function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPos) {
-    let verified;
+    let result = {};
 
     // Limit each feature based on whether it is allowed by types & stacks filters.
     if (options.types || options.stacks || options.languageMode === 'strict') {
@@ -187,13 +187,12 @@ function afterFeatures(loaded, options, query, geocoder, spatialmatches, startPo
                 filteredLoaded.push(loaded[i]);
             }
         });
-        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
+        result = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options, startPos);
     // No filters specified, go straight to verify
     } else {
-        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
+        result = verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos);
     }
-
-    return verified;
+    return result;
 }
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
@@ -242,10 +241,13 @@ function countGoodContexts(batch) {
 * @param {Object} loaded - features that are loaded from the carmen index
 * @param {Object} options - passed through the geocode function in geocode.js
 * @param {Number} startPos - the index of the first feature from the original spatialmatches array
-* @returns {Array} filtered - sorted and verified features
+* @returns {{verified: Array, partialNumberCount: number}} result - object with sorted and verified features, and partial number count
 */
 function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startPos) {
-    const result = [];
+    const result = {
+        verified: [],
+        partialNumberCount: 0
+    };
     let feats;
     for (let pos = 0; pos < loaded.length; pos++) {
         if (!loaded[pos]) continue;
@@ -368,7 +370,6 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             });
         }
 
-        // TODO: keep track of partialnumbercount here and add it to a result object
         for (const feat of feats) {
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
@@ -393,13 +394,13 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
             feat.properties['carmen:relev'] = cover.relev;
             feat.properties['carmen:geocoder_address_order'] = source.geocoder_address_order;
             feat.properties['carmen:zoom'] = cover.zoom;
-            result.push(feat);
+            result.verified.push(feat);
         }
     }
 
     // Set a score + distance combined heuristic.
-    for (let k = 0; k < result.length; k++) {
-        const feat = result[k];
+    for (let k = 0; k < result.verified.length; k++) {
+        const feat = result.verified[k];
         if (options.proximity) {
             feat.properties['carmen:scoredist'] = proximity.scoredist(
                 feat.properties['carmen:score'],
@@ -421,23 +422,25 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
 
     // Sort + disallow more than options.limit_verify of
     // the best results at this point.
-    result.sort(sortFeature);
+    result.verified.sort(sortFeature);
 
     // Eliminate any score < 0 results if there are better-scored results
     // with identical text.
     const filtered = [];
     const byText = {};
-    for (let i = 0; i < result.length; i++) {
-        const feat = result[i];
+    for (let i = 0; i < result.verified.length; i++) {
+        const feat = result.verified[i];
         const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
         const text = languageText || feat.properties['carmen:text'];
         if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
             filtered.push(feat);
             byText[text] = true;
+            if (feat.properties['carmen:spatialmatch'].partialNumber) result.partialNumberCount++;
         }
     }
     // TODO: or maybe this is where partialnumbercount needs to be calculated
-    return filtered;
+    result.verified = filtered;
+    return result;
 }
 
 /**

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -20,7 +20,7 @@ module.exports.sortContext = sortContext;
 
 /**
 * verifymatch - results from spatialmatch are now verified by querying real geometries in vector tiles
-*
+*q
 * @access public
 * @param {Array} query - a list of terms composing the query to Carmen
 * @param {Object} stats - ?
@@ -90,7 +90,7 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
                 }
                 // TODO: this should never be >, so could switch to ==
                 if (spatialmatchesChunk.length >= batchSize) {
-                    backfill.push(...spatialmatches.slice(i));
+                    backfill.push(...spatialmatches.slice(i + 1));
                     break;
                 }
             }
@@ -104,28 +104,27 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         for (let i = 0; i < spatialmatchesChunk.length; i++) q.defer(loadFeature, spatialmatchesChunk[i]);
         q.awaitAll((err, loaded) => {
             if (err) return callback(err);
-            const verifiedChunk = afterFeatures(loaded);
+            const verifiedChunk = afterFeatures(loaded, options, query, geocoder, spatialmatchesChunk);
             verified.push(...verifiedChunk);
             // Base cases
-            if (verified.length >= options.verifymatch_stack_limit ||
-                matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT ||
-                backfill.length === 0) {
+            if (backfill.length === 0 ||
+                verified.length >= options.verifymatch_stack_limit ||
+                matchesSeen + loaded.length >= VERIFYMATCH_MAX_FEATURES_LIMIT
+            ) {
                 return done(null, verified);
             }
 
-            if (backfill.length >= 0) {
-                const verifyFeatureOpts = {
-                    verified: verified,
-                    spatialmatches: backfill,
-                    batchSize: options.verifymatch_stack_limit - verified.length,
-                    partialNumberCount : 0, // TODO: handle this
-                    matchesSeen: matchesSeen + loaded.length
-                };
-                verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, done);
-            }
+            const verifyFeatureOpts = {
+                verified: verified,
+                spatialmatches: backfill,
+                batchSize: options.verifymatch_stack_limit - verified.length,
+                partialNumberCount : 0, // TODO: handle this
+                matchesSeen: matchesSeen + loaded.length
+            };
+
+            verifyFeatureChunk(query, geocoder, verifyFeatureOpts, options, done);
         });
     }
-
 
 
     /**
@@ -146,39 +145,37 @@ function verifymatch(query, stats, geocoder, matched, options, callback) {
         // getFeatureByCover() uses `getGeocoderData` to fetch a carmen record
         feature.getFeatureByCover(source, cover, callback);
     }
-
-    /**
-     * Once all features are loaded, filter, verify, and load contexts
-     *
-     * @param {Array<object>} loaded array of GeoJSON fetures
-     * @returns {Array} verified features
-     */
-    function afterFeatures(loaded) {
-        let verified;
-
-        // Limit each feature based on whether it is allowed by types & stacks filters.
-        if (options.types || options.stacks || options.languageMode === 'strict') {
-            const filteredSpatialmatches = [];
-            const filteredLoaded = [];
-            loaded.forEach((feature, i) => {
-                if (!feature || !feature.properties) return;
-                const source = geocoder.indexes[feature.properties['carmen:index']];
-                if (source && filter.featureAllowed(source, feature, options)) {
-                    filteredSpatialmatches.push(spatialmatches[i]);
-                    filteredLoaded.push(loaded[i]);
-                }
-            });
-            verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options);
-        // No filters specified, go straight to verify
-        } else {
-            verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options);
-        }
-
-        return verified;
-    }
 }
 
+/**
+ * Once all features are loaded, filter, verify, and load contexts
+ *
+ * @param {Array<object>} loaded array of GeoJSON fetures
+ * @returns {Array} verified features
+ */
+function afterFeatures(loaded, options, query, geocoder, spatialmatches) {
+    let verified;
 
+    // Limit each feature based on whether it is allowed by types & stacks filters.
+    if (options.types || options.stacks || options.languageMode === 'strict') {
+        const filteredSpatialmatches = [];
+        const filteredLoaded = [];
+        loaded.forEach((feature, i) => {
+            if (!feature || !feature.properties) return;
+            const source = geocoder.indexes[feature.properties['carmen:index']];
+            if (source && filter.featureAllowed(source, feature, options)) {
+                filteredSpatialmatches.push(spatialmatches[i]);
+                filteredLoaded.push(loaded[i]);
+            }
+        });
+        verified = verifyFeatures(query, geocoder, filteredSpatialmatches, filteredLoaded, options);
+    // No filters specified, go straight to verify
+    } else {
+        verified = verifyFeatures(query, geocoder, spatialmatches, loaded, options);
+    }
+
+    return verified;
+}
 
 function verifyContextChunk(geocoder, verifiedContexts, sets, options, callback) {
     loadContexts(geocoder, verifiedContexts.batch, sets, options, (err, contextResults) => {

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -106,7 +106,7 @@ tape('verifymatch.verifyFeatures', (t) => {
         ]
     };
     doc.properties['carmen:types'] = ['address'];
-    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {});
+    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {}).verified;
     t.ok(filtered.length <= 10, 'limit dupe address numbers to 10');
     t.end();
 

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -106,7 +106,7 @@ tape('verifymatch.verifyFeatures', (t) => {
         ]
     };
     doc.properties['carmen:types'] = ['address'];
-    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {}).verified;
+    const filtered = verifymatch.verifyFeatures(query, geocoder, spatialmatches, [doc], {});
     t.ok(filtered.length <= 10, 'limit dupe address numbers to 10');
     t.end();
 


### PR DESCRIPTION
### Context
The previous verifymatch stack limit increase and context backfill PR #879 allows for better results, but also is a significant performance decrease. Instead of reading data for 50 features at the beginning of verifymatch, this adds a similar backfill mechanism for feature loading, where additional features (on top of the initial 20) are only loaded if there aren't a full 20 verified features after verifying the first batch. Features are then loaded as needed, until there are either 20 verified features, or there have been a total of 50 loaded.


### Summary of Changes
- [x] Adds feature backfill mechanism in verifymatch
- [x] Updates the spatialmatch stack limit constant to 40, the number most often actually passed in as an option
- [x] Adds a heuristic for stopping the feature backfill process if there is a reduction in spatialmatch relevance (see #887 )


### Next Steps
- [x] Clean up some stray todos
- [x] Make it clearer how and when the partialNumberLimit is applied


cc @mapbox/search
