### PR TITLE
Gridstore opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,6 +355,8 @@ function Geocoder(indexes, options) {
                     // read case: we'll be creating a GridStore and storing it in _gridstore.reader
                     source._gridstore = {
                         reader: new carmenCore.GridStore(gridStoreFile, {
+                            idx: source.idx,
+                            zoom: source.zoom,
                             type_id: source.ndx,
                             non_overlapping_indexes: source.bmask,
                             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS

--- a/index.js
+++ b/index.js
@@ -124,9 +124,9 @@ function Geocoder(indexes, options) {
 
             if (names.indexOf(name) === -1) names.push(name);
 
-            // Set references to _geocoder, _fuzzyset on original source to
-            // avoid duplication if it's loaded again.
-            source._original._gridstore = source._gridstore;
+            if (source._original._gridstore) source._gridstore = source._original._gridstore;
+            if (source._original._fuzzyset) source._fuzzyset = source._original._fuzzyset;
+
             source._original._fuzzyset = source._fuzzyset;
 
             if (info.geocoder_address) {
@@ -341,6 +341,7 @@ function Geocoder(indexes, options) {
                         writer: null
                     };
                 }
+                source._original._fuzzyset = source._fuzzyset;
             }
 
             if (!source._gridstore) {
@@ -364,6 +365,7 @@ function Geocoder(indexes, options) {
                         writer: null
                     };
                 }
+                source._original._gridstore = source._gridstore;
             }
         }
 

--- a/lib/geocoder/geocode.js
+++ b/lib/geocoder/geocode.js
@@ -389,18 +389,20 @@ function forwardGeocode(geocoder, text, options, callback) {
         }
         if (options.debug) {
             options.debug.phrasematch = {};
+            let idx = 0;
             for (const resultSet of _phrasematchResults) {
-                const id = geocoder.byidx[resultSet.idx].id;
+                const id = geocoder.byidx[idx].id;
+                idx++;
                 options.debug.phrasematch[id] = {};
-                for (let x = 0; x < resultSet.phrasematches.length; x++) {
-                    const matched = resultSet.phrasematches[x];
+                for (let x = 0; x < resultSet.length; x++) {
+                    const matched = resultSet[x];
                     const phraseText = matched.subquery.join(' ');
                     options.debug.phrasematch[id][phraseText] = matched.weight;
                 }
             }
         }
 
-        const phrasematchResults = _phrasematchResults.filter((resultSet) => resultSet.phrasematches.length > 0);
+        const phrasematchResults = _phrasematchResults.filter((resultSet) => resultSet.length > 0);
         spatialmatch(queryData.query, phrasematchResults, options, spatialmatchComplete);
     });
 

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -28,13 +28,13 @@ module.exports = function phrasematch(source, query, options, callback) {
     // if requested country isn't included, skip
     if (options.stacks) {
         const stackAllowed = filter.sourceMatchesStacks(source, options);
-        if (!stackAllowed) return callback(null, new PhrasematchResult([], source));
+        if (!stackAllowed) return callback(null, []);
     }
 
     // if not in bbox, skip
     if (options.bbox) {
         const intersects = bb.amIntersect(options.bbox, source.bounds);
-        if (!intersects) return callback(null, new PhrasematchResult([], source));
+        if (!intersects) return callback(null, []);
     }
 
     const proxMatch = options.proximity ?
@@ -302,7 +302,7 @@ module.exports = function phrasematch(source, query, options, callback) {
         phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, editMultiplier, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
     }
 
-    return callback(null, new PhrasematchResult(phrasematches, source));
+    return callback(null, phrasematches);
 };
 
 /**
@@ -460,19 +460,6 @@ function coverGaps(masks, sq) {
         }
     }
     return ret;
-}
-
-/**
-* PhrasematchResult
-* @param {Object} phrasematches for the subquery combinations generated from the phrasematch function
-* @param {Object} source a Geocoder datasource
-**/
-module.exports.PhrasematchResult = PhrasematchResult;
-function PhrasematchResult(phrasematches, source) {
-    this.phrasematches = phrasematches;
-    this.idx = source.idx;
-    this.nmask = 1 << source.ndx;
-    this.bmask = source.bmask;
 }
 
 /**

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -257,7 +257,6 @@ module.exports = function phrasematch(source, query, options, callback) {
         const b = findMaskBounds(subquery.mask, MAX_QUERY_TOKENS);
         const weight = (b[1] - b[0] + 1) / query.tokens.length;
 
-        let editMultiplier = 1;
         if (subquery.edit_distance !== 0) {
             // approximate a levenshtein ratio -- this is usually defined as
             // ratio(a, b) = ((len(a) + len(b)) - distance(a, b)) / (len(a) + len(b))
@@ -265,10 +264,11 @@ module.exports = function phrasematch(source, query, options, callback) {
             // so that different matches that are the same distance from the query
             // text can be disambiguated by score even if they have different lengths
             const original = subquery.original_phrase.join(' ');
-            editMultiplier = Math.max(
+            const penalty = Math.max(
                 (original.length - (subquery.edit_distance / 2)) / original.length,
                 .75
             );
+            weight *= penalty;
         }
 
         // If the query matches an index with geocoder_categories set
@@ -291,7 +291,7 @@ module.exports = function phrasematch(source, query, options, callback) {
             // the match's number isn't where the index expects it to be
             subquery.address.numberOrder !== source.geocoder_expected_number_order
         ) {
-            editMultiplier *= 0.99;
+            weight *= 0.99;
         }
 
         // Set prefix to determine how carmen cache will handle autocomplete
@@ -299,7 +299,7 @@ module.exports = function phrasematch(source, query, options, callback) {
         const phrase_id_range = subquery.phrase_id_range;
         const extendedScan = partialNumber;
 
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, editMultiplier, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
     }
 
     return callback(null, phrasematches);
@@ -477,14 +477,13 @@ function coverGaps(masks, sq) {
  * @param {Number} radius proximity radius of the source to use in coalesce
  * @param {Number} prefix the ending type of the match - nonPrefix: 0, anyPrefix: 1, wordBoundaryPrefix: 2
  * @param {Array} languages langagues matched
- * @param {Number} editMultiplier an approximation of a levenstein ratio
  * @param {boolean} proxMatch whether the proximity point is inside the source bounds, or false if no proximity was specified
  * @param {boolean} catMatch whether the phrase matches any categories specified on the source index
  * @param {boolean} partialNumber whether the phrase is a number-only query
  * @param {boolean} extendedScan whether or not to do an extended scan
  * @param {Number} address the address number that matches the query
  */
-function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, store, zoom, radius, prefix, languages, editMultiplier, proxMatch, catMatch, partialNumber, extendedScan, address) {
+function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, address) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -496,7 +495,6 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
     this.store = store;
     this.zoom = zoom;
     this.radius = radius;
-    this.editMultiplier = editMultiplier || 1;
     this.proxMatch = proxMatch || false;
     this.catMatch = catMatch || false;
     this.partialNumber = partialNumber || false;
@@ -523,7 +521,7 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
 }
 
 Phrasematch.prototype.clone = function() {
-    const cloned = new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.editMultiplier, this.proxMatch, this.catMatch, this.partialNumber, this.extendedScan, this.address);
+    const cloned = new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.extendedScan, this.address);
     cloned.id = this.id;
     return cloned;
 };

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -112,10 +112,10 @@ function rebalance(query, stack) {
     let totalWeight = 0;
     for (let k = 0; k < stack.length; k++) {
         stackClone[k] = stack[k].clone();
-        stackClone[k].weight = roundTo((
+        stackClone[k].weight = roundTo(
             weightPerMatch +
             (totalLengthBonus * stack[k].weight)
-        ) * stack[k].editMultiplier, 8);
+        , 8);
         totalWeight += stackClone[k].weight;
     }
 

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -4,7 +4,6 @@ const stackAndCoalesce = require('@mapbox/carmen-core').stackAndCoalesce;
 const bbox = require('../util/bbox.js');
 const roundTo = require('../util/round-to.js');
 const termops = require('../text-processing/termops');
-const constants = require('../constants');
 
 module.exports = spatialmatch;
 module.exports.rebalance = rebalance;
@@ -28,17 +27,10 @@ function spatialmatch(query, phrasematchResults, options, callback) {
     coalesceOpts.zoom = preparedPhrasematches.maxZoom;
     if (options) {
         if (options.proximity) {
-            coalesceOpts.proximity = {
-                point: proximity.center2zxy(
-                    options.proximity,
-                    coalesceOpts.zoom
-                ).slice(1),
-                // TODO: this used to be *either* the constant or the per-index
-                // value based on the contents of the particular stack, but
-                // now that this is shared across all stacks, we should ditch
-                // the radius altogether here and instead move it into the index
-                radius: constants.COALESCE_PROXIMITY_RADIUS
-            };
+            coalesceOpts.proximity = proximity.center2zxy(
+                options.proximity,
+                coalesceOpts.zoom
+            ).slice(1);
         }
 
         if (options.bbox) {
@@ -46,7 +38,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
         }
     }
 
-    stackAndCoalesce(phrasematchResults, coalesceOpts, done);
+    stackAndCoalesce(preparedPhrasematches.flattenedPhrasematches, coalesceOpts, done);
 
     function done(err, results) {
         if (err) return callback(err);
@@ -138,22 +130,8 @@ function preparePhrasematches(phrasematchResults) {
     let maxZoom = 0;
 
     for (let i = 0; i < phrasematchResults.length; i++) {
-        for (let j = 0; j < phrasematchResults[i].phrasematches.length; j++) {
-            const phrasematch = phrasematchResults[i].phrasematches[j];
-            const subquery = phrasematch.subquery;
-            if (subquery) {
-                phrasematch.subquery = Array.from(subquery);
-                phrasematch.subquery_edit_distance = subquery.edit_distance;
-                phrasematch.subquery_edit_distance = subquery.ending_type;
-                phrasematch.subquery_phrase_id_range = subquery.phrase_id_range;
-                phrasematch.subquery_mask = subquery.mask;
-                phrasematch.subquery_address = subquery.address;
-                phrasematch.original_phrase = Array.from(subquery.original_phrase);
-                phrasematch.original_phrase_ender = subquery.original_phrase.ender;
-                phrasematch.original_phrase_mask = subquery.original_phrase.mask;
-                phrasematch.original_phrase_address = subquery.original_phrase.address;
-            }
-
+        for (let j = 0; j < phrasematchResults[i].length; j++) {
+            const phrasematch = phrasematchResults[i][j];
             phrasematch.id = id;
 
             if (phrasematch.zoom > maxZoom) maxZoom = phrasematch.zoom;

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const feature = require('../util/feature'),
+    constants = require('../constants'),
     queue = require('d3-queue').queue,
     indexdocs = require('./indexdocs'),
     split = require('split'),
@@ -227,7 +228,13 @@ function store(source, callback) {
 
         const gridStoreFile = source.getBaseFilename() + '.gridstore.rocksdb';
         source._gridstore.writer = null;
-        source._gridstore.reader = new carmenCore.GridStore(gridStoreFile);
+        source._gridstore.reader = new carmenCore.GridStore(gridStoreFile, {
+            idx: source.idx,
+            zoom: source.zoom,
+            type_id: source.ndx,
+            non_overlapping_indexes: source.bmask,
+            coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS
+        });
 
         callback();
     });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "0.1.1",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#a3052827fab58b61bd75769ff306b393525b9bcf",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,10 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/carmen-core/-/carmen-core-0.1.1.tgz#dea441af76d360aecd2a140ce34f6472f8f6bd98"
-  integrity sha512-yQreA+klXKai1XZsT84oFgGqj66n/O+5lp79R8rWAdRzycgIWqfR4x73vCByj92xvl7g415Dr2S++6pcGAO+vg==
+"@mapbox/carmen-core@github:mapbox/carmen-core#a3052827fab58b61bd75769ff306b393525b9bcf":
+  version "0.1.1-stack-and-coalesce-4"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/a3052827fab58b61bd75769ff306b393525b9bcf"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This is the companion PR to mapbox/carmen-core#72, which moves a bunch of fields from phrasematches into the gridstore type, and makes some other changes to how phrasematches are structured and coalesce is called.


### Summary of Changes
- [x] The big one is the refactor of index.js in Carmen, which includes the Carmen constructor that does all of the setup for new geocoding instances. There are a bunch of items that are currently properties on each carmen `source` object that get copied onto every phrasematch produced by that source (idx, zoom, ndx/nmask, bmask, etc.). I wanted to just move those into the store up front, at construction time, rather than send them over the wire on every call. Unfortunately, in master we construct the gridstore object before many of these values are calculated and set, so the order of operations in the construction of new Carmen objects had to change.
- [x] while I was at it, I simplified the structure a bit. It was super callback-hell-y, with an order of operations that was hard to follow. Hopefully it's easier now?
- [x] I changed phrasematch to just return an array rather than a nested thing, since the nested thing just had properties that are now in the gridstore
- [x] I dropped some fields from the phrasematches that get passed in; we were doing some copying from the subquery onto the phrasematch, but we don't actually need any of those copied fields on the rust side
- [x] dropped the editMultiplier, which was a way of keeping both full and penalized relevances around for the complicated heuristics we used to do to rank stacks. We don't rank stacks anymore, so this shouldn't be necessary anymore and we can just penalize the weights directly


### Next Steps
No?


cc @mapbox/search
