### PR TITLE
Check if cover scoredist is score before treating it like its an encoded score

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -574,7 +574,7 @@ function Cover(cacheCover, phrasematch) {
     this.tmpid = cacheCover.tmpid;
     this.distance = cacheCover.distance;
     this.score = termops.decode3BitLogScale(cacheCover.score, phrasematch.scorefactor);
-    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, phrasematch.scorefactor);
+    this.scoredist = cacheCover.scoredist !== cacheCover.score ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : this.score;
     this.scorefactor = phrasematch.scorefactor;
     this.matches_language = cacheCover.matches_language;
     this.prefix = phrasematch.prefix;


### PR DESCRIPTION
### Context
Currently, if a cover's scoredist is <7, the scoredist gets treated as if it were the same as the score, which gets encoded as a value between 1 and 7 on a log scale. The scoredist is then "decoded" based on the scorefactor of the index. The scoredist is the same as the score in many cases, for example, when there is no proximity option.

It's possible for a scoredist that does take distance from a proximity point into account as part of it's scoredist to have a scoredist of <7. When it's treated the same as the score, it often gets "decoded" to end up as 1. This hides relevant differences in features that have low scores but some differentiation in distance from a point.

This is an attempt to preserve the original scoredist if the scoredist is not equal to the score, instead of guessing based on whether the scoredist is <7.

### Summary of Changes
- [x] Only decode the scoredist if it is not the same as the score


### Next Steps
- [ ] Evaluate whether this is the correct approach for scoredists based on scores that have been encoded on the log scale

cc @mapbox/search
