### PR TITLE
Handle missing ordinals 

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,8 +204,8 @@ function Geocoder(indexes, options) {
             }
             source.categorized_replacement_words = token.categorizeTokenReplacements(info.geocoder_tokens);
             source.simple_replacer = token.createSimpleReplacer(source.categorized_replacement_words.simple);
-            source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex);
-            source.complex_indexing_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { includeUnambiguous: true });
+            source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { reduceRelevance: false });
+            source.complex_indexing_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { includeUnambiguous: true , reduceRelevance: true });
             source.format_helpers = options.formatHelpers;
 
             source.categories = false;

--- a/index.js
+++ b/index.js
@@ -204,8 +204,8 @@ function Geocoder(indexes, options) {
             }
             source.categorized_replacement_words = token.categorizeTokenReplacements(info.geocoder_tokens);
             source.simple_replacer = token.createSimpleReplacer(source.categorized_replacement_words.simple);
-            source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { reduceRelevance: false });
-            source.complex_indexing_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { includeUnambiguous: true , reduceRelevance: true });
+            source.complex_query_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { includeRelevanceReduction: false });
+            source.complex_indexing_replacer = token.createComplexReplacer(source.categorized_replacement_words.complex, { includeUnambiguous: true , includeRelevanceReduction: true });
             source.format_helpers = options.formatHelpers;
 
             source.categories = false;

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -66,7 +66,7 @@ function indexdocs(docs, source, options, callback) {
     if (TIMER) console.time('update:freq');
     let freq;
     try {
-        freq = generateFrequency(docs, source.simple_replacer, source.complex_query_replacer, options.tokens, parseInt(source.maxscore, 10), source.lang.has_languages);
+        freq = generateFrequency(docs, source.simple_replacer, source.complex_indexing_replacer, options.tokens, parseInt(source.maxscore, 10), source.lang.has_languages);
     } catch (err) {
         return callback(err);
     }

--- a/lib/indexer/indexdocs.js
+++ b/lib/indexer/indexdocs.js
@@ -66,7 +66,7 @@ function indexdocs(docs, source, options, callback) {
     if (TIMER) console.time('update:freq');
     let freq;
     try {
-        freq = generateFrequency(docs, source.simple_replacer, source.complex_indexing_replacer, options.tokens, parseInt(source.maxscore, 10), source.lang.has_languages);
+        freq = generateFrequency(docs, source.simple_replacer, source.complex_query_replacer, options.tokens, parseInt(source.maxscore, 10), source.lang.has_languages);
     } catch (err) {
         return callback(err);
     }

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -451,7 +451,7 @@ function getIndexableText(simpleReplacer, complexReplacer, globalReplacer, doc, 
                 const intersectionVariants = token.enumerateTokenReplacements(complexReplacer, tokenize(intersections[l]));
 
                 for (const intersectionVariant of intersectionVariants) {
-                    let intersectionTokens = normalizeQuery(tokenize(intersectionVariant)).tokens;
+                    let intersectionTokens = normalizeQuery(tokenize(intersectionVariant.phrase)).tokens;
 
                     // simpleReplacer to covert things like northwest => nw
                     intersectionTokens = simpleReplacer ? simpleReplacer.replacer(intersectionTokens) : intersectionTokens;
@@ -470,7 +470,7 @@ function getIndexableText(simpleReplacer, complexReplacer, globalReplacer, doc, 
         const variants = token.enumerateTokenReplacements(complexReplacer, tokenize(text));
 
         for (const variant of variants) {
-            const tokenized = tokenize(variant);
+            const tokenized = tokenize(variant.phrase);
             const encoded = normalizeQuery(tokenized).tokens;
 
             // do simple token replacements without regexes -- just look them up in a dict
@@ -498,15 +498,19 @@ function getIndexableText(simpleReplacer, complexReplacer, globalReplacer, doc, 
             for (const key of keys) {
                 indexableText[key] = indexableText[key] || new Set();
                 for (const language of langs) indexableText[key].add(language);
+                if (variant.reduceRelevance) {
+                    indexableText[key].reduceRelevance = variant.reduceRelevance;
+                }
             }
         }
     }
 
     const output = [];
     Object.keys(indexableText).forEach((phrase) => {
-        const obj = { tokens: phrase.split(' '), languages: Array.from(indexableText[phrase]) };
+        const obj = { tokens: phrase.split(' '), languages: Array.from(indexableText[phrase]), reduceRelevance: indexableText[phrase].reduceRelevance };
         output.push(obj);
     });
+
     return output;
 }
 
@@ -608,6 +612,8 @@ function parseSemiNumber(_) {
  *        - relev: {number}
  */
 function permutations(terms, weights, all, frequentWords) {
+    const reduceRelevance = terms.reduceRelevance;
+    terms = (terms && Array.isArray(terms)) ? terms : terms.tokens;
     const length = terms.length;
     const masks = all && length <= 8 ? permute.all(length) : permute.continuous(length);
 
@@ -641,8 +647,12 @@ function permutations(terms, weights, all, frequentWords) {
             }
             if (weights) relev += (weights[j] || 0);
         }
+
         if (weights) {
-            permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(0.8, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
+            if (reduceRelevance === true && permutation.length === length) permutation.relev = 0.8;
+            else {
+                permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(0.8, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
+            }
         }
 
         // If it's a trailing numToken swap it to the front.
@@ -716,7 +726,7 @@ function getIndexablePhrases(text, freq, frequentWords) {
         }];
     }
 
-    const perms = permutations(text.tokens, getWeights(text.tokens, freq), true, frequentWords);
+    const perms = permutations(text, getWeights(text.tokens, freq), true, frequentWords);
     perms.sort(sortByRelev);
 
     for (let i = 0; i < perms.length; i++) {

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -451,6 +451,7 @@ function getIndexableText(simpleReplacer, complexReplacer, globalReplacer, doc, 
                 const intersectionVariants = token.enumerateTokenReplacements(complexReplacer, tokenize(intersections[l]));
 
                 for (const intersectionVariant of intersectionVariants) {
+                    if (intersectionVariant.reduceRelevance) continue;
                     let intersectionTokens = normalizeQuery(tokenize(intersectionVariant.phrase)).tokens;
 
                     // simpleReplacer to covert things like northwest => nw

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -614,6 +614,7 @@ function parseSemiNumber(_) {
  */
 function permutations(terms, weights, all, frequentWords) {
     const reduceRelevance = terms.reduceRelevance;
+    const minRelevance = 0.8;
     terms = (terms && Array.isArray(terms)) ? terms : terms.tokens;
     const length = terms.length;
     const masks = all && length <= 8 ? permute.all(length) : permute.continuous(length);
@@ -650,9 +651,10 @@ function permutations(terms, weights, all, frequentWords) {
         }
 
         if (weights) {
-            if (reduceRelevance && permutation.length === length) permutation.relev = 0.8;
+
+            if (reduceRelevance && permutation.length === length) permutation.relev = minRelevance;
             else {
-                permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(0.8, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
+                permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(minRelevance, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
             }
         }
 

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -650,7 +650,7 @@ function permutations(terms, weights, all, frequentWords) {
         }
 
         if (weights) {
-            if (reduceRelevance === true && permutation.length === length) permutation.relev = 0.8;
+            if (reduceRelevance && permutation.length === length) permutation.relev = 0.8;
             else {
                 permutation.relev  = (wordDropped && (permutation.length === terms.length - 1)) ? Math.max(0.8, Math.round(relev * 5) / 5) : Math.round(relev * 5) / 5;
             }

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -84,6 +84,7 @@ module.exports.createComplexReplacer = function(tokens, inverseOpts) {
         let replacementOpts = {};
         if (typeof orig_to == 'object') {
             if (orig_to.text === undefined) continue;
+            if (tokenPair.to.reduceRelevance === true && inverseOpts.reduceRelevance === false) continue;
             replacementOpts = orig_to;
             orig_to = orig_to.text.toLowerCase();
         } else {
@@ -122,6 +123,7 @@ module.exports.createComplexReplacer = function(tokens, inverseOpts) {
                     entry.spanBoundaries = from.split(/\s/).length - 1;
                 }
             }
+            if (tokenPair.to.reduceRelevance === true && inverseOpts.reduceRelevance === true) entry.reduceRelevance = true;
             entry.fromLastWord = false;
             entry.to = orig_to;
             entry.inverse = inverse;
@@ -252,7 +254,8 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
         terms[i] = [{
             t: text.tokens[i],
             l: 1,
-            d: 0
+            d: 0,
+            reduceRelevance: false
         }];
     }
     // Iterate thourgh replacers and attempt to apply them to each token. If a
@@ -278,7 +281,7 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
                 // the first spot in the tokens array. So it's safe to use the
                 // index-0 element for comparison and addition to the terms list.
                 if (altered.tokens[0] !== text.tokens[i]) {
-
+                    if (replacers[k].reduceRelevance) altered.reduceRelevance = true;
                     // If the replacer is inverse get a low output position
                     if (replacers[k].inverse) {
                         altered.changes = text.changes === undefined ? -1 : text.changes - 1;
@@ -288,7 +291,8 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
                     terms[i + offset].push({
                         t: altered.tokens[0],
                         l: cnt,
-                        d: altered.changes
+                        d: altered.changes,
+                        reduceRelevance: altered.reduceRelevance
                     });
 
                     // Recurse, but prevent more that depthLimit variants
@@ -318,24 +322,30 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
     // Iterate through the versions of each input token and assemble possible
     // combinations of the subsequent tokens.
     const out = [];
-    const assemble = (a, i, o) => {
+    const assemble = (a, i, o, m) => {
         const len = a[i].length;
         for (let j = 0; j < len; j++) {
             if (out.length >= outLimit) break;
+            const ordinal = a[i][j].reduceRelevance;
+            const reduceRelevance = ordinal ? m || true : m;
             const t = a[i][j].t;
             const offset = a[i][j].l;
             const s = o ? `${o} ${t}` : t;
             if (i + offset < a.length) {
-                assemble(a, i + offset, s);
+                assemble(a, i + offset, s, reduceRelevance);
             } else {
-                out.push(s);
+                out.push({
+                    phrase: s,
+                    reduceRelevance: reduceRelevance
+                });
             }
         }
     };
-    assemble(terms, 0, false);
-
+    assemble(terms, 0, false, false);
     return out;
 };
+
+
 
 
 /**

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -33,22 +33,22 @@ const escapeRegExp = require('./closest-lang').escapeRegExp;
  * @name createComplexReplacer
  *
  * @param {TokenizedQuery} tokens - tokenized text
- * @param {object} inverseOpts - options for inverting token replacements
- * @param {object} inverseOpts.includeUnambiguous - options for
+ * @param {object} options - options for token replacements
+ * @param {object} options.includeUnambiguous - options for whether the keys are unique
  * @returns {Array<ReplaceRule>} an array of replace rules
  */
-module.exports.createComplexReplacer = function(tokens, inverseOpts) {
+module.exports.createComplexReplacer = function(tokens, options) {
     tokens = JSON.parse(JSON.stringify(tokens));
     if (!Array.isArray(tokens)) {
         tokens = Object.keys(tokens).map((k) => { return { from: k, to: tokens[k] }; });
     }
-    inverseOpts = inverseOpts || {};
-    inverseOpts.includeUnambiguous = inverseOpts.includeUnambiguous || false;
+    options = options || {};
+    options.includeUnambiguous = options.includeUnambiguous || false;
 
     const replacers = [];
     const isInverse = {};
 
-    if (inverseOpts.includeUnambiguous) {
+    if (options.includeUnambiguous) {
         // go through the keys and if check if their values are unique; if so,
         // include them backwards as well
         const tos = {};
@@ -84,7 +84,7 @@ module.exports.createComplexReplacer = function(tokens, inverseOpts) {
         let replacementOpts = {};
         if (typeof orig_to == 'object') {
             if (orig_to.text === undefined) continue;
-            if (tokenPair.to.reduceRelevance === true && inverseOpts.reduceRelevance === false) continue;
+            if (tokenPair.to.reduceRelevance === true && options.reduceRelevance === false) continue;
             replacementOpts = orig_to;
             orig_to = orig_to.text.toLowerCase();
         } else {
@@ -123,7 +123,7 @@ module.exports.createComplexReplacer = function(tokens, inverseOpts) {
                     entry.spanBoundaries = from.split(/\s/).length - 1;
                 }
             }
-            if (tokenPair.to.reduceRelevance === true && inverseOpts.reduceRelevance === true) entry.reduceRelevance = true;
+            if (tokenPair.to.reduceRelevance === true && options.reduceRelevance === true) entry.reduceRelevance = true;
             entry.fromLastWord = false;
             entry.to = orig_to;
             entry.inverse = inverse;
@@ -344,8 +344,6 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
     assemble(terms, 0, false, false);
     return out;
 };
-
-
 
 
 /**

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -323,21 +323,21 @@ module.exports.enumerateTokenReplacements = function(replacers, text) {
     // Iterate through the versions of each input token and assemble possible
     // combinations of the subsequent tokens.
     const out = [];
-    const assemble = (a, i, o, m) => {
-        const len = a[i].length;
+    const assemble = (termsArray, i, o, reduceRelevance) => {
+        const len = termsArray[i].length;
         for (let j = 0; j < len; j++) {
             if (out.length >= outLimit) break;
-            const ordinal = a[i][j].reduceRelevance;
-            const reduceRelevance = ordinal ? m || true : m;
-            const t = a[i][j].t;
-            const offset = a[i][j].l;
+            const ordinal = termsArray[i][j].reduceRelevance;
+            const r = ordinal ? reduceRelevance || true : reduceRelevance;
+            const t = termsArray[i][j].t;
+            const offset = termsArray[i][j].l;
             const s = o ? `${o} ${t}` : t;
-            if (i + offset < a.length) {
-                assemble(a, i + offset, s, reduceRelevance);
+            if (i + offset < termsArray.length) {
+                assemble(termsArray, i + offset, s, r);
             } else {
                 out.push({
                     phrase: s,
-                    reduceRelevance: reduceRelevance
+                    reduceRelevance: r
                 });
             }
         }

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -34,7 +34,8 @@ const escapeRegExp = require('./closest-lang').escapeRegExp;
  *
  * @param {TokenizedQuery} tokens - tokenized text
  * @param {object} options - options for token replacements
- * @param {object} options.includeUnambiguous - options for whether the keys are unique
+ * @param {object} options.includeUnambiguous - option for whether or not to include token replacements that are unambiguous
+ * @param {object} options.includeRelevanceReductions - option for whether or not to include token replacements that reduce relevance
  * @returns {Array<ReplaceRule>} an array of replace rules
  */
 module.exports.createComplexReplacer = function(tokens, options) {
@@ -84,7 +85,7 @@ module.exports.createComplexReplacer = function(tokens, options) {
         let replacementOpts = {};
         if (typeof orig_to == 'object') {
             if (orig_to.text === undefined) continue;
-            if (tokenPair.to.reduceRelevance === true && options.reduceRelevance === false) continue;
+            if (tokenPair.to.reduceRelevance && !options.includeRelevanceReduction) continue;
             replacementOpts = orig_to;
             orig_to = orig_to.text.toLowerCase();
         } else {
@@ -123,7 +124,7 @@ module.exports.createComplexReplacer = function(tokens, options) {
                     entry.spanBoundaries = from.split(/\s/).length - 1;
                 }
             }
-            if (tokenPair.to.reduceRelevance === true && options.reduceRelevance === true) entry.reduceRelevance = true;
+            if (tokenPair.to.reduceRelevance && options.includeRelevanceReduction) entry.reduceRelevance = true;
             entry.fromLastWord = false;
             entry.to = orig_to;
             entry.inverse = inverse;

--- a/test/acceptance/geocode-unit.tokens.test.js
+++ b/test/acceptance/geocode-unit.tokens.test.js
@@ -587,6 +587,8 @@ tape('teardown', (t) => {
             maxzoom: 6,
             geocoder_frequent_word_list: ['Street'],
             geocoder_tokens: {
+                // regex to drop ordinals
+                // changes 4th -> 4
                 '([0-9]+)(?:st|nd|rd|th)': {
                     'regex': true,
                     'text': '$1',
@@ -626,6 +628,8 @@ tape('teardown', (t) => {
         address: new mem({
             maxzoom: 6,
             geocoder_tokens: {
+                // regex to drop ordinals
+                // changes 4th -> 4
                 '([0-9]+)(?:st|nd|rd|th)': {
                     'regex': true,
                     'text': '$1',

--- a/test/acceptance/geocode-unit.tokens.test.js
+++ b/test/acceptance/geocode-unit.tokens.test.js
@@ -578,3 +578,49 @@ tape('teardown', (t) => {
         });
     });
 })();
+
+(() => {
+    const conf = {
+        address: new mem({
+            maxzoom: 6,
+            geocoder_tokens: {
+                '([0-9]+)(?:st|nd|rd|th)': {
+                    'regex': true,
+                    'text': '$1',
+                    'reduceRelevance': true
+                },
+                'Street': 'st',
+                'Northwest': 'nw'
+            }
+        }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('geocoder token test', (t) => {
+        const address = {
+            id:1,
+            properties: {
+                'carmen:text':'4th Street Northwest',
+                'carmen:center':[0,0],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+    tape('test token replacement', (t) => {
+        c.geocode('4th Street Northwest', { fuzzyMatch: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 1, '4th Street Northwest; relevance = 1');
+            t.end();
+        });
+    });
+    tape('test token replacement', (t) => {
+        c.geocode('4 Street Northwest', { fuzzyMatch: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 0.8, '4 Street Northwest; relevance = 0.8');
+            t.end();
+        });
+    });
+})();

--- a/test/acceptance/geocode-unit.tokens.test.js
+++ b/test/acceptance/geocode-unit.tokens.test.js
@@ -579,6 +579,48 @@ tape('teardown', (t) => {
     });
 })();
 
+// test to see if phrases that have both frequentWords and reduceRelevance are indexed
+// we need the resultant relevance to be 0.8 otherwise we lose the functionality of being able to surface 4 street northwest
+(() => {
+    const conf = {
+        address: new mem({
+            maxzoom: 6,
+            geocoder_frequent_word_list: ['Street'],
+            geocoder_tokens: {
+                '([0-9]+)(?:st|nd|rd|th)': {
+                    'regex': true,
+                    'text': '$1',
+                    'reduceRelevance': true
+                },
+                'Street': 'st',
+                'Northwest': 'nw'
+            }
+        }, () => {})
+    };
+    const c = new Carmen(conf);
+    tape('geocoder token test', (t) => {
+        const address = {
+            id:1,
+            properties: {
+                'carmen:text':'4th Street Northwest',
+                'carmen:center':[0,0],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+    tape('test for when both relevance reducing and frequentWords are in the phrase', (t) => {
+        c.geocode('4 Street Northwest', { fuzzyMatch: 1 }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features[0].relevance, 0.8, '4 Street Northwest; relevance = 0.8');
+            t.end();
+        });
+    });
+})();
+
 (() => {
     const conf = {
         address: new mem({

--- a/test/unit/text-processing/termops.getIndexablePhrases.test.js
+++ b/test/unit/text-processing/termops.getIndexablePhrases.test.js
@@ -29,7 +29,7 @@ test('termops.getIndexablePhrases', (t) => {
         {
             tokens: ['4', 'st', 'nw'],
             languages: ['default'],
-            variant: 1
+            reduceRelevance: true
         };
 
     const freq = {};
@@ -38,7 +38,7 @@ test('termops.getIndexablePhrases', (t) => {
     freq[tokens.tokens[1]] = [1];
     freq[tokens.tokens[2]] = [1];
 
-    t.deepEqual(termops.getIndexablePhrases(tokens , freq), [{ relev: 1, text: '4 st nw', phrase: '4 st nw' }]);
+    t.deepEqual(termops.getIndexablePhrases(tokens , freq), [{ relev: 0.8, text: '4 st nw', phrase: '4 st nw' }]);
     t.end();
 });
 

--- a/test/unit/text-processing/termops.getIndexablePhrases.test.js
+++ b/test/unit/text-processing/termops.getIndexablePhrases.test.js
@@ -24,6 +24,24 @@ test('termops.getIndexablePhrases', (t) => {
     t.end();
 });
 
+test('termops.getIndexablePhrases', (t) => {
+    const tokens =
+        {
+            tokens: ['4', 'st', 'nw'],
+            languages: ['default'],
+            variant: 1
+        };
+
+    const freq = {};
+    freq['__COUNT__'] = [101];
+    freq[tokens.tokens[0]] = [1];
+    freq[tokens.tokens[1]] = [1];
+    freq[tokens.tokens[2]] = [1];
+
+    t.deepEqual(termops.getIndexablePhrases(tokens , freq), [{ relev: 1, text: '4 st nw', phrase: '4 st nw' }]);
+    t.end();
+});
+
 test('termops.getIndexablePhrases - frequentWords', (t) => {
     const tokens = ['main', 'st', 'nw'];
     const frequentWords = new Set(['st', 'nw']);

--- a/test/unit/text-processing/termops.getIndexableText.test.js
+++ b/test/unit/text-processing/termops.getIndexableText.test.js
@@ -22,21 +22,21 @@ test('termops.getIndexableText', (t) => {
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'Main Street' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'street'] }
+        { languages: ['default'], tokens: ['main', 'street'],  reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'creates indexableText');
 
     replacers = createMultipleReplacers({ 'Street':'St' });
     doc = { properties: { 'carmen:text': 'Main Street' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'st'] },
+        { languages: ['default'], tokens: ['main', 'st'],  reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'creates contracted phrases using geocoder_tokens');
 
     replacers = createMultipleReplacers({ 'Street':'St' });
     doc = { properties: { 'carmen:text': 'Main Street, main st' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'st'] },
+        { languages: ['default'], tokens: ['main', 'st'],  reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'include variants');
 
@@ -44,7 +44,7 @@ test('termops.getIndexableText', (t) => {
 
     doc = { properties: { 'carmen:text': 'Main Street Lane' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'st', 'ln'] },
+        { languages: ['default'], tokens: ['main', 'st', 'ln'],  reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'include variants 2');
 
@@ -55,7 +55,7 @@ test('termops.getIndexableText', (t) => {
 
     doc = { properties: { 'carmen:text': 'Main Street St Lane' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'st', 'st', 'ln'] },
+        { languages: ['default'], tokens: ['main', 'st', 'st', 'ln'],  reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'don\'t expand st if it\'s ambiguous');
 
@@ -66,10 +66,10 @@ test('termops.getIndexableText', (t) => {
     }, { includeUnambiguous: true });
     doc = { properties: { 'carmen:text': 'Äpfelstrüdeln Strasse' } };
     texts = [
-        { languages: ['default'], tokens: ['aepfelstruedeln', 'strasse'] },
-        { languages: ['default'], tokens: ['aepfelstrudeln', 'strasse'] },
-        { languages: ['default'], tokens: ['apfelstruedeln', 'strasse'] },
-        { languages: ['default'], tokens: ['apfelstrudeln', 'strasse'] }
+        { languages: ['default'], tokens: ['aepfelstruedeln', 'strasse'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['aepfelstrudeln', 'strasse'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['apfelstruedeln', 'strasse'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['apfelstrudeln', 'strasse'],  reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'support custom reverse functions that can skip word boundaries');
 
@@ -79,8 +79,8 @@ test('termops.getIndexableText', (t) => {
     });
     doc = { properties: { 'carmen:text': 'Avenue du dix-huitième régiment' } };
     texts = [
-        { languages: ['default'], tokens: ['avenue', 'du', '18e', 'regiment'] },
-        { languages: ['default'], tokens: ['avenue', 'du', 'dix', 'huitieme', 'regiment'] }
+        { languages: ['default'], tokens: ['avenue', 'du', '18e', 'regiment'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['avenue', 'du', 'dix', 'huitieme', 'regiment'],  reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'hypenated replacement');
 
@@ -92,11 +92,11 @@ test('termops.getIndexableText', (t) => {
         }
     };
     texts = [
-        { languages: ['default'], tokens: ['main', 'street'] },
-        { languages: ['default'], tokens: ['2##', 'main', 'street'] },
-        { languages: ['default'], tokens: ['1##', 'main', 'street'] },
-        { languages: ['default'], tokens: ['##', 'main', 'street'] },
-        { languages: ['default'], tokens: ['#', 'main', 'street'] }
+        { languages: ['default'], tokens: ['main', 'street'], reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['2##', 'main', 'street'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['1##', 'main', 'street'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['##', 'main', 'street'],  reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['#', 'main', 'street'],  reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [],  doc), texts, 'with range');
 
@@ -108,11 +108,11 @@ test('termops.getIndexableText', (t) => {
         }
     };
     texts = [
-        { tokens: ['main', 'st'],            languages: ['default'] },
-        { tokens: ['2##', 'main', 'st'],     languages: ['default'] },
-        { tokens: ['1##', 'main', 'st'],     languages: ['default'] },
-        { tokens: ['##', 'main', 'st'],      languages: ['default'] },
-        { tokens: ['#', 'main', 'st'],       languages: ['default'] }
+        { tokens: ['main', 'st'],            languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['2##', 'main', 'st'],     languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['1##', 'main', 'st'],     languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['##', 'main', 'st'],      languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['#', 'main', 'st'],       languages: ['default'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [],  doc), texts, 'with range');
 
@@ -124,7 +124,7 @@ test('termops.getIndexableText', (t) => {
         }
     };
     texts = [
-        { tokens: ['n', 'newtown', 'st', 'rd'], languages: ['default'] },
+        { tokens: ['n', 'newtown', 'st', 'rd'], languages: ['default'], reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [],  doc), texts, '8 variants');
 
@@ -138,90 +138,90 @@ test('termops.getIndexableText', (t) => {
     // it happens that none of the variants with "street" will be found, since
     // those happen to be the final 8 combinations
     texts = [
-        { tokens: ['n', 'newtown', 'sq', 'st', 'rd'], languages: ['default'] }
+        { tokens: ['n', 'newtown', 'sq', 'st', 'rd'], languages: ['default'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [],  doc), texts, 'more than 8 variants');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'Main Street', 'carmen:text_es': 'El Main Street' } };
     texts = [
-        { languages: ['default'], tokens: ['main', 'street'] },
-        { languages: ['es'], tokens: ['el', 'main', 'street'] }
+        { languages: ['default'], tokens: ['main', 'street'], reduceRelevance: undefined },
+        { languages: ['es'], tokens: ['el', 'main', 'street'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, true), texts, 'in the presence of translations, plain carmen:text has language "default" and translations are language-specific');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'San Francisco Airport', 'carmen:text_universal': 'SFO' } };
     texts = [
-        { languages: ['default'], tokens: ['san', 'francisco', 'airport'] },
-        { languages: ['all'], tokens: ['sfo'] }
+        { languages: ['default'], tokens: ['san', 'francisco', 'airport'], reduceRelevance: undefined },
+        { languages: ['all'], tokens: ['sfo'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'in the presence of universal text, plain carmen:text and text_universal both have language "all"');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'San Francisco Airport', 'carmen:text_universal': 'SFO', 'carmen:text_es': 'Aeropuerto de San Francisco' } };
     texts = [
-        { languages: ['default'], tokens: ['san', 'francisco', 'airport'] },
-        { languages: ['all'], tokens: ['sfo'] },
-        { languages: ['es'], tokens: ['aeropuerto', 'de', 'san', 'francisco'] }
+        { languages: ['default'], tokens: ['san', 'francisco', 'airport'], reduceRelevance: undefined },
+        { languages: ['all'], tokens: ['sfo'], reduceRelevance: undefined },
+        { languages: ['es'], tokens: ['aeropuerto', 'de', 'san', 'francisco'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, true), texts, 'universal text is always indexed across langauges');
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'Latveria,Republic of Latveria' } };
     texts = [
-        { languages: ['default'], tokens: ['latveria'] },
-        { languages: ['default'], tokens: ['republic', 'of', 'latveria'] }
+        { languages: ['default'], tokens: ['latveria'], reduceRelevance: undefined },
+        { languages: ['default'], tokens: ['republic', 'of', 'latveria'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'creates indexableText w/ synonyms');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'carmen:text_en': 'New York' } };
     texts = [
-        { languages: ['default', 'en'], tokens: ['new', 'york'] },
-        { languages: ['es'], tokens: ['nueva', 'york'] }
+        { languages: ['default', 'en'], tokens: ['new', 'york'], reduceRelevance: undefined },
+        { languages: ['es'], tokens: ['nueva', 'york'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, true), texts, 'translations with phrase overlaps are properly grouped');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'United States', 'carmen:text_sv': 'USA', 'carmen:text_universal': 'USA' } };
     texts = [
-        { languages: ['default'], tokens: ['united', 'states'] },
-        { languages: ['sv', 'all'], tokens: ['usa'] }
+        { languages: ['default'], tokens: ['united', 'states'], reduceRelevance: undefined },
+        { languages: ['sv', 'all'], tokens: ['usa'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, true), texts, 'universal text');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York' } };
     texts = [
-        { languages: ['default', 'en'], tokens: ['new', 'york'] },
-        { languages: ['es'], tokens: ['nueva', 'york'] }
+        { languages: ['default', 'en'], tokens: ['new', 'york'], reduceRelevance: undefined },
+        { languages: ['es'], tokens: ['nueva', 'york'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, ['en']), texts, 'auto-populate from default works');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'New York,NYC,bakery', 'carmen:text_es': 'Nueva York' } };
     texts = [
-        { tokens: ['new', 'york'], languages: ['default', 'en'] },
-        { tokens: ['nyc'], languages: ['default', 'en'] },
-        { tokens: ['bakery'], languages: ['all'] },
-        { tokens: ['nueva', 'york'], languages: ['es'] }
+        { tokens: ['new', 'york'], languages: ['default', 'en'], reduceRelevance: undefined },
+        { tokens: ['nyc'], languages: ['default', 'en'], reduceRelevance: undefined },
+        { tokens: ['bakery'], languages: ['all'], reduceRelevance: undefined },
+        { tokens: ['nueva', 'york'], languages: ['es'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, ['en'], new Set(['bakery'])), texts, 'auto-universalize categories works');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'bakery,New York' } };
     texts = [
-        { tokens: ['bakery'], languages: ['default', 'en'] },
-        { tokens: ['new', 'york'], languages: ['default', 'en'] }
+        { tokens: ['bakery'], languages: ['default', 'en'], reduceRelevance: undefined },
+        { tokens: ['new', 'york'], languages: ['default', 'en'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, ['en'], new Set(['bakery'])), texts, 'display words are not universalized');
 
     replacers = createMultipleReplacers({});
     doc = { properties: { 'carmen:text': 'New York', 'carmen:text_es': 'Nueva York', 'text_en': 'The Big Apple' } };
     texts = [
-        { languages: ['default'], tokens: ['new', 'york'] },
-        { languages: ['es'], tokens: ['nueva', 'york'] },
-        { languages: ['en'], tokens: ['the', 'big', 'apple'] },
+        { languages: ['default'], tokens: ['new', 'york'], reduceRelevance: undefined },
+        { languages: ['es'], tokens: ['nueva', 'york'], reduceRelevance: undefined },
+        { languages: ['en'], tokens: ['the', 'big', 'apple'], reduceRelevance: undefined },
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc, ['en']), texts, 'auto-populate doesn\'t overwrite supplied translation');
 
@@ -234,8 +234,8 @@ test('termops.getIndexableText', (t) => {
     };
     // indexes docs with intersections in the following way:
     texts = [
-        { tokens: ['main', 'st', 'nw'], languages: ['default'] },
-        { tokens: ['+intersection', 'o', 'st', 'nw', ',', 'main', 'st', 'nw'], languages: ['default'] }
+        { tokens: ['main', 'st', 'nw'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['+intersection', 'o', 'st', 'nw', ',', 'main', 'st', 'nw'], languages: ['default'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [],  doc), texts, 'intersection indexing');
     t.end();
@@ -259,16 +259,16 @@ test('replacer/previously-globalReplacer interaction', (t) => {
 
     t.deepEqual(withUmlaut, withOe, 'umlaut and oe versions get treated the same way');
     t.deepEqual(withOe, [
-        { tokens: ['phoenix', 'str'], languages: ['default'] },
-        { tokens: ['phonix', 'str'], languages: ['default'] },
-        { tokens: ['phoenixstrasse'], languages: ['default'] },
-        { tokens: ['phonixstrasse'], languages: ['default'] }
+        { tokens: ['phoenix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phoenixstrasse'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonixstrasse'], languages: ['default'], reduceRelevance: undefined }
     ], 'all variants are generated');
     t.deepEqual(withUmlaut, [
-        { tokens: ['phoenix', 'str'], languages: ['default'] },
-        { tokens: ['phonix', 'str'], languages: ['default'] },
-        { tokens: ['phoenixstrasse'], languages: ['default'] },
-        { tokens: ['phonixstrasse'], languages: ['default'] }
+        { tokens: ['phoenix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phoenixstrasse'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonixstrasse'], languages: ['default'], reduceRelevance: undefined }
     ], 'all variants are generated');
 
     t.end();
@@ -289,12 +289,12 @@ test('replacer/globalReplacer interaction', (t) => {
 
     // Global replacers are not enumerated
     t.deepEqual(withOe, [
-        { tokens: ['phoenix', 'str'], languages: ['default'] },
-        { tokens: ['phonix', 'str'], languages: ['default'] },
+        { tokens: ['phoenix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonix', 'str'], languages: ['default'], reduceRelevance: undefined },
     ], 'all variants are generated');
     t.deepEqual(withUmlaut, [
-        { tokens: ['phoenix', 'str'], languages: ['default'] },
-        { tokens: ['phonix', 'str'], languages: ['default'] },
+        { tokens: ['phoenix', 'str'], languages: ['default'], reduceRelevance: undefined },
+        { tokens: ['phonix', 'str'], languages: ['default'], reduceRelevance: undefined },
     ], 'all variants are generated');
 
     t.end();
@@ -304,7 +304,7 @@ test('Reserved words for inherited functions', (t) => {
     const replacers = createMultipleReplacers({});
     const doc = { properties: { 'carmen:text': 'constructor' } };
     const texts = [
-        { languages: ['default'], tokens: ['constructor'] }
+        { languages: ['default'], tokens: ['constructor'], reduceRelevance: undefined }
     ];
     t.deepEqual(termops.getIndexableText(replacers.simple, replacers.complex, [], doc), texts, 'creates indexableText');
     t.end();

--- a/test/unit/text-processing/token.replaceToken.test.js
+++ b/test/unit/text-processing/token.replaceToken.test.js
@@ -299,17 +299,17 @@ test('enumerateTokenReplacement', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(replacer, termops.tokenize('fargo street northeast, san francisco')),
         [
-            'fargo street ne sf',
-            'fargo street ne san francisco',
-            'fargo street northeast sf',
-            'fargo street northeast san francisco'
+            { phrase: 'fargo street ne sf', reduceRelevance: false },
+            { phrase: 'fargo street ne san francisco', reduceRelevance: false },
+            { phrase: 'fargo street northeast sf', reduceRelevance: false },
+            { phrase: 'fargo street northeast san francisco', reduceRelevance: false }
         ],
         'fargo street northeast, san francisco - correct permutations'
     );
     t.deepEqual(
         token.enumerateTokenReplacements(replacer, termops.tokenize('fargo street ne, sf')),
         [
-            'fargo street ne sf'
+            { phrase: 'fargo street ne sf', reduceRelevance: false }
         ],
         'fargo street ne sf - correct permutations'
     );
@@ -321,20 +321,20 @@ test('enumerateTokenReplacement', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(replacer, termops.tokenize('fargo street northeast, san francisco')),
         [
-            'fargo street ne sf',
-            'fargo street ne san francisco',
-            'fargo street northeast sf',
-            'fargo street northeast san francisco'
+            { phrase: 'fargo street ne sf', reduceRelevance: false },
+            { phrase: 'fargo street ne san francisco', reduceRelevance: false },
+            { phrase: 'fargo street northeast sf', reduceRelevance: false },
+            { phrase: 'fargo street northeast san francisco', reduceRelevance: false }
         ],
         'fargo street northeast, san francisco - inverse, correct permutations'
     );
     t.deepEqual(
         token.enumerateTokenReplacements(replacer, termops.tokenize('fargo street ne, sf')),
         [
-            'fargo street ne sf',
-            'fargo street ne san francisco',
-            'fargo street northeast sf',
-            'fargo street northeast san francisco'
+            { phrase: 'fargo street ne sf', reduceRelevance: false },
+            { phrase: 'fargo street ne san francisco', reduceRelevance: false },
+            { phrase: 'fargo street northeast sf', reduceRelevance: false },
+            { phrase: 'fargo street northeast san francisco', reduceRelevance: false }
         ],
         'fargo street ne sf - inverse, correct permutations'
     );
@@ -346,10 +346,10 @@ test('enumerateTokenReplacement', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(replacer, termops.tokenize('abc 123 def')),
         [
-            'xyz @@@123@@@ def',
-            'xyz 123 def',
-            'abc @@@123@@@ def',
-            'abc 123 def'
+            { phrase: 'xyz @@@123@@@ def', reduceRelevance: false },
+            { phrase: 'xyz 123 def', reduceRelevance: false },
+            { phrase: 'abc @@@123@@@ def', reduceRelevance: false },
+            { phrase: 'abc 123 def', reduceRelevance: false }
         ],
         'numeric capture groups - correct permutations'
     );
@@ -372,10 +372,10 @@ test('enumerateTokenReplacement cascades', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(ubTokens, termops.tokenize('Jüdenstraße 17')),
         [
-            'jueden str 17',
-            'jüden str 17',
-            'juedenstraße 17',
-            'jüdenstraße 17'
+            { phrase: 'jueden str 17', reduceRelevance: false },
+            { phrase: 'jüden str 17', reduceRelevance: false },
+            { phrase: 'juedenstraße 17', reduceRelevance: false },
+            { phrase: 'jüdenstraße 17', reduceRelevance: false }
         ],
         'Jüdenstraße 17 - correct permutations'
     );
@@ -392,10 +392,10 @@ test('enumerateTokenReplacement cascades', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(ubTokens, termops.tokenize('Jüdenstraße 17')),
         [
-            'jueden str 17',
-            'jüden str 17',
-            'juedenstraße 17',
-            'jüdenstraße 17'
+            { phrase: 'jueden str 17', reduceRelevance: false },
+            { phrase: 'jüden str 17', reduceRelevance: false },
+            { phrase: 'juedenstraße 17', reduceRelevance: false },
+            { phrase: 'jüdenstraße 17', reduceRelevance: false }
         ],
         'Jüdenstraße 17 - correct permutations, reversed replacement order'
     );
@@ -413,14 +413,14 @@ test('enumerateTokenReplacement cascades', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(ubTokens, termops.tokenize('Kölnerstraße 27 40211 Düsseldorf')),
         [
-            'koelner str 27 40211 duesseldorf',
-            'koelner str 27 40211 düsseldorf',
-            'kölner str 27 40211 duesseldorf',
-            'kölner str 27 40211 düsseldorf',
-            'koelnerstraße 27 40211 duesseldorf',
-            'koelnerstraße 27 40211 düsseldorf',
-            'kölnerstraße 27 40211 duesseldorf',
-            'kölnerstraße 27 40211 düsseldorf'
+            { phrase: 'koelner str 27 40211 duesseldorf', reduceRelevance: false },
+            { phrase: 'koelner str 27 40211 düsseldorf', reduceRelevance: false },
+            { phrase: 'kölner str 27 40211 duesseldorf', reduceRelevance: false },
+            { phrase: 'kölner str 27 40211 düsseldorf', reduceRelevance: false },
+            { phrase: 'koelnerstraße 27 40211 duesseldorf', reduceRelevance: false },
+            { phrase: 'koelnerstraße 27 40211 düsseldorf', reduceRelevance: false },
+            { phrase: 'kölnerstraße 27 40211 duesseldorf', reduceRelevance: false },
+            { phrase: 'kölnerstraße 27 40211 düsseldorf', reduceRelevance: false }
         ],
         'Kölnerstraße 27 40211 Düsseldorf - correct permutations'
     );
@@ -435,18 +435,18 @@ test('enumerateTokenReplacement - inverse behavior', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(replacers, termops.tokenize('saint street term')),
         [
-            'st st',
-            'st street term',
-            'saint st',
-            'saint street term'
+            { phrase: 'st st', reduceRelevance: false },
+            { phrase: 'st street term', reduceRelevance: false },
+            { phrase: 'saint st', reduceRelevance: false },
+            { phrase: 'saint street term', reduceRelevance: false }
         ],
         'correct permutations for replacement with identical output'
     );
     t.deepEqual(
         token.enumerateTokenReplacements(replacers, termops.tokenize('st street term')),
         [
-            'st st',
-            'st street term'
+            { phrase: 'st st', reduceRelevance: false },
+            { phrase: 'st street term', reduceRelevance: false }
         ],
         'correct permutations for replacement with identical output'
     );
@@ -457,18 +457,18 @@ test('enumerateTokenReplacement - inverse behavior', (t) => {
     t.deepEqual(
         token.enumerateTokenReplacements(replacers, termops.tokenize('saint street term')),
         [
-            'saint st',
-            'saint street term'
+            { phrase: 'saint st', reduceRelevance: false },
+            { phrase: 'saint street term', reduceRelevance: false }
         ],
         'replaced terms are not re-expanded by inverse replacers'
     );
     t.deepEqual(
         token.enumerateTokenReplacements(replacers, termops.tokenize('st street term')),
         [
-            'st st',
-            'st street term',
-            'street term st',
-            'street term street term'
+            { phrase: 'st st', reduceRelevance: false },
+            { phrase: 'st street term', reduceRelevance: false },
+            { phrase: 'street term st', reduceRelevance: false },
+            { phrase: 'street term street term', reduceRelevance: false }
         ],
         'inverse replacement are used on input, but do not re-expanded previous replacement'
     );
@@ -490,17 +490,17 @@ test('enumerateTokenReplacement limits', (t) => {
 
     query = new Array(1).fill('Kölnerstraße').join(' ');
     enumerated = token.enumerateTokenReplacements(replacements, termops.tokenize(query));
-    t.equal(enumerated[0], 'koelner str');
+    t.deepEqual(enumerated[0], { phrase: 'koelner str', reduceRelevance: false });
     t.deepEqual(enumerated.length, 4, '1 double replaced input');
 
     query = new Array(2).fill('Kölnerstraße').join(' ');
     enumerated = token.enumerateTokenReplacements(replacements, termops.tokenize(query));
-    t.equal(enumerated[0], 'koelner str koelner str');
+    t.deepEqual(enumerated[0], { phrase: 'koelner str koelner str', reduceRelevance: false });
     t.deepEqual(enumerated.length, 8, '2 double replaced inputs');
 
     query = new Array(4).fill('Kölnerstraße').join(' ');
     enumerated = token.enumerateTokenReplacements(replacements, termops.tokenize(query));
-    t.equal(enumerated[0], 'koelner str koelner str koelner str koelner str');
+    t.deepEqual(enumerated[0], { phrase: 'koelner str koelner str koelner str koelner str', reduceRelevance: false });
     t.deepEqual(enumerated.length, 8, '4 double replaced inputs');
 
     t.end();


### PR DESCRIPTION
### Context
A recent address triage process revealed that ~7% of the failures came from details missing data in input which means that the query left out details like the cardinal directions NW, SW), or way types (street, road etc) or ordinals. Out of the 7% of failures where the user failed to include details in the query, users most frequently left out ordinals like `th` in `7th street northwest`. A solution to this problem was to index both forms of the feature, one with the ordinal and one without at a reduced relevance. For example, say we have the following feature:
```
const address = {
            id:1,
            properties: {
                'carmen:text':'4th Street Northwest',
                'carmen:center':[0,0],
            },
            geometry: {
                type: 'Point',
                coordinates: [0,0]
            }
        };
```
The idea here is to index both `4th Street Northwest` as well as `4 Street Northwest` but the phrase `4 Street Northwest` would have a lower relevance (0.8).

This would only affect our indexing process and will not affect our behaviour during query time.

### Summary of Changes
- [x] Add a flag to complex token replacement on the indexing side which suggests relevance reduction
- [x] Add functionality to reduce the relevance of a phrase if a flag is set
- [x] Add tests that are indicative of ordinal dropping token replacement - check to see if we get back a result after dropping the ordinal


### Next Steps
- [x] Review 
- [ ] Merge
- [ ] Release + changelog

cc @mapbox/search
