### PR TITLE
Feature prox radius

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -496,7 +496,8 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
                 geocoder.minScore,
                 geocoder.maxScore,
                 feat.properties['carmen:distance'],
-                feat.properties['carmen:zoom']
+                feat.properties['carmen:zoom'],
+                feat.properties['carmen:proximity_radius']
             );
             feat.properties['carmen:relevance'] = proximity.relevanceScore(
                 feat.properties['carmen:spatialmatch'].relev,

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -896,7 +896,8 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
                 geocoder.minScore,
                 geocoder.maxScore,
                 feat.properties['carmen:distance'],
-                feat.properties['carmen:zoom']
+                feat.properties['carmen:zoom'],
+                feat.properties['carmen:proximity_radius']
             );
             feat.properties['carmen:relevance'] = proximity.relevanceScore(
                 feat.properties['carmen:spatialmatch'].relev,

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -288,9 +288,6 @@ function storableProperties(properties, type) {
             case 'carmen:geocoder_stack':
                 storable[k] = properties[k];
                 break;
-            case 'carmen:proximity_radius':
-                storable[k] = properties[k];
-                break;
             case 'carmen:addressprops':
             case 'carmen:addressnumber':
             case 'carmen:address_style':
@@ -304,6 +301,7 @@ function storableProperties(properties, type) {
             case 'carmen:ltohn':
             case 'carmen:rtohn':
             case 'carmen:zxy':
+            case 'carmen:proximity_radius':
                 if (type !== 'vector') storable[k] = properties[k];
                 break;
         }

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -288,6 +288,9 @@ function storableProperties(properties, type) {
             case 'carmen:geocoder_stack':
                 storable[k] = properties[k];
                 break;
+            case 'carmen:proximity_radius':
+                storable[k] = properties[k];
+                break;
             case 'carmen:addressprops':
             case 'carmen:addressnumber':
             case 'carmen:address_style':

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -91,9 +91,9 @@ function center2zxy(center, z) {
  * @param {String} zoom The vector tile zoom level of the index the feature is part of.
  * @return {Number} proximity adjusted score value between 1 and 5,000
  */
-function scoredist(score, minScore, maxScore, dist, zoom) {
+function scoredist(score, minScore, maxScore, dist, zoom, radius) {
     const scoreVal = scoreWeight(score, minScore, maxScore);
-    const distVal = distWeight(dist, zoom);
+    const distVal = distWeight(dist, zoom, radius);
     return distVal * scoreVal;
 }
 
@@ -123,8 +123,8 @@ function scoreWeight(score, minScore, maxScore) {
  * @param {String} zoom The vector tile zoom level of the index the feature is part of.
  * @return {Number} scaled score value
  */
-function distWeight(dist, zoom) {
-    const distRatio = dist / scaleRadius(zoom);
+function distWeight(dist, zoom, radius) {
+    const distRatio = dist / (radius || scaleRadius(zoom));
     const gaussVal = gauss(distRatio * 3, VARIANCE_CONSTANT);
     return (9 * gaussVal) + 1;
 }

--- a/lib/util/proximity.js
+++ b/lib/util/proximity.js
@@ -89,6 +89,7 @@ function center2zxy(center, z) {
  * @param {Number} maxScore The maximum score of all features in all indexes
  * @param {Number} dist The distance from the feature to the proximity point in miles.
  * @param {String} zoom The vector tile zoom level of the index the feature is part of.
+ * @param {Number} radius Optional proximity radius to override the zoom-based default.
  * @return {Number} proximity adjusted score value between 1 and 5,000
  */
 function scoredist(score, minScore, maxScore, dist, zoom, radius) {
@@ -121,6 +122,7 @@ function scoreWeight(score, minScore, maxScore) {
  * proximity radius.
  * @param {Number} dist The distance in miles from the feature to the proximity point
  * @param {String} zoom The vector tile zoom level of the index the feature is part of.
+ * @param {Number} radius Optional proximity radius to override the zoom-based default.
  * @return {Number} scaled score value
  */
 function distWeight(dist, zoom, radius) {

--- a/test/unit/util/feature.storableProperties.test.js
+++ b/test/unit/util/feature.storableProperties.test.js
@@ -1,0 +1,29 @@
+'use strict';
+const tape = require('tape');
+const feature = require('../../../lib/util/feature.js');
+
+tape('storableProperties', (t) => {
+    const featProperties = {
+        // Should be stored
+        'noncarmenproperty': 'not a carmen property',
+        'carmen:text': 'a',
+        'carmen:text_en': 'a',
+        'carmen:center': [0, 0],
+        'carmen:zxy': ['6/32/32'],
+        'carmen:format_es': '{{address.number}} {{address.name}}, {{place.name}}, {{country.name}}',
+        'carmen:score': 5,
+        'carmen:proximity_radius': 1000,
+        // Should not be stored
+        'carmen:newproperty': 'new property',
+    };
+    const properties = feature.storableProperties(featProperties);
+    t.ok(properties['noncarmenproperty'], 'property not prefixed with Carmen should be stored.');
+    t.ok(properties['carmen:text'], 'carmen:text property should be stored.');
+    t.ok(properties['carmen:text_en'], 'carmen:text_* language properties should be stored.');
+    t.ok(properties['carmen:center'], 'carmen:center should be stored.');
+    t.ok(properties['carmen:format_es'], 'carmen:format_* address formats should be stored.');
+    t.ok(properties['carmen:score'], 'carmen:score should be stored.');
+    t.ok(properties['carmen:proximity_radius'], 'carmen:proximity_radius should be stored.');
+    t.notOk(properties['carmen:newproperty'], 'carmen properties not explicitly allowed should not be stored.');
+    t.end();
+});

--- a/test/unit/util/proximity.scoredist.test.js
+++ b/test/unit/util/proximity.scoredist.test.js
@@ -26,7 +26,8 @@ function calculateScoreDist(input) {
             minScore,
             maxScore,
             feat.properties['carmen:distance'],
-            feat.properties['carmen:zoom']
+            feat.properties['carmen:zoom'],
+            feat.properties['carmen:proximity_radius']
         ).toFixed(6));
     }
 }
@@ -205,6 +206,27 @@ test('scoredist', (t) => {
             { id: 19, properties: { 'carmen:text': 'Mission-Foothill', 'carmen:distance': 19.97574371302543, 'carmen:score': 44, 'carmen:zoom': ZOOM_LEVELS.neighborhood } },
             { id: 13, properties: { 'carmen:text': 'Mission Workshop,bicycle, bike, cycle', 'carmen:distance': 0.821663496329208, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
             { id: 14, properties: { 'carmen:text': 'Mission Pet Hospital', 'carmen:distance': 0.6281933184839765, 'carmen:score': 0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+        ];
+
+        calculateScoreDist(input);
+        input.sort(compareScoreDist);
+        for (let i = 0; i < input.length; i++) {
+            const feat = input[i];
+            t.equal(i + 1, feat.id, `${feat.properties['carmen:text']}`);
+        }
+        t.end();
+    });
+
+    t.test('jfk airport near Yonkers', (t) => {
+        // -- query="JFK" --proximity="-73.8987,40.9312"
+        // Withouth the proximity radius, JFK Marina would have the highest scoredist, since it's much closer to the proximity point in Yonkers, NY
+        const input = [
+            { 'id': 2, 'properties': { 'carmen:text': 'JFK Marina', 'carmen:distance': 1.5874323231313108, 'carmen:score': 2, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { 'id': 1, 'properties': { 'carmen:text': 'JFK Airport', 'carmen:distance': 20.869597236876366, 'carmen:score': 323, 'carmen:zoom': ZOOM_LEVELS.poi, 'carmen:proximity_radius': 1000 } },
+            { 'id': 3, 'properties': { 'carmen:text': 'JFK Fried Chicken', 'carmen:distance': 8.337828979299953, 'carmen:score':  0, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { 'id': 4, 'properties': { 'carmen:text': 'JFK Memorial Library', 'carmen:distance': 12.372310018772831, 'carmen:score': 1, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { 'id': 5, 'properties': { 'carmen:text': 'JFK Liquors', 'carmen:distance': 16.226635859349628, 'carmen:score': 6, 'carmen:zoom': ZOOM_LEVELS.poi } },
+            { 'id': 6, 'properties': { 'carmen:text': 'JFK AirTrain', 'carmen:distance': 16.721436332089933, 'carmen:score': 10, 'carmen:zoom': ZOOM_LEVELS.poi } }
         ];
 
         calculateScoreDist(input);


### PR DESCRIPTION
### Context
This PR makes it possible for a feature to have a custom proximity radius for calculating scoredist. This allows for surfacing important features, like airports, from farther away, without using a scoring adjustment that would increase the max score of an index. Increasing the max score of an index has wider ramifications, since the max score is used to encode and decode scores, and compare features across indexes. In addition, this doesn't change the global distribution of scores, it only affects the scoredist calculations when proximity is provided


### Summary of Changes
- [x] Adds `carmen:proximity_radius` as a storable property on a feature for indexing
- [x] Adds a radius option to the proximity.scoredist calculation, which overrides the default zoom-based proximity radius constant
- [x] Passes the feature's `carmen:proximity_radius` property into the scoredist calculation


### Next Steps
- [ ] Release a new carmen version

cc @mapbox/search
