### PR TITLE
VT Query Direct Hit Polygon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 /.nyc_output/
 coverage.lcov
 yarn-error.log
+.idea/

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -343,7 +343,8 @@ function nearestPoints(source, lon, lat, scoreFilter, callback) {
             radius: 1000,
             layer: source.geocoder_layer,
             limit: 5,
-            dedupe: true
+            dedupe: true,
+            direct_hit_polygon: true
         }, afterQuery);
     }
 
@@ -548,7 +549,8 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
                 layer: source.geocoder_layer,
                 limit: 5,
                 dedupe: true,
-                'basic-filters': ['all', [['carmen:score', '>=', 0]]]
+                'basic-filters': ['all', [['carmen:score', '>=', 0]]],
+                direct_hit_polygon: true
             }, (err, results) => {
                 if (err) return callback(err);
                 if (!results || !results.features.length) return callback(null, false);
@@ -564,7 +566,8 @@ function contextVector(source, lon, lat, full, matched, language, scoreFilter, r
                 radius: 1000,
                 layer: source.geocoder_layer,
                 limit: 100,
-                dedupe: true
+                dedupe: true,
+                direct_hit_polygon: true
             }, (err, results) => {
                 if (err) return callback(err);
                 if (!results || !results.features.length) return callback(null, false);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",
     "@mapbox/tilelive": "^6.0.0",
-    "@mapbox/vtquery": "^0.4.1",
+    "@mapbox/vtquery": "git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "@turf/bearing": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",
     "@mapbox/tilelive": "^6.0.0",
-    "@mapbox/vtquery": "git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c",
+    "@mapbox/vtquery": "git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "@turf/bearing": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",
     "@mapbox/tilelive": "^6.0.0",
-    "@mapbox/vtquery": "mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b",
+    "@mapbox/vtquery": "^0.5.0",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "@turf/bearing": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "1.0.x",
     "@mapbox/tilelive": "^6.0.0",
-    "@mapbox/vtquery": "git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b",
+    "@mapbox/vtquery": "mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "@turf/bearing": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,9 +1038,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
 
-"@mapbox/vtquery@mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b":
-  version "0.4.2-dhp-01"
-  resolved "https://codeload.github.com/mapbox/vtquery/tar.gz/1b4d8980aa8481796c131df27d0af91bed88579b"
+"@mapbox/vtquery@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/vtquery/-/vtquery-0.5.0.tgz#2919fbccd95233f13d6c670c6be37f6f1012f581"
+  integrity sha512-bNwot8w9i9fNCsAvuCG8YGvPTqDcBBih+ip6h45tPlh+rjXNKpHp81SwshqAL/YmAR/8jvgKQbQwZN1GYhRqtQ==
   dependencies:
     "@mapbox/mason-js" "^0.1.5"
     nan "^2.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,9 +1038,9 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
 
-"@mapbox/vtquery@git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c":
-  version "0.4.1"
-  resolved "git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c"
+"@mapbox/vtquery@git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b":
+  version "0.4.2-dhp-01"
+  resolved "git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b"
   dependencies:
     "@mapbox/mason-js" "^0.1.5"
     nan "^2.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,9 +1038,9 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
 
-"@mapbox/vtquery@git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b":
+"@mapbox/vtquery@mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b":
   version "0.4.2-dhp-01"
-  resolved "git://github.com/mapbox/vtquery.git#1b4d8980aa8481796c131df27d0af91bed88579b"
+  resolved "https://codeload.github.com/mapbox/vtquery/tar.gz/1b4d8980aa8481796c131df27d0af91bed88579b"
   dependencies:
     "@mapbox/mason-js" "^0.1.5"
     nan "^2.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,10 +1038,9 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
 
-"@mapbox/vtquery@^0.4.1":
+"@mapbox/vtquery@git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c":
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/vtquery/-/vtquery-0.4.1.tgz#abfa5dcd623a71917ec1f358c326bfab0ed91c01"
-  integrity sha512-KWqxcXjqiSyH3L+s7vMZOSJSRKXBLkLncQ/O3mkz7wE/nTPni1bxsTnNfZewXnajNVwo4H4EE3jIvehXHt1+TQ==
+  resolved "git://github.com/mapbox/vtquery.git#a0a27f01536c4a14a7f4024d19527d7a2e8cbf3c"
   dependencies:
     "@mapbox/mason-js" "^0.1.5"
     nan "^2.14.0"


### PR DESCRIPTION
### Context
When upgrading from mapnik to VTQuery, it was unrealized at the time that mapnik did not support distance to polygons while VTQuery did.  This caused reverse geocode results return polygons that the point was not in.  This change returns to the original functionality which requires reverse geocoding points to be within the polygons it returns.  This does not affect behavior around point or line geometries.

<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->


### Summary of Changes
* Update VTQuery
* Enable direct hit flag in VT Query
* Only direct hits on polygons will match
* Add .idea to .gitignore

### Next Steps
<!-- if you're still working on it -->


cc @mapbox/search
