### PR TITLE
Less length penalty

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -335,7 +335,7 @@ function getStackByIdx(stack) {
  * @param {Array} phrasematchResults - generated for each subquery permutation
  * @param {Number} limit - output limit
  * @param {Object} memo - memoization object, used for caching result to check relevance, masks across different indexes
- * @param {Number} idx - index number
+ * @param {Number} index - index number
  * @param {Number} mask - caluculated by phrasematch; is used to represent all possible cominations
  * @param {Number} nmask - used to determine whether to two indexes have the same tokens which means they cannot be stacked together
  * @param {Array} stack - a list of indexes that stack spatially
@@ -343,14 +343,14 @@ function getStackByIdx(stack) {
  * @param {Number} adjRelev - adjusted relevance score for each feature
  * @returns {Array<Array<object>>} Arrays of phrasematch archetypes
  */
-function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, relev, adjRelev) {
+function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, relev, adjRelev) {
     if (memo === undefined) {
         memo = {
             stacks: [],
             maxStacks: [],
             maxRelev: 0
         };
-        idx = 0;
+        index = 0;
         mask = 0;
         nmask = 0;
         stack = [];
@@ -359,11 +359,11 @@ function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, rel
     }
 
     // Recurse, skipping this level
-    if (phrasematchResults[idx + 1] !== undefined) {
-        stackable(phrasematchResults, limit, memo, idx + 1, mask, nmask, stack, relev, adjRelev);
+    if (phrasematchResults[index + 1] !== undefined) {
+        stackable(phrasematchResults, limit, memo, index + 1, mask, nmask, stack, relev, adjRelev);
     }
 
-    const phrasematchResult = phrasematchResults[idx];
+    const phrasematchResult = phrasematchResults[index];
 
     if (nmask & phrasematchResult.nmask) return;
 
@@ -418,16 +418,16 @@ function stackable(phrasematchResults, limit, memo, idx, mask, nmask, stack, rel
         }
 
         // Recurse to next level
-        if (phrasematchResults[idx + 1] !== undefined) {
-            stackable(phrasematchResults, limit, memo, idx + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
+        if (phrasematchResults[index + 1] !== undefined) {
+            stackable(phrasematchResults, limit, memo, index + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
         }
     }
 
-    if (idx === 0) {
+    if (index === 0) {
         const stacks = memo.stacks.concat(memo.maxStacks);
         for (const stack of stacks) {
-            // this will hyperbolically scale from 1 asymptotically down to .9
-            const lengthPenalty = .9 + (.1 / (stack.length || 1));
+            // this will hyperbolically scale from 1 asymptotically down to .95
+            const lengthPenalty = .95 + (.05 / (stack.length || 1));
             stack.adjRelev *= lengthPenalty;
         }
         return stacks;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -425,8 +425,11 @@ function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, r
 
     if (index === 0) {
         const stacks = memo.stacks.concat(memo.maxStacks);
-        const stackPenaltyMultiplier = [1, 1, .975, .933, .92, .91, .9, .9];
+        // These are relatively arbitrary penalties. The idea is that stack length 2 should be slightly penalized,
+        // and lengths 3+ should be more heavily penalized so that valid fuzzy matches can be surfaced
+        const stackPenaltyMultiplier = [1, 1, .975, .933, .92, .91];
         for (const stack of stacks) {
+            // The smallest stack penalty mutiplier is .9, so beyond length 5, the penalty is .9
             stack.adjRelev *= stackPenaltyMultiplier[stack.length] || .9;
         }
         return stacks;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -335,7 +335,7 @@ function getStackByIdx(stack) {
  * @param {Array} phrasematchResults - generated for each subquery permutation
  * @param {Number} limit - output limit
  * @param {Object} memo - memoization object, used for caching result to check relevance, masks across different indexes
- * @param {Number} index - index number
+ * @param {Number} pmi - phrasematch results index
  * @param {Number} mask - caluculated by phrasematch; is used to represent all possible cominations
  * @param {Number} nmask - used to determine whether to two indexes have the same tokens which means they cannot be stacked together
  * @param {Array} stack - a list of indexes that stack spatially
@@ -343,14 +343,14 @@ function getStackByIdx(stack) {
  * @param {Number} adjRelev - adjusted relevance score for each feature
  * @returns {Array<Array<object>>} Arrays of phrasematch archetypes
  */
-function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, relev, adjRelev) {
+function stackable(phrasematchResults, limit, memo, pmi, mask, nmask, stack, relev, adjRelev) {
     if (memo === undefined) {
         memo = {
             stacks: [],
             maxStacks: [],
             maxRelev: 0
         };
-        index = 0;
+        pmi = 0;
         mask = 0;
         nmask = 0;
         stack = [];
@@ -359,11 +359,11 @@ function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, r
     }
 
     // Recurse, skipping this level
-    if (phrasematchResults[index + 1] !== undefined) {
-        stackable(phrasematchResults, limit, memo, index + 1, mask, nmask, stack, relev, adjRelev);
+    if (phrasematchResults[pmi + 1] !== undefined) {
+        stackable(phrasematchResults, limit, memo, pmi + 1, mask, nmask, stack, relev, adjRelev);
     }
 
-    const phrasematchResult = phrasematchResults[index];
+    const phrasematchResult = phrasematchResults[pmi];
 
     if (nmask & phrasematchResult.nmask) return;
 
@@ -418,18 +418,18 @@ function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, r
         }
 
         // Recurse to next level
-        if (phrasematchResults[index + 1] !== undefined) {
-            stackable(phrasematchResults, limit, memo, index + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
+        if (phrasematchResults[pmi + 1] !== undefined) {
+            stackable(phrasematchResults, limit, memo, pmi + 1, targetMask, targetNmask, targetStack, targetStack.relev, targetStack.adjRelev);
         }
     }
 
-    if (index === 0) {
+    if (pmi === 0) {
         const stacks = memo.stacks.concat(memo.maxStacks);
         // These are relatively arbitrary penalties. The idea is that stack length 2 should be slightly penalized,
         // and lengths 3+ should be more heavily penalized so that valid fuzzy matches can be surfaced
         const stackPenaltyMultiplier = [1, 1, .975, .933, .92, .91];
         for (const stack of stacks) {
-            // The smallest stack penalty mutiplier is .9, so beyond length 5, the penalty is .9
+            // The smallest stack penalty mutiplier should be .9, and beyond length 5, the penalty will be .9
             stack.adjRelev *= stackPenaltyMultiplier[stack.length] || .9;
         }
         return stacks;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -425,10 +425,9 @@ function stackable(phrasematchResults, limit, memo, index, mask, nmask, stack, r
 
     if (index === 0) {
         const stacks = memo.stacks.concat(memo.maxStacks);
+        const stackPenaltyMultiplier = [1, 1, .975, .933, .92, .91, .9, .9];
         for (const stack of stacks) {
-            // this will hyperbolically scale from 1 asymptotically down to .95
-            const lengthPenalty = .95 + (.05 / (stack.length || 1));
-            stack.adjRelev *= lengthPenalty;
+            stack.adjRelev *= stackPenaltyMultiplier[stack.length] || .9;
         }
         return stacks;
     }

--- a/test/acceptance/geocode-unit.spatialmatch-stack-length.test.js
+++ b/test/acceptance/geocode-unit.spatialmatch-stack-length.test.js
@@ -1,0 +1,136 @@
+'use strict';
+// spatialmatch test to ensure the highest relev for a stacked zxy cell
+// is used, disallowing a lower scoring cell from overwriting a previous
+// entry.
+
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const addFeature = require('../../lib/indexer/addfeature'),
+    queueFeature = addFeature.queueFeature,
+    buildQueued = addFeature.buildQueued;
+
+const conf = {
+    region2: new mem({ maxzoom: 6 }, () => {}),
+    region3: new mem({ maxzoom: 6 }, () => {}),
+    region4: new mem({ maxzoom: 6 }, () => {}),
+    region: new mem({ maxzoom: 6 }, () => {}),
+    place: new mem({ maxzoom: 6 }, () => {}),
+    poi: new mem({ maxzoom: 14 }, () => {}),
+    poi2: new mem({ maxzoom: 14 }, () => {}),
+    poi3: new mem({ maxzoom: 14 }, () => {}),
+    poi4: new mem({ maxzoom: 14 }, () => {})
+};
+
+const c = new Carmen(conf);
+tape('index region', (t) => {
+    const feature = {
+        id:1,
+        properties: {
+            'carmen:text':'california',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[0,0],
+        }
+    };
+    queueFeature(conf.region, feature, t.end);
+});
+
+tape('index region2', (t) => {
+    const feature = {
+        id:1,
+        properties: {
+            'carmen:text':'ca',
+            'carmen:zxy':['6/1/1'],
+            'carmen:center':[0,0],
+        }
+    };
+    queueFeature(conf.region2, feature, t.end);
+});
+
+tape('index region3', (t) => {
+    const feature = {
+        id:1,
+        properties: {
+            'carmen:text':'francisco ca',
+            'carmen:zxy':['6/2/2'],
+            'carmen:center':[0,0],
+        }
+    };
+    queueFeature(conf.region3, feature, t.end);
+});
+tape('index region4', (t) => {
+    const feature = {
+        id:1,
+        properties: {
+            'carmen:text':'cal',
+            'carmen:zxy':['6/5/5'],
+            'carmen:center':[0,0],
+        }
+    };
+    queueFeature(conf.region4, feature, t.end);
+});
+
+tape('index place', (t) => {
+    const feature = {
+        id:2,
+        properties: {
+            'carmen:text':'san francisco',
+            'carmen:zxy':['6/32/32'],
+            'carmen:center':[2.82,-2.84],
+            'carmen:score': 500
+        }
+    };
+    queueFeature(conf.place, feature, t.end);
+});
+
+tape('index pois', (t) => {
+    const q = queue();
+    const feature = {
+        id:1,
+        properties: {
+            'carmen:text':'san francisco cable car 1',
+            'carmen:zxy':['14/8320/8320'],
+            'carmen:center':[2.82,-2.84]
+        }
+    };
+    const featureFuzzy = {
+        id:2,
+        properties: {
+            'carmen:text':'sen francisco cable car 2',
+            'carmen:zxy':['14/8320/8320'],
+            'carmen:center':[2.82,-2.84]
+        }
+    };
+    q.defer(queueFeature, conf.poi, feature);
+    q.defer(queueFeature, conf.poi2, featureFuzzy);
+    q.defer(queueFeature, conf.poi3, featureFuzzy);
+    q.defer(queueFeature, conf.poi4, featureFuzzy);
+
+    q.awaitAll(t.end);
+});
+
+tape('build queued features', (t) => {
+    const q = queue();
+    Object.keys(conf).forEach((c) => {
+        q.defer((cb) => {
+            buildQueued(conf[c], cb);
+        });
+    });
+    q.awaitAll(t.end);
+});
+
+tape('test stack length penalty', (t) => {
+    c.geocode('san francisco ca', { proximity: [0,0], spatialmatch_stack_limit: 5 }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].id, 'place.2');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});
+


### PR DESCRIPTION
### Context
Issue: #849 

There is a stack length relevance penalty to prefer matches from fewer indexes over matches that span many indexes. This makes sense because it's likely that multiple words matching a single cover is more relevant than finding fewer words across many indexes.

A side effect of this was that a search for `San Francisco, CA` would return a poi called `San Francisco cable car` because the `san francisco` + `california` stack got an early relevance penalty and never made it into the final results. This PR reduces this penalty slightly.

The first approach changed the penalty from somewhere between .9 and 1 to be somewhere between .95 and 1, depending on the stack length. This meant that some pretty relevant fuzzy matches weren't making it to the final results because the stacks were getting drowned out by less relevant stacks of a longer length, which ultimately didn't end up having a high relevance after verifymatch. For example, `654 Clement SF` with a proximity point in SF was  not returning `654 clement st` because stacks that included matches for `6##` `Clement` and `SF` in different indexes were getting a higher relevance from stackable.

The latest approach hard-codes some stack length penalties, with the idea that there's a small penalty for stacks of length 2, and a much larger penalty for stacks of length 3, and then the penalty increases more gradually as the length gets longer, with a max multiplier of 0.9. These numbers are relatively arbitrary, but it was too complicated to get a mathematical equation to capture this intuitive distribution of stack length penalties.


### Summary of Changes
- [x] Add more intuitive stack length penalties that penalize stacks of length 2 less
- [x] Rename the idx variable to index, since `idx` is usually what we call a data index, not a counter in a loop


cc @mapbox/search
