### PR TITLE
Scoredist decode hack

### DIFF
--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -574,7 +574,7 @@ function Cover(cacheCover, phrasematch) {
     this.tmpid = cacheCover.tmpid;
     this.distance = cacheCover.distance;
     this.score = termops.decode3BitLogScale(cacheCover.score, phrasematch.scorefactor);
-    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, phrasematch.scorefactor);
+    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, Math.min(phrasematch.scorefactor, 1.01));
     this.scorefactor = phrasematch.scorefactor;
     this.matches_language = cacheCover.matches_language;
     this.prefix = phrasematch.prefix;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -573,8 +573,8 @@ function Cover(cacheCover, phrasematch) {
     this.idx = cacheCover.idx;
     this.tmpid = cacheCover.tmpid;
     this.distance = cacheCover.distance;
-    this.score = termops.decode3BitLogScale(cacheCover.score, phrasematch.scorefactor);
-    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, Math.max(phrasematch.scorefactor, 1.01), 3);
+    this.score = termops.decode3BitLogScale(cacheCover.score, phrasematch.scorefactor, true);
+    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, Math.max(phrasematch.scorefactor, 1.01));
     this.scorefactor = phrasematch.scorefactor;
     this.matches_language = cacheCover.matches_language;
     this.prefix = phrasematch.prefix;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -574,7 +574,7 @@ function Cover(cacheCover, phrasematch) {
     this.tmpid = cacheCover.tmpid;
     this.distance = cacheCover.distance;
     this.score = termops.decode3BitLogScale(cacheCover.score, phrasematch.scorefactor);
-    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, Math.min(phrasematch.scorefactor, 1.01));
+    this.scoredist = cacheCover.scoredist > 7 ? (phrasematch.scorefactor / 7) * cacheCover.scoredist : termops.decode3BitLogScale(cacheCover.scoredist, Math.max(phrasematch.scorefactor, 1.01), 3);
     this.scorefactor = phrasematch.scorefactor;
     this.matches_language = cacheCover.matches_language;
     this.prefix = phrasematch.prefix;

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -4,7 +4,6 @@ const removeDiacritics = require('./remove-diacritics');
 const idPattern = /^(\S+)\.([0-9]+)$/;
 const token = require('./token');
 const permute = require('../util/permute');
-const roundTo = require('../util/round-to');
 const cl = require('./closest-lang');
 const MAX_QUERY_TOKENS = require('../constants').MAX_QUERY_TOKENS;
 
@@ -937,18 +936,17 @@ function encode3BitLogScale(num, max) {
  * decode3BitLogScale - Convert a 3-bit log scale integer to a number
  * @param {number} num - The number to be converted
  * @param {number} max - The value `num` is scaled against
- * @param {number} round - The number of places to round to
+ * @param {bool} round - Whether or not to round to the nearest integer
  * @return {number} scaled up value
  */
 function decode3BitLogScale(num, max, round) {
     if (!num || !max) return 0;
     if (round) {
-        return roundTo(Math.pow(max, num / 7), round);
-    }
-    else {
         return Math.round(Math.pow(max, num / 7));
     }
-
+    else {
+        return Math.pow(max, num / 7);
+    }
 }
 
 /**

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -4,6 +4,7 @@ const removeDiacritics = require('./remove-diacritics');
 const idPattern = /^(\S+)\.([0-9]+)$/;
 const token = require('./token');
 const permute = require('../util/permute');
+const roundTo = require('../util/round-to');
 const cl = require('./closest-lang');
 const MAX_QUERY_TOKENS = require('../constants').MAX_QUERY_TOKENS;
 
@@ -936,12 +937,18 @@ function encode3BitLogScale(num, max) {
  * decode3BitLogScale - Convert a 3-bit log scale integer to a number
  * @param {number} num - The number to be converted
  * @param {number} max - The value `num` is scaled against
+ * @param {number} round - The number of places to round to
  * @return {number} scaled up value
  */
-function decode3BitLogScale(num, max) {
+function decode3BitLogScale(num, max, round) {
     if (!num || !max) return 0;
+    if (round) {
+        return roundTo(Math.pow(max, num / 7), round);
+    }
+    else {
+        return Math.round(Math.pow(max, num / 7));
+    }
 
-    return Math.pow(max, num / 7);
 }
 
 /**

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -940,7 +940,8 @@ function encode3BitLogScale(num, max) {
  */
 function decode3BitLogScale(num, max) {
     if (!num || !max) return 0;
-    return Math.round(Math.pow(max, num / 7));
+
+    return Math.pow(max, num / 7);
 }
 
 /**

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -315,7 +315,7 @@ function matchScore(features, cover, source) {
     let scoreSimple;
     features = features.filter((feature) => {
         scoreSimple3Bit = termops.encode3BitLogScale(feature.properties['carmen:score'], source.maxscore);
-        scoreSimple = termops.decode3BitLogScale(scoreSimple3Bit, source.maxscore);
+        scoreSimple = termops.decode3BitLogScale(scoreSimple3Bit, source.maxscore, true);
         return scoreSimple === cover.score;
     });
     return features;

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -300,7 +300,7 @@
                             "tmpid": 67108865,
                             "distance": 0,
                             "score": 1,
-                            "scoredist": 1.001,
+                            "scoredist":  1.0014224866118175,
                             "scorefactor": 1,
                             "matches_language": true,
                             "prefix": 2,
@@ -311,7 +311,7 @@
                     ],
                     "partialNumber": false,
                     "address": null,
-                    "scoredist": 1.001
+                    "scoredist":  1.0014224866118175
                 },
                 "carmen:relev": 1,
                 "carmen:geocoder_address_order": "ascending",

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -300,7 +300,7 @@
                             "tmpid": 67108865,
                             "distance": 0,
                             "score": 1,
-                            "scoredist": 1,
+                            "scoredist": 1.001,
                             "scorefactor": 1,
                             "matches_language": true,
                             "prefix": 2,
@@ -311,7 +311,7 @@
                     ],
                     "partialNumber": false,
                     "address": null,
-                    "scoredist": 1
+                    "scoredist": 1.001
                 },
                 "carmen:relev": 1,
                 "carmen:geocoder_address_order": "ascending",

--- a/test/unit/text-processing/termops.logScale3Bit.test.js
+++ b/test/unit/text-processing/termops.logScale3Bit.test.js
@@ -25,17 +25,18 @@ test('encode', (t) => {
 
 test('decode', (t) => {
     let term = 0;
-    term = termops.decode3BitLogScale(5,180000);
+    term = termops.decode3BitLogScale(5,180000, true);
     t.equal(term, 5672);
 
-    t.equal(termops.decode3BitLogScale(0,10), 0);
-    t.equal(termops.decode3BitLogScale(1,10), 1);
-    t.equal(termops.decode3BitLogScale(2,10), 2);
-    t.equal(termops.decode3BitLogScale(3,10), 3);
-    t.equal(termops.decode3BitLogScale(4,10), 4);
-    t.equal(termops.decode3BitLogScale(5,10), 5);
-    t.equal(termops.decode3BitLogScale(6,10), 7);
-    t.equal(termops.decode3BitLogScale(7,10), 10);
+    t.equal(termops.decode3BitLogScale(0,10, true), 0);
+    t.equal(termops.decode3BitLogScale(1,10, true), 1);
+    t.equal(termops.decode3BitLogScale(2,10, true), 2);
+    t.equal(termops.decode3BitLogScale(3,10, true), 3);
+    t.equal(termops.decode3BitLogScale(4,10, true), 4);
+    t.equal(termops.decode3BitLogScale(5,10, true), 5);
+    t.equal(termops.decode3BitLogScale(6,10, true), 7);
+    t.equal(termops.decode3BitLogScale(7,10, true), 10);
+    t.equal(termops.decode3BitLogScale(6.5, 1.01), 1.0092824097422461);
 
     t.end();
 });


### PR DESCRIPTION
### Context
Scores are encoded on a log scale between 1 and 7 for storage purposes. The scoredists coming out of carmen-cache are based on this log-encoded score. In spatialmatch, there is an attempt to "decode" the scoredist by accounting for the scorefactor of the data source. This isn't an exactly inverse mathmatical operation because the scoredist can factor in distance, in addition to the score.

Scoredists coming out of carmen-cache were getting "decoded" to a value that was always equal to 1 if the scorefactor of an index was 1. For example, matches with a scoredist of 1 coming out of coalesce and matches with a scoredist of 6 would both get "decoded" to a scoredist of 1 if the scorefactor of an index is 1.

This PR adds a small boost to the scorefactor to avoid losing the differentiation between relatively low scoredists. A value of 1.01 was somewhat arbitrarily chosen, but it intersects nicely with the values that the other equation for expanding scoredists (if the scoredist is greater than 7) produces. That way a scoredist that's less than 7 coming out of coalesce should not ever result in a higher decoded scoredist than one that's greater than 7 coming out of coalesce.

![Screen Shot 2019-11-15 at 1 54 24 PM](https://user-images.githubusercontent.com/5750602/68980787-4fa6df80-07b6-11ea-8144-46592ea32a76.png)

Since the original reason for applying a different operation to scoredists that are greater than 7 vs scoredists that are less than 7 is unknown, this PR leaves that intact.

A more robust solution would probably be to decode the scores before calculating the scoredist in carmen-cache in the future.

### Summary of Changes
- [ ] Adds a small boost to the scorefactor when "decoding" scoredists
- [ ] Adds an argument to decode3BitLogScale for whether or not to round to the nearest integer, since other operations rely on the output of that function being an integer.


cc @mapbox/search
