### PR TITLE
Queens Address Matching

### DIFF
--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -15,6 +15,8 @@ const addressStyleVTable = {
     'queens': matchesQueensAddress
 };
 
+const addressOverideSet = new Set(['queens']);
+
 /**
  * Given a feature, calculate the desired properties for
  * an individual address using the carmen:addressprops key
@@ -69,7 +71,9 @@ function forward(feat, address, num = 10) {
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feat));
                 featureClone = properties(featureClone, addressIndex);
-                featureClone.properties['carmen:address'] = cluster[c_it][addressIndex];
+                if (addressOverideSet.has(addressStyle)) {
+                    featureClone.properties['carmen:address'] = cluster[c_it][addressIndex];
+                }
                 featureClone.geometry = {
                     type:'Point',
                     coordinates: [
@@ -113,7 +117,6 @@ function forwardPrefix(feature, address) {
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feature));
                 featureClone = properties(featureClone, addressIndex);
-                featureClone.properties['carmen:address'] = cluster[c_it][addressIndex];
                 matchedAddressFeatures.push({
                     idx: addressIndex,
                     number: cluster[c_it][addressIndex],

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -67,8 +67,8 @@ function forward(feat, address, num = 10) {
             const addressStyle = getAddressStyle(feat, addressIndex);
 
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
-                const featureClone = JSON.parse(JSON.stringify(feat));
-                properties(featureClone, addressIndex);
+                let featureClone = JSON.parse(JSON.stringify(feat));
+                featureClone = properties(featureClone, addressIndex);
                 featureClone.geometry = {
                     type:'Point',
                     coordinates: [
@@ -110,8 +110,8 @@ function forwardPrefix(feature, address) {
             const addressStyle = getAddressStyle(feature, addressIndex);
 
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
-                const featureClone = JSON.parse(JSON.stringify(feature));
-                properties(featureClone, addressIndex);
+                let featureClone = JSON.parse(JSON.stringify(feature));
+                featureClone = properties(featureClone, addressIndex);
                 matchedAddressFeatures.push({
                     idx: addressIndex,
                     number: cluster[c_it][addressIndex],

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -112,6 +112,7 @@ function forwardPrefix(feature, address) {
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feature));
                 featureClone = properties(featureClone, addressIndex);
+                featureClone.properties['carmen:address'] = cluster[c_it][addressIndex];
                 matchedAddressFeatures.push({
                     idx: addressIndex,
                     number: cluster[c_it][addressIndex],

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -55,11 +55,6 @@ function properties(feat, idx) {
 function forward(feat, address, num = 10) {
     if (!feat.geometry || feat.geometry.type !== 'GeometryCollection') return false;
 
-    let baseAddressStyle = defaultAddressStyle;
-    if (feat.properties['carmen:address_style']) {
-        baseAddressStyle = feat.properties['carmen:address_style'];
-    }
-
     const cluster = feat.properties['carmen:addressnumber'];
 
     const matchedAddressFeatures = [];
@@ -69,7 +64,7 @@ function forward(feat, address, num = 10) {
 
         for (let addressIndex = 0; addressIndex < cluster[c_it].length; addressIndex++) {
 
-            const addressStyle = getAddressStyle(baseAddressStyle, feat, addressIndex);
+            const addressStyle = getAddressStyle(feat, addressIndex);
 
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
                 const featureClone = JSON.parse(JSON.stringify(feat));
@@ -103,11 +98,6 @@ function forward(feat, address, num = 10) {
 function forwardPrefix(feature, address) {
     if (!feature.geometry || feature.geometry.type !== 'GeometryCollection') return false;
 
-    let baseAddressStyle = defaultAddressStyle;
-    if (feature.properties['carmen:address_style']) {
-        baseAddressStyle = feature.properties['carmen:address_style'];
-    }
-
     const cluster = feature.properties['carmen:addressnumber'];
 
     const matchedAddressFeatures = [];
@@ -117,7 +107,7 @@ function forwardPrefix(feature, address) {
 
         for (let addressIndex = 0; addressIndex < cluster[c_it].length; addressIndex++) {
 
-            const addressStyle = getAddressStyle(baseAddressStyle, feature, addressIndex);
+            const addressStyle = getAddressStyle(feature, addressIndex);
 
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
                 const featureClone = JSON.parse(JSON.stringify(feature));
@@ -241,13 +231,15 @@ function reverse(feat,query) {
 
 /**
  * Returns the address style for a address index in a feature
- * @param {string} baseAddressStyle - Default address style for feature
  * @param {Object} feature - Feature
  * @param {Number} addressIndex - Index of of 'carmen:addressnum' that the style applies to
  * @returns {string} addresStyle - The style of this particular address
  */
-function getAddressStyle(baseAddressStyle, feature, addressIndex) {
-    let addressStyle = baseAddressStyle;
+function getAddressStyle(feature, addressIndex) {
+    let addressStyle = defaultAddressStyle;
+    if (feature.properties['carmen:address_style']) {
+        addressStyle = feature.properties['carmen:address_style'];
+    }
     if (feature.properties['carmen:addressprops'] && feature.properties['carmen:addressprops']['carmen:address_style']
         && addressIndex in feature.properties['carmen:addressprops']['carmen:address_style']) {
         addressStyle = feature.properties['carmen:addressprops']['carmen:address_style'][addressIndex];
@@ -290,12 +282,13 @@ function matchesStandardAddress(queryAddress, featureAddress, autocomplete = fal
     const numericMatch = typeof queryAddress === 'string'
         ? queryAddress.replace(/\D/, '')
         : queryAddress.toString();
+    const localFeatureAddress = featureAddress.toString();
     if (autocomplete) {
-        return featureAddress.toString().startsWith(rawMatch)
-            || featureAddress.toString().startsWith(numericMatch);
+        return localFeatureAddress.startsWith(rawMatch)
+            || localFeatureAddress.startsWith(numericMatch);
     }
-    return (featureAddress === rawMatch
-        || featureAddress === numericMatch);
+    return (localFeatureAddress === rawMatch
+        || localFeatureAddress === numericMatch);
 }
 
 /**
@@ -322,12 +315,13 @@ function matchesQueensAddress(queryAddress, featureAddress, autocomplete = false
         ? queryAddress.replace(/[^\d]/, '')
         : queryAddress.toString();
     const containsHyphen = queryAddress.includes('-');
+    const localFeatureAddress = featureAddress.toString();
     if (autocomplete) {
-        return featureAddress.toString().startsWith(rawMatch)
-            || featureAddress.toString().startsWith(hyphenatedMatch)
-            || (featureAddress.toString().startsWith(numericMatch) && !containsHyphen);
+        return localFeatureAddress.startsWith(rawMatch)
+            || localFeatureAddress.startsWith(hyphenatedMatch)
+            || (localFeatureAddress.startsWith(numericMatch) && !containsHyphen);
     }
-    return (featureAddress === rawMatch
-        || featureAddress === hyphenatedMatch
-        || (featureAddress === numericMatch && !containsHyphen));
+    return (localFeatureAddress === rawMatch
+        || localFeatureAddress === hyphenatedMatch
+        || (localFeatureAddress === numericMatch && !containsHyphen));
 }

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -269,7 +269,7 @@ function getAddressStyle(baseAddressStyle, feature, addressIndex) {
  * @returns {boolean} - True if a match
  */
 function matchesStyle(queryAddress, featureAddress, style, autocomplete = false) {
-    return addressStyleVTable[style](queryAddress, featureAddress, true);
+    return addressStyleVTable[style](queryAddress, featureAddress, autocomplete);
 }
 
 /**

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -69,6 +69,7 @@ function forward(feat, address, num = 10) {
             if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feat));
                 featureClone = properties(featureClone, addressIndex);
+                featureClone.properties['carmen:address'] = cluster[c_it][addressIndex];
                 featureClone.geometry = {
                     type:'Point',
                     coordinates: [

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -15,6 +15,11 @@ const addressStyleVTable = {
     'queens': matchesQueensAddress
 };
 
+const addressMatchStringVTable = {
+    'standard': generateStandardAddressMatchStrings,
+    'queens': generateQueensAddressMatchStrings
+};
+
 const addressOverideSet = new Set(['queens']);
 
 /**
@@ -50,7 +55,6 @@ function properties(feat, idx) {
  * @param {Object} feat GeoJSON Feature to derive individual address from
  * @param {String|number} address User's queried address number
  * @param {number} num Max number of address features to potentially return (default 10)
- * @param {boolean} autocomplete Whether or not autocomplete is enabled
  *
  * @return {Array|false} Array of potential address feats or false
  */
@@ -58,6 +62,10 @@ function forward(feat, address, num = 10) {
     if (!feat.geometry || feat.geometry.type !== 'GeometryCollection') return false;
 
     const cluster = feat.properties['carmen:addressnumber'];
+
+    const addressStyles = feat.properties['carmen:address_styles'] ? feat.properties['carmen:address_styles'] : ['standard'];
+
+    const queryMatchStrings = generateMatchStrings(address, addressStyles);
 
     const matchedAddressFeatures = [];
 
@@ -68,7 +76,9 @@ function forward(feat, address, num = 10) {
 
             const addressStyle = getAddressStyle(feat, addressIndex);
 
-            if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
+            const featureMatchStrings = generateMatchStrings(cluster[c_it][addressIndex], [addressStyle]);
+
+            if (matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feat));
                 featureClone = properties(featureClone, addressIndex);
                 if (addressOverideSet.has(addressStyle)) {
@@ -105,6 +115,10 @@ function forwardPrefix(feature, address) {
 
     const cluster = feature.properties['carmen:addressnumber'];
 
+    const addressStyles = feature.properties['carmen:address_styles'] ? feature.properties['carmen:address_styles'] : ['standard'];
+
+    const queryMatchStrings = generateMatchStrings(address, addressStyles);
+
     const matchedAddressFeatures = [];
 
     for (let c_it = 0; c_it < cluster.length; c_it++) {
@@ -114,7 +128,9 @@ function forwardPrefix(feature, address) {
 
             const addressStyle = getAddressStyle(feature, addressIndex);
 
-            if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
+            const featureMatchStrings = generateMatchStrings(cluster[c_it][addressIndex], [addressStyle]);
+
+            if (matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
                 let featureClone = JSON.parse(JSON.stringify(feature));
                 featureClone = properties(featureClone, addressIndex);
                 matchedAddressFeatures.push({
@@ -256,98 +272,112 @@ function getAddressStyle(feature, addressIndex) {
 }
 
 /**
+ * Generate Address Style dependent match strings
+ * @param {String} address - Address to generate match strings from
+ * @param {Array<String>} addressStyles - Address styles to generate match strings for
+ * @returns {Map<String, Map<String, String>>} - Mapping from address styles to match strings
+ */
+function generateMatchStrings(address, addressStyles) {
+    const matchStringMap = new Map();
+    addressStyles.forEach((style) => matchStringMap.set(style, addressMatchStringVTable[style](address)));
+    return matchStringMap;
+}
+
+/**
+ * Generates Address match strings for Standard addresses
+ * @param {String} address - Address to generate match strings from
+ * @returns {Map<String, String>} - Mapping from match string name to match string
+ */
+function generateStandardAddressMatchStrings(address) {
+    // A raw string version of the query
+    const rawAddress = typeof address === 'string'
+        ? address.toLowerCase()
+        : address.toString();
+    // A numeric match version of the query
+    const numericAddress = typeof address === 'string'
+        ? address.replace(/[^\d]/, '')
+        : address.toString();
+    return new Map([
+        ['rawAddress', rawAddress],
+        ['numericAddress', numericAddress]
+    ]);
+}
+
+/**
+ * Generates Address match strings for Queens addresses
+ * @param {String} address - Address to generate match strings from
+ * @returns {Map<String, String>} - Mapping from match string name to match string
+ */
+function generateQueensAddressMatchStrings(address) {
+    // A raw string version of the query
+    const rawAddress = typeof address === 'string'
+        ? address.toLowerCase()
+        : address.toString();
+    // A hyphenated numeric version of the query
+    const hyphenatedAddress = typeof address === 'string'
+        ? address.replace(/[^\d-]/, '')
+        : address.toString();
+    // A numeric match version of the query
+    const numericAddress = typeof address === 'string'
+        ? address.replace(/[^\d]/, '')
+        : address.toString();
+    // Boolean for Having a Hyphen
+    const containsHyphen = address.includes('-');
+    return new Map([
+        ['rawAddress', rawAddress],
+        ['numericAddress', numericAddress],
+        ['hyphenatedAddress', hyphenatedAddress],
+        ['containsHyphen', containsHyphen]
+    ]);
+}
+
+/**
  * matchesStyle is a wrapper around the VTable lookup for the various
  * address style matchers.  The exposure like this is driven primarily
  * for testing purposes.
- * @param {string|number} queryAddress - Address number provided by the query
- * @param {string|number} featureAddress - Address number in the address cluster
+ * @param {Map<String, Map<String, String>>} queryMatchStringMaps - Mapping from match string name to match string for the query
+ * @param {Map<String, Map<String, String>>} featureMatchStringMaps - Mapping from match string name to match string for the feature
  * @param {string} style - What address style is to be called
- * @param {boolean} autocomplete - Whether to match on a partial result
+ * @param {boolean} prefixMatch - Whether to match on a partial result
  * @returns {boolean} - True if a match
  */
-function matchesStyle(queryAddress, featureAddress, style, autocomplete = false) {
-    return addressStyleVTable[style](queryAddress, featureAddress, autocomplete);
+function matchesStyle(queryMatchStringMaps, featureMatchStringMaps, style, prefixMatch = false) {
+    return addressStyleVTable[style](queryMatchStringMaps.get(style), featureMatchStringMaps.get(style), prefixMatch);
 }
 
 /**
  * AddressMatcher for Standard Address Number Styles
  * This will match either the raw string or a numeric only version of the address number
- * @param {string|number} queryAddress - Address number provided by the query
- * @param {string|number} featureAddress - Address number in the address cluster
- * @param {boolean} autocomplete - Whether to match on a partial result
+ * @param {Map<String, String>} queryMatchStrings - Mapping from match string name to match string for the query
+ * @param {Map<String, String>} featureMatchStrings - Mapping from match string name to match string for the feature
+ * @param {boolean} prefixMatch - Whether to match on a partial result
  * @returns {boolean} - True if a match
  */
-function matchesStandardAddress(queryAddress, featureAddress, autocomplete = false) {
-    // A raw string version of the query
-    const rawQuery = typeof queryAddress === 'string'
-        ? queryAddress.toLowerCase()
-        : queryAddress.toString();
-    // A numeric match version of the query
-    const numericQuery = typeof queryAddress === 'string'
-        ? queryAddress.replace(/[^\d]/, '')
-        : queryAddress.toString();
-
-    // A raw string version of the query
-    const rawFeature = typeof featureAddress === 'string'
-        ? featureAddress.toLowerCase()
-        : featureAddress.toString();
-    // A numeric match version of the query
-    const numericFeature = typeof featureAddress === 'string'
-        ? featureAddress.replace(/[^\d]/, '')
-        : featureAddress.toString();
-
-    if (autocomplete) {
-        return rawFeature.startsWith(rawQuery)
-            || numericFeature.startsWith(numericQuery);
+function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
+    if (prefixMatch) {
+        return featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))
+            || featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('numericAddress'));
     }
-    return (rawFeature === rawQuery
-        || numericFeature === numericQuery);
+    return (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')
+        || featureMatchStrings.get('rawAddress') === queryMatchStrings.get('numericAddress'));
 }
 
 /**
  * AddressMatcher for Queens Address Number Styles
  * This will match the raw string or the hyphenated Queens style number
  * If no hyphen is in the query, it will fallback to a numeric match
- * @param {string|number} queryAddress - Address number provided by the query
- * @param {string|number} featureAddress - Address number in the address cluster
- * @param {boolean} autocomplete - Whether to match on a partial result
+ * @param {Map<String, String>} queryMatchStrings - Mapping from match string name to match string for the query
+ * @param {Map<String, String>} featureMatchStrings - Mapping from match string name to match string for the feature
+ * @param {boolean} prefixMatch - Whether to match on a partial result
  * @returns {boolean} - True if a match
  */
-function matchesQueensAddress(queryAddress, featureAddress, autocomplete = false) {
-    // A raw string version of the query
-    const rawQuery = typeof queryAddress === 'string'
-        ? queryAddress.toLowerCase()
-        : queryAddress.toString();
-    // A hyphenated numeric version of the query
-    const hyphenatedQuery = typeof queryAddress === 'string'
-        ? queryAddress.replace(/[^\d-]/, '')
-        : queryAddress.toString();
-    // A numeric match version of the query
-    const numericQuery = typeof queryAddress === 'string'
-        ? queryAddress.replace(/[^\d]/, '')
-        : queryAddress.toString();
-
-    // A raw string version of the query
-    const rawFeature = typeof featureAddress === 'string'
-        ? featureAddress.toLowerCase()
-        : featureAddress.toString();
-    // A hyphenated numeric version of the query
-    const hyphenatedFeature = typeof featureAddress === 'string'
-        ? featureAddress.replace(/[^\d-]/, '')
-        : featureAddress.toString();
-    // A numeric version of the feature
-    const numericFeature = typeof featureAddress === 'string'
-        ? featureAddress.replace(/[^\d]/, '')
-        : featureAddress.toString();
-
-    const containsHyphen = queryAddress.includes('-');
-
-    if (autocomplete) {
-        return rawFeature.startsWith(rawQuery)
-            || hyphenatedFeature.startsWith(hyphenatedQuery)
-            || (numericFeature.startsWith(numericQuery) && !containsHyphen);
+function matchesQueensAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
+    if (prefixMatch) {
+        return featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))
+            || featureMatchStrings.get('hyphenatedAddress').startsWith(queryMatchStrings.get('hyphenatedAddress'))
+            || (featureMatchStrings.get('numericAddress').startsWith(queryMatchStrings.get('numericAddress')) && !queryMatchStrings.get('containsHyphen'));
     }
-    return (rawFeature === rawQuery
-        || hyphenatedFeature === hyphenatedQuery
-        || (numericFeature === numericQuery && !containsHyphen));
+    return (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')
+        || featureMatchStrings.get('hyphenatedAddress') === queryMatchStrings.get('hyphenatedAddress'))
+        || (featureMatchStrings.get('numericAddress') === queryMatchStrings.get('numericAddress') && !queryMatchStrings.get('containsHyphen'));
 }

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -3,13 +3,16 @@ module.exports.forward = forward;
 module.exports.forwardPrefix = forwardPrefix;
 module.exports.forwardPrefixFiltered = forwardPrefixFiltered;
 module.exports.reverse = reverse;
+module.exports.getAddressStyle = getAddressStyle;
+module.exports.matchesStyle = matchesStyle;
 
 const proximity = require('../util/proximity');
 
 const defaultAddressStyle = 'standard';
 
-const addressStyleVtable = {
-    'standard': forwardStandard
+const addressStyleVTable = {
+    'standard': matchesStandardAddress,
+    'queens': matchesQueensAddress
 };
 
 /**
@@ -18,7 +21,7 @@ const addressStyleVtable = {
  *
  * @param {Object} feat GeoJSON Feature
  * @param {Number} idx Address Point IDX to calculate properties for
- * @returns Object GeoJSON Feature
+ * @returns {Object} GeoJSON Feature
  */
 function properties(feat, idx) {
     if (!feat.properties['carmen:addressprops']) return feat;
@@ -45,13 +48,14 @@ function properties(feat, idx) {
  * @param {Object} feat GeoJSON Feature to derive individual address from
  * @param {String|number} address User's queried address number
  * @param {number} num Max number of address features to potentially return (default 10)
+ * @param {boolean} autocomplete Whether or not autocomplete is enabled
  *
  * @return {Array|false} Array of potential address feats or false
  */
 function forward(feat, address, num = 10) {
-    let baseAddressStyle = defaultAddressStyle;
     if (!feat.geometry || feat.geometry.type !== 'GeometryCollection') return false;
 
+    let baseAddressStyle = defaultAddressStyle;
     if (feat.properties['carmen:address_style']) {
         baseAddressStyle = feat.properties['carmen:address_style'];
     }
@@ -64,15 +68,10 @@ function forward(feat, address, num = 10) {
         if (!cluster[c_it]) continue;
 
         for (let addressIndex = 0; addressIndex < cluster[c_it].length; addressIndex++) {
-            let addressStyle = baseAddressStyle;
-            if (feat.properties['carmen:addressprops'] && feat.properties['carmen:addressprops']['carmen:address_style']
-                && addressIndex in feat.properties['carmen:addressprops']['carmen:address_style']) {
-                addressStyle = feat.properties['carmen:addressprops']['carmen:address_style'][addressIndex];
-            }
-            if (!(addressStyle in addressStyleVtable)) {
-                addressStyle = defaultAddressStyle;
-            }
-            if (addressStyleVtable[addressStyle](address, cluster[c_it][addressIndex]) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
+
+            const addressStyle = getAddressStyle(baseAddressStyle, feat, addressIndex);
+
+            if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
                 const featureClone = JSON.parse(JSON.stringify(feat));
                 properties(featureClone, addressIndex);
                 featureClone.geometry = {
@@ -92,21 +91,6 @@ function forward(feat, address, num = 10) {
     return matchedAddressFeatures.length ? matchedAddressFeatures : false;
 }
 
-
-/**
- * AddressMatcher for Standard Address Number Styles
- * @param {string|number} queryAddress - Address number provided by the query
- * @param {string|number} featureAddress - Address number in the address cluster
- * @returns {boolean} - True if a match
- */
-function forwardStandard(queryAddress, featureAddress) {
-
-    // Check both forms of the address (raw, number-parsed)
-    const a1 = typeof queryAddress === 'string' ? queryAddress.toLowerCase() : queryAddress;
-    const a2 = typeof queryAddress === 'string' ? queryAddress.replace(/\D/, '') : queryAddress;
-    return (featureAddress === a1 || featureAddress === a2);
-}
-
 /**
  * Given an address cluster and a house number prefix, try and find all house
  * numbers within the cluster that start with that prefix, and and return an
@@ -119,39 +103,39 @@ function forwardStandard(queryAddress, featureAddress) {
 function forwardPrefix(feature, address) {
     if (!feature.geometry || feature.geometry.type !== 'GeometryCollection') return false;
 
-    // Check both forms of the address (raw, number-parsed)
-    const a1 = typeof address === 'string' ? address.toLowerCase() : ('' + address).toLowerCase();
+    let baseAddressStyle = defaultAddressStyle;
+    if (feature.properties['carmen:address_style']) {
+        baseAddressStyle = feature.properties['carmen:address_style'];
+    }
 
     const cluster = feature.properties['carmen:addressnumber'];
+
+    const matchedAddressFeatures = [];
 
     for (let c_it = 0; c_it < cluster.length; c_it++) {
         if (!cluster[c_it]) continue;
 
-        // this code identifies all the indexes of cluster[c_it] that start with a1
-        // using a similar strategy as above in forward, but with matching prefixes
-        // instead of exact numbers
-        const a_index = cluster[c_it].reduce((a, e, i) => {
-            const element = typeof e === 'string' ? e : ('' + e);
-            return element.startsWith(a1) ? a.concat(i) : a;
-        }, []);
+        for (let addressIndex = 0; addressIndex < cluster[c_it].length; addressIndex++) {
 
-        // Check if cluster is pt geom
-        if (a_index.length && feature.geometry.geometries[c_it].type === 'MultiPoint') {
-            return a_index.map((idx) => {
-                return {
-                    idx: idx,
-                    number: cluster[c_it][idx],
-                    numberAsInt: parseInt(cluster[c_it][idx], 10),
+            const addressStyle = getAddressStyle(baseAddressStyle, feature, addressIndex);
+
+            if (matchesStyle(address, cluster[c_it][addressIndex], addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
+                const featureClone = JSON.parse(JSON.stringify(feature));
+                properties(featureClone, addressIndex);
+                matchedAddressFeatures.push({
+                    idx: addressIndex,
+                    number: cluster[c_it][addressIndex],
+                    numberAsInt: parseInt(cluster[c_it][addressIndex], 10),
                     geometry: {
-                        type:'Point',
-                        coordinates: feature.geometry.geometries[c_it].coordinates[idx]
+                        type: 'Point',
+                        coordinates: feature.geometry.geometries[c_it].coordinates[addressIndex]
                     }
-                };
-            });
+                });
+            }
         }
     }
 
-    return [];
+    return matchedAddressFeatures;
 }
 
 /**
@@ -167,7 +151,7 @@ function forwardPrefix(feature, address) {
 function forwardPrefixFiltered(feat, address, options, cover) {
     const matchingAddressPoints = forwardPrefix(feat, address);
 
-    if (matchingAddressPoints.length > 0) {
+    if (matchingAddressPoints && matchingAddressPoints.length > 0) {
         // now we have a bunch of points that might be the right answer, but let's just pick one
         matchingAddressPoints.sort((a, b) => a.numberAsInt - b.numberAsInt);
 
@@ -253,4 +237,97 @@ function reverse(feat,query) {
     feat.properties['carmen:address'] = closest.address;
 
     return feat;
+}
+
+/**
+ * Returns the address style for a address index in a feature
+ * @param {string} baseAddressStyle - Default address style for feature
+ * @param {Object} feature - Feature
+ * @param {Number} addressIndex - Index of of 'carmen:addressnum' that the style applies to
+ * @returns {string} addresStyle - The style of this particular address
+ */
+function getAddressStyle(baseAddressStyle, feature, addressIndex) {
+    let addressStyle = baseAddressStyle;
+    if (feature.properties['carmen:addressprops'] && feature.properties['carmen:addressprops']['carmen:address_style']
+        && addressIndex in feature.properties['carmen:addressprops']['carmen:address_style']) {
+        addressStyle = feature.properties['carmen:addressprops']['carmen:address_style'][addressIndex];
+    }
+    if (!(addressStyle in addressStyleVTable)) {
+        addressStyle = defaultAddressStyle;
+    }
+    return addressStyle;
+}
+
+/**
+ * matchesStyle is a wrapper around the VTable lookup for the various
+ * address style matchers.  The exposure like this is driven primarily
+ * for testing purposes.
+ * @param {string|number} queryAddress - Address number provided by the query
+ * @param {string|number} featureAddress - Address number in the address cluster
+ * @param {string} style - What address style is to be called
+ * @param {boolean} autocomplete - Whether to match on a partial result
+ * @returns {boolean} - True if a match
+ */
+function matchesStyle(queryAddress, featureAddress, style, autocomplete = false) {
+    return addressStyleVTable[style](queryAddress, featureAddress, true);
+}
+
+/**
+ * AddressMatcher for Standard Address Number Styles
+ * This will match either the raw string or a numeric only version of the address number
+ * @param {string|number} queryAddress - Address number provided by the query
+ * @param {string|number} featureAddress - Address number in the address cluster
+ * @param {boolean} autocomplete - Whether to match on a partial result
+ * @returns {boolean} - True if a match
+ */
+function matchesStandardAddress(queryAddress, featureAddress, autocomplete = false) {
+
+    // A raw string match string
+    const rawMatch = typeof queryAddress === 'string'
+        ? queryAddress.toLowerCase()
+        : queryAddress.toString();
+    // A numeric match string
+    const numericMatch = typeof queryAddress === 'string'
+        ? queryAddress.replace(/\D/, '')
+        : queryAddress.toString();
+    if (autocomplete) {
+        return featureAddress.toString().startsWith(rawMatch)
+            || featureAddress.toString().startsWith(numericMatch);
+    }
+    return (featureAddress === rawMatch
+        || featureAddress === numericMatch);
+}
+
+/**
+ * AddressMatcher for Queens Address Number Styles
+ * This will match the raw string or the hyphenated Queens style number
+ * If no hyphen is in the query, it will fallback to a numeric match
+ * @param {string|number} queryAddress - Address number provided by the query
+ * @param {string|number} featureAddress - Address number in the address cluster
+ * @param {boolean} autocomplete - Whether to match on a partial result
+ * @returns {boolean} - True if a match
+ */
+function matchesQueensAddress(queryAddress, featureAddress, autocomplete = false) {
+
+    // A raw string match string
+    const rawMatch = typeof queryAddress === 'string'
+        ? queryAddress.toLowerCase()
+        : queryAddress.toString();
+    // A hyphenated numeric match string
+    const hyphenatedMatch = typeof queryAddress === 'string'
+        ? queryAddress.replace(/[^\d-]/, '')
+        : queryAddress.toString();
+    // A numeric match string
+    const numericMatch = typeof queryAddress === 'string'
+        ? queryAddress.replace(/[^\d]/, '')
+        : queryAddress.toString();
+    const containsHyphen = queryAddress.includes('-');
+    if (autocomplete) {
+        return featureAddress.toString().startsWith(rawMatch)
+            || featureAddress.toString().startsWith(hyphenatedMatch)
+            || (featureAddress.toString().startsWith(numericMatch) && !containsHyphen);
+    }
+    return (featureAddress === rawMatch
+        || featureAddress === hyphenatedMatch
+        || (featureAddress === numericMatch && !containsHyphen));
 }

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -273,22 +273,30 @@ function matchesStyle(queryAddress, featureAddress, style, autocomplete = false)
  * @returns {boolean} - True if a match
  */
 function matchesStandardAddress(queryAddress, featureAddress, autocomplete = false) {
-
-    // A raw string match string
-    const rawMatch = typeof queryAddress === 'string'
+    // A raw string version of the query
+    const rawQuery = typeof queryAddress === 'string'
         ? queryAddress.toLowerCase()
         : queryAddress.toString();
-    // A numeric match string
-    const numericMatch = typeof queryAddress === 'string'
-        ? queryAddress.replace(/\D/, '')
+    // A numeric match version of the query
+    const numericQuery = typeof queryAddress === 'string'
+        ? queryAddress.replace(/[^\d]/, '')
         : queryAddress.toString();
-    const localFeatureAddress = featureAddress.toString();
+
+    // A raw string version of the query
+    const rawFeature = typeof featureAddress === 'string'
+        ? featureAddress.toLowerCase()
+        : featureAddress.toString();
+    // A numeric match version of the query
+    const numericFeature = typeof featureAddress === 'string'
+        ? featureAddress.replace(/[^\d]/, '')
+        : featureAddress.toString();
+
     if (autocomplete) {
-        return localFeatureAddress.startsWith(rawMatch)
-            || localFeatureAddress.startsWith(numericMatch);
+        return rawFeature.startsWith(rawQuery)
+            || numericFeature.startsWith(numericQuery);
     }
-    return (localFeatureAddress === rawMatch
-        || localFeatureAddress === numericMatch);
+    return (rawFeature === rawQuery
+        || numericFeature === numericQuery);
 }
 
 /**
@@ -301,27 +309,40 @@ function matchesStandardAddress(queryAddress, featureAddress, autocomplete = fal
  * @returns {boolean} - True if a match
  */
 function matchesQueensAddress(queryAddress, featureAddress, autocomplete = false) {
-
-    // A raw string match string
-    const rawMatch = typeof queryAddress === 'string'
+    // A raw string version of the query
+    const rawQuery = typeof queryAddress === 'string'
         ? queryAddress.toLowerCase()
         : queryAddress.toString();
-    // A hyphenated numeric match string
-    const hyphenatedMatch = typeof queryAddress === 'string'
+    // A hyphenated numeric version of the query
+    const hyphenatedQuery = typeof queryAddress === 'string'
         ? queryAddress.replace(/[^\d-]/, '')
         : queryAddress.toString();
-    // A numeric match string
-    const numericMatch = typeof queryAddress === 'string'
+    // A numeric match version of the query
+    const numericQuery = typeof queryAddress === 'string'
         ? queryAddress.replace(/[^\d]/, '')
         : queryAddress.toString();
+
+    // A raw string version of the query
+    const rawFeature = typeof featureAddress === 'string'
+        ? featureAddress.toLowerCase()
+        : featureAddress.toString();
+    // A hyphenated numeric version of the query
+    const hyphenatedFeature = typeof featureAddress === 'string'
+        ? featureAddress.replace(/[^\d-]/, '')
+        : featureAddress.toString();
+    // A numeric version of the feature
+    const numericFeature = typeof featureAddress === 'string'
+        ? featureAddress.replace(/[^\d]/, '')
+        : featureAddress.toString();
+
     const containsHyphen = queryAddress.includes('-');
-    const localFeatureAddress = featureAddress.toString();
+
     if (autocomplete) {
-        return localFeatureAddress.startsWith(rawMatch)
-            || localFeatureAddress.startsWith(hyphenatedMatch)
-            || (localFeatureAddress.startsWith(numericMatch) && !containsHyphen);
+        return rawFeature.startsWith(rawQuery)
+            || hyphenatedFeature.startsWith(hyphenatedQuery)
+            || (numericFeature.startsWith(numericQuery) && !containsHyphen);
     }
-    return (localFeatureAddress === rawMatch
-        || localFeatureAddress === hyphenatedMatch
-        || (localFeatureAddress === numericMatch && !containsHyphen));
+    return (rawFeature === rawQuery
+        || hyphenatedFeature === hyphenatedQuery
+        || (numericFeature === numericQuery && !containsHyphen));
 }

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -6,6 +6,12 @@ module.exports.reverse = reverse;
 
 const proximity = require('../util/proximity');
 
+const defaultAddressStyle = 'standard';
+
+const addressStyleVtable = {
+    'standard': forwardStandard
+};
+
 /**
  * Given a feature, calculate the desired properties for
  * an individual address using the carmen:addressprops key
@@ -43,46 +49,62 @@ function properties(feat, idx) {
  * @return {Array|false} Array of potential address feats or false
  */
 function forward(feat, address, num = 10) {
+    let baseAddressStyle = defaultAddressStyle;
     if (!feat.geometry || feat.geometry.type !== 'GeometryCollection') return false;
 
-    // Check both forms of the address (raw, number-parsed)
-    const a1 = typeof address === 'string' ? address.toLowerCase() : address;
-    const a2 = typeof address === 'string' ? address.replace(/\D/, '') : address;
+    if (feat.properties['carmen:address_style']) {
+        baseAddressStyle = feat.properties['carmen:address_style'];
+    }
 
     const cluster = feat.properties['carmen:addressnumber'];
+
+    const matchedAddressFeatures = [];
 
     for (let c_it = 0; c_it < cluster.length; c_it++) {
         if (!cluster[c_it]) continue;
 
-        // this code identifies all the indexes of cluster[c_it] that have a1 or, if that fails, a2
-        // equivalent approximately to python [i for i,e in enumerate(cluster[c_it]) if e == a1]
-        // expressed as a reduction starting with an empty array `a` that, if the value e at each step
-        // `e` is equal to `a1`, gets the current index `i` appended to it
-        // more info at https://stackoverflow.com/questions/20798477/how-to-find-index-of-all-occurrences-of-element-in-array#comment69744472_20798754
-        let a_index = cluster[c_it].reduce((a, e, i) => { return (e === a1) ? a.concat(i) : a; }, []);
-        if (!a_index.length) a_index = cluster[c_it].reduce((a, e, i) => { return (e === a2) ? a.concat(i) : a; }, []);
-
-        // Check is cluster is pt geom
-        if (a_index.length && feat.geometry.geometries[c_it].type === 'MultiPoint') {
-            return a_index.slice(0, num).map((idx) => {
-                const feat_clone = JSON.parse(JSON.stringify(feat));
-
-                properties(feat_clone, idx);
-
-                feat_clone.geometry = {
+        for (let addressIndex = 0; addressIndex < cluster[c_it].length; addressIndex++) {
+            let addressStyle = baseAddressStyle;
+            if (feat.properties['carmen:addressprops'] && feat.properties['carmen:addressprops']['carmen:address_style']
+                && addressIndex in feat.properties['carmen:addressprops']['carmen:address_style']) {
+                addressStyle = feat.properties['carmen:addressprops']['carmen:address_style'][addressIndex];
+            }
+            if (!(addressStyle in addressStyleVtable)) {
+                addressStyle = defaultAddressStyle;
+            }
+            if (addressStyleVtable[addressStyle](address, cluster[c_it][addressIndex]) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
+                const featureClone = JSON.parse(JSON.stringify(feat));
+                properties(featureClone, addressIndex);
+                featureClone.geometry = {
                     type:'Point',
                     coordinates: [
-                        Math.round(feat.geometry.geometries[c_it].coordinates[idx][0] * 1e6) / 1e6,
-                        Math.round(feat.geometry.geometries[c_it].coordinates[idx][1] * 1e6) / 1e6
+                        Math.round(feat.geometry.geometries[c_it].coordinates[addressIndex][0] * 1e6) / 1e6,
+                        Math.round(feat.geometry.geometries[c_it].coordinates[addressIndex][1] * 1e6) / 1e6
                     ]
                 };
-
-                return feat_clone;
-            });
+                matchedAddressFeatures.push(featureClone);
+            }
+            if (matchedAddressFeatures.length >= num) {
+                return matchedAddressFeatures;
+            }
         }
     }
+    return matchedAddressFeatures.length ? matchedAddressFeatures : false;
+}
 
-    return false;
+
+/**
+ * AddressMatcher for Standard Address Number Styles
+ * @param {string|number} queryAddress - Address number provided by the query
+ * @param {string|number} featureAddress - Address number in the address cluster
+ * @returns {boolean} - True if a match
+ */
+function forwardStandard(queryAddress, featureAddress) {
+
+    // Check both forms of the address (raw, number-parsed)
+    const a1 = typeof queryAddress === 'string' ? queryAddress.toLowerCase() : queryAddress;
+    const a2 = typeof queryAddress === 'string' ? queryAddress.replace(/\D/, '') : queryAddress;
+    return (featureAddress === a1 || featureAddress === a2);
 }
 
 /**

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -288,6 +288,7 @@ function storableProperties(properties, type) {
             case 'carmen:geocoder_stack':
                 storable[k] = properties[k];
                 break;
+            case 'carmen:address_style':
             case 'carmen:addressprops':
             case 'carmen:addressnumber':
             case 'carmen:intersections':

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -288,9 +288,10 @@ function storableProperties(properties, type) {
             case 'carmen:geocoder_stack':
                 storable[k] = properties[k];
                 break;
-            case 'carmen:address_style':
             case 'carmen:addressprops':
             case 'carmen:addressnumber':
+            case 'carmen:address_style':
+            case 'carmen:address_styles':
             case 'carmen:intersections':
             case 'carmen:rangetype':
             case 'carmen:parityl':

--- a/test/unit/geocoder/address.properties.test.js
+++ b/test/unit/geocoder/address.properties.test.js
@@ -242,3 +242,111 @@ test('reverse: override property', (t) => {
 
     t.end();
 });
+
+test('getAddressStyle', (t) => {
+    const standardStyle = 'standard';
+    const queensStyle = 'queens';
+    const defaultStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:addressprops': {
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const standardStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': standardStyle,
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                }
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const queensStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': queensStyle,
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                    1: standardStyle,
+                    '2': 'invalid'
+                }
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const invalidStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': 'invalid'
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    t.deepEqual(
+        cluster.getAddressStyle(defaultStyleFeature, 0),
+        standardStyle,
+        'Default to standard'
+    );
+    t.deepEqual(
+        cluster.getAddressStyle(standardStyleFeature, 0),
+        standardStyle,
+        'Specified standard'
+    );
+    t.deepEqual(
+        cluster.getAddressStyle(queensStyleFeature, 0),
+        queensStyle,
+        'Specified queens'
+    );
+    t.deepEqual(
+        cluster.getAddressStyle(invalidStyleFeature, 0),
+        standardStyle,
+        'Unrecognized defaults to standard'
+    );
+    t.deepEqual(
+        cluster.getAddressStyle(queensStyleFeature, 1),
+        standardStyle,
+        'Override feature default'
+    );
+    t.deepEqual(
+        cluster.getAddressStyle(queensStyleFeature, 2),
+        standardStyle,
+        'Unrecognized defaults to standard'
+    );
+    t.end();
+});
+

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -924,6 +924,7 @@ test('queens', (t) => {
                 accuracy: 'building',
                 'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
                 'carmen:address_style': queensStyle,
+                'carmen:address': '10-10',
                 'carmen:addressprops': {
                     'carmen:address_style': {
                         0: queensStyle,

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -891,33 +891,19 @@ test('prefix', (t) => {
     t.end();
 });
 
-test('getAddressStyle', (t) => {
+test('queens', (t) => {
     const standardStyle = 'standard';
     const queensStyle = 'queens';
-    const defaultStyleFeature = {
+    const feature = {
         type: 'Feature',
         properties: {
             accuracy: 'building',
-            'carmen:addressnumber': [[100, 200, 300]],
-            'carmen:addressprops': {
-            }
-        },
-        geometry: {
-            type: 'GeometryCollection',
-            geometries: [{
-                type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3]]
-            }]
-        }
-    };
-    const standardStyleFeature = {
-        type: 'Feature',
-        properties: {
-            accuracy: 'building',
-            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
             'carmen:address_style': standardStyle,
             'carmen:addressprops': {
                 'carmen:address_style': {
+                    0: queensStyle,
+                    2: queensStyle
                 }
             }
         },
@@ -925,75 +911,114 @@ test('getAddressStyle', (t) => {
             type: 'GeometryCollection',
             geometries: [{
                 type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3]]
+                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6]]
             }]
         }
     };
-    const queensStyleFeature = {
-        type: 'Feature',
-        properties: {
-            accuracy: 'building',
-            'carmen:addressnumber': [[100, 200, 300]],
-            'carmen:address_style': queensStyle,
-            'carmen:addressprops': {
-                'carmen:address_style': {
-                    1: standardStyle,
-                    '2': 'invalid'
+    t.deepEqual(
+        addressCluster.forward(feature, '10-10'),
+        [{
+            type: 'Feature',
+            properties: {
+                accuracy: 'building',
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
+                'carmen:address_style': queensStyle,
+                'carmen:addressprops': {
+                    'carmen:address_style': {
+                        0: queensStyle,
+                        2: queensStyle
+                    }
                 }
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
             }
-        },
-        geometry: {
-            type: 'GeometryCollection',
-            geometries: [{
-                type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3]]
-            }]
-        }
-    };
-    const invalidStyleFeature = {
-        type: 'Feature',
-        properties: {
-            accuracy: 'building',
-            'carmen:addressnumber': [[100, 200, 300]],
-            'carmen:address_style': 'invalid'
-        },
-        geometry: {
-            type: 'GeometryCollection',
-            geometries: [{
-                type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3]]
-            }]
-        }
-    };
-    t.deepEqual(
-        addressCluster.getAddressStyle(defaultStyleFeature, 0),
-        standardStyle,
-        'Default to standard'
+        }, {
+            type: 'Feature',
+            properties: {
+                accuracy: 'building',
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
+                'carmen:address_style': standardStyle,
+                'carmen:addressprops': {
+                    'carmen:address_style': {
+                        0: queensStyle,
+                        2: queensStyle
+                    }
+                }
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [6,6]
+            }
+        }],
+        'Retrieve Queens Address with Hyphen'
     );
     t.deepEqual(
-        addressCluster.getAddressStyle(standardStyleFeature, 0),
-        standardStyle,
-        'Specified standard'
+        addressCluster.forwardPrefix(feature, '10-'),
+        [
+            {
+                idx: 0,
+                number: '10-10',
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [1, 1] },
+            },
+            {
+                idx: 2,
+                number: '10-200',
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [3, 3] },
+            },
+            {
+                idx: 3,
+                number: 10,
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [4, 4] },
+            },
+            {
+                idx: 4,
+                number: 100,
+                numberAsInt: 100,
+                geometry: { type: 'Point', coordinates: [5, 5] },
+            },
+            {
+                idx: 5,
+                number: 1010,
+                numberAsInt: 1010,
+                geometry: { type: 'Point', coordinates: [6, 6] },
+            }
+        ],
+        'Prefix on Queens Addresses',
     );
     t.deepEqual(
-        addressCluster.getAddressStyle(queensStyleFeature, 0),
-        queensStyle,
-        'Specified queens'
+        addressCluster.forwardPrefix(feature, '10-1'),
+        [
+            {
+                idx: 0,
+                number: '10-10',
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [1, 1] },
+            },
+            {
+                idx: 5,
+                number: 1010,
+                numberAsInt: 1010,
+                geometry: { type: 'Point', coordinates: [6, 6] },
+            }
+        ],
+        'Prefix on Queens Addresses Hyphen in Correct Spot',
     );
     t.deepEqual(
-        addressCluster.getAddressStyle(invalidStyleFeature, 0),
-        standardStyle,
-        'Unrecognized defaults to standard'
-    );
-    t.deepEqual(
-        addressCluster.getAddressStyle(queensStyleFeature, 1),
-        standardStyle,
-        'Override feature default'
-    );
-    t.deepEqual(
-        addressCluster.getAddressStyle(queensStyleFeature, 2),
-        standardStyle,
-        'Unrecognized defaults to standard'
+        addressCluster.forwardPrefix(feature, '1-01'),
+        [
+            {
+                idx: 5,
+                number: 1010,
+                numberAsInt: 1010,
+                geometry: { type: 'Point', coordinates: [6, 6] },
+            }
+        ],
+        'Prefix on Queens Addresses Hyphen in Incorrect Spot',
     );
     t.end();
 });

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -900,6 +900,7 @@ test('queens', (t) => {
             accuracy: 'building',
             'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
             'carmen:address_style': standardStyle,
+            'carmen:address_styles': [standardStyle, queensStyle],
             'carmen:addressprops': {
                 'carmen:address_style': {
                     0: queensStyle,
@@ -924,6 +925,7 @@ test('queens', (t) => {
                 accuracy: 'building',
                 'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
                 'carmen:address_style': queensStyle,
+                'carmen:address_styles': [standardStyle, queensStyle],
                 'carmen:address': '10-10',
                 'carmen:addressprops': {
                     'carmen:address_style': {
@@ -943,6 +945,7 @@ test('queens', (t) => {
                 accuracy: 'building',
                 'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
                 'carmen:address_style': standardStyle,
+                'carmen:address_styles': [standardStyle, queensStyle],
                 'carmen:addressprops': {
                     'carmen:address_style': {
                         0: queensStyle,

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -890,3 +890,110 @@ test('prefix', (t) => {
     );
     t.end();
 });
+
+test('getAddressStyle', (t) => {
+    const standardStyle = 'standard';
+    const queensStyle = 'queens';
+    const defaultStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:addressprops': {
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const standardStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': standardStyle,
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                }
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const queensStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': queensStyle,
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                    1: standardStyle,
+                    '2': 'invalid'
+                }
+            }
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    const invalidStyleFeature = {
+        type: 'Feature',
+        properties: {
+            accuracy: 'building',
+            'carmen:addressnumber': [[100, 200, 300]],
+            'carmen:address_style': 'invalid'
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: [[1,1],[2,2],[3,3]]
+            }]
+        }
+    };
+    t.deepEqual(
+        addressCluster.getAddressStyle(defaultStyleFeature, 0),
+        standardStyle,
+        'Default to standard'
+    );
+    t.deepEqual(
+        addressCluster.getAddressStyle(standardStyleFeature, 0),
+        standardStyle,
+        'Specified standard'
+    );
+    t.deepEqual(
+        addressCluster.getAddressStyle(queensStyleFeature, 0),
+        queensStyle,
+        'Specified queens'
+    );
+    t.deepEqual(
+        addressCluster.getAddressStyle(invalidStyleFeature, 0),
+        standardStyle,
+        'Unrecognized defaults to standard'
+    );
+    t.deepEqual(
+        addressCluster.getAddressStyle(queensStyleFeature, 1),
+        standardStyle,
+        'Override feature default'
+    );
+    t.deepEqual(
+        addressCluster.getAddressStyle(queensStyleFeature, 2),
+        standardStyle,
+        'Unrecognized defaults to standard'
+    );
+    t.end();
+});

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -898,12 +898,13 @@ test('queens', (t) => {
         type: 'Feature',
         properties: {
             accuracy: 'building',
-            'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
+            'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
             'carmen:address_style': standardStyle,
             'carmen:addressprops': {
                 'carmen:address_style': {
                     0: queensStyle,
-                    2: queensStyle
+                    2: queensStyle,
+                    6: queensStyle
                 }
             }
         },
@@ -911,7 +912,7 @@ test('queens', (t) => {
             type: 'GeometryCollection',
             geometries: [{
                 type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6]]
+                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7]]
             }]
         }
     };
@@ -921,12 +922,13 @@ test('queens', (t) => {
             type: 'Feature',
             properties: {
                 accuracy: 'building',
-                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
                 'carmen:address_style': queensStyle,
                 'carmen:addressprops': {
                     'carmen:address_style': {
                         0: queensStyle,
-                        2: queensStyle
+                        2: queensStyle,
+                        6: queensStyle
                     }
                 }
             },
@@ -938,12 +940,13 @@ test('queens', (t) => {
             type: 'Feature',
             properties: {
                 accuracy: 'building',
-                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010]],
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
                 'carmen:address_style': standardStyle,
                 'carmen:addressprops': {
                     'carmen:address_style': {
                         0: queensStyle,
-                        2: queensStyle
+                        2: queensStyle,
+                        6: queensStyle
                     }
                 }
             },
@@ -1016,6 +1019,12 @@ test('queens', (t) => {
                 number: 1010,
                 numberAsInt: 1010,
                 geometry: { type: 'Point', coordinates: [6, 6] },
+            },
+            {
+                idx: 6,
+                number: '1-010',
+                numberAsInt: 1,
+                geometry: { type: 'Point', coordinates: [7, 7] },
             }
         ],
         'Prefix on Queens Addresses Hyphen in Incorrect Spot',


### PR DESCRIPTION
### Context
Queens uses a unique addressing system in which the address number follows the format `\d{2,3}-\d{2,3}` where the pre-hyphen number represents the major cross street/avenue number and the post-hyphen number represents the house number.  This ticket is the first half of supporting these addresses in Carmen.  This covers point lookups but not interpolation. Part of this will cause searches in Queens to be more lenient in the case of searching without a hyphen and the results will always return the hyphenated Queens style addresses. In addition, it lays out a base framework for adding other specific address styles.
### Summary of Changes
- [x] Create a modular address style matching system
- [x] Migrate standard address validation to the new matching system
- [x] Implement new Queens style address matching
- [x] Add style override so that the address returned matches the data format


### Future Work
- [ ] Enable Interpolation for Queens addresses

cc @mapbox/search
