### PR TITLE
[dnm] disallow address number rearrangements that traverse dropped tokens

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -208,6 +208,15 @@ module.exports = function phrasematch(source, query, options, callback) {
                 }
 
                 if (subquery.address) {
+                    if (subquery.address.numberOrder === 'last') {
+                        // the number was at the end and has been moved to the beginning
+                        if (subquery.address.position - lim[0] < normalized.owner[subquery.address.position] - normalized.owner[lim[0]]) {
+                            // we moved the address number to the beginning and apparently traversed some dropped words along the way;
+                            // disallow this behavior and skip this subquery
+                            continue;
+                        }
+                    }
+
                     sq.address = {
                         number: subquery.address.number,
                         numberOrder: subquery.address.numberOrder,


### PR DESCRIPTION
### Context
Carmen has two mechanisms, one for token replacements that drop multiple words from a query (introduced in #826), and one that rearranges address phrasematches containing address numbers such that the number is always at the beginning (introduced... a long time ago, but most recently touched in #837). This PR changes how they interact with one another, such that if the moving of an address number would require that we move it to the other side of some tokens that have been dropped, we skip that combination; we don't expect, for example, to see address that have street name *then* apartment number (which would be dropped) *then* house number.

**Note:** I tried this change with the goal of fixing a specific query that, as it turns out, still fails with this change applied for a new reason. In the abstract I think it's still a good idea, but absent a clearly-motivating breakage that this would fix, I'm mostly cutting this PR to capture this potential change for posterity, should the need arise at some point in the future.

refs #809 

### Summary of Changes
- [x] for address phrasematches where the number was originally at the end, compare the number of tokens between the start of the phrasematch and the address number, and see if the post-token-replacement count is less than the pre-token-replacement count; if so, skip that phrasematch


### Next Steps
- [ ] should we actually want to do anything with this, it will need tests

cc @mapbox/search
