### PR TITLE
Put idx and non_overlapping_indexes back how they were

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,10 +351,8 @@ function Geocoder(indexes, options) {
                     // read case: we'll be creating a GridStore and storing it in _gridstore.reader
                     source._gridstore = {
                         reader: new carmenCore.GridStore(gridStoreFile, {
-                            idx: source.idx,
                             zoom: source.zoom,
                             type_id: source.ndx,
-                            non_overlapping_indexes: source.non_overlapping_indexes,
                             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS
                         }),
                         writer: null

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -299,7 +299,7 @@ module.exports = function phrasematch(source, query, options, callback) {
         const phrase_id_range = subquery.phrase_id_range;
         const extendedScan = partialNumber;
 
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
     }
 
     return callback(null, phrasematches);
@@ -483,7 +483,7 @@ function coverGaps(masks, sq) {
  * @param {boolean} extendedScan whether or not to do an extended scan
  * @param {Number} address the address number that matches the query
  */
-function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, address) {
+function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, non_overlapping_indexes, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, address) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -492,6 +492,7 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
     this.scorefactor = scorefactor;
     this.prefix = prefix;
     this.idx = idx;
+    this.non_overlapping_indexes = non_overlapping_indexes;
     this.store = store;
     this.zoom = zoom;
     this.radius = radius;

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -229,10 +229,8 @@ function store(source, callback) {
         const gridStoreFile = source.getBaseFilename() + '.gridstore.rocksdb';
         source._gridstore.writer = null;
         source._gridstore.reader = new carmenCore.GridStore(gridStoreFile, {
-            idx: source.idx,
             zoom: source.zoom,
             type_id: source.ndx,
-            non_overlapping_indexes: source.non_overlapping_indexes,
             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS
         });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#a3052827fab58b61bd75769ff306b393525b9bcf",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#6754ba2e5dc339946257b6ad6744f88e84f258eb",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#a3052827fab58b61bd75769ff306b393525b9bcf":
-  version "0.1.1-stack-and-coalesce-4"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/a3052827fab58b61bd75769ff306b393525b9bcf"
+"@mapbox/carmen-core@github:mapbox/carmen-core#6754ba2e5dc339946257b6ad6744f88e84f258eb":
+  version "0.1.1-put-idx-back-1"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/6754ba2e5dc339946257b6ad6744f88e84f258eb"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This is the companion PR to https://github.com/mapbox/carmen-core/pull/76, which requires that the `idx` and `non_overlapping_indexes` properties, which had moved from phrasematches onto the gridstore object, be moved back to the phrasematch again. This was necessary because it turns out Carmen can reuse the same gridstore for multiple tilesets, and two different Carmen sources that share the same gridstore might not have the same idx.


### Summary of Changes
- [x] Move a `idx` and `non_overlapping_indexes` back to the way they were before #921

### Next Steps
<!-- if you're still working on it -->


cc @mapbox/search
