### PR TITLE
carmen-core@nearby-only

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -522,7 +522,12 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
 }
 
 Phrasematch.prototype.clone = function() {
-    const cloned = new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.nearby_only, this.address);
+    const subquery = this.subquery.slice();
+    for (const key of Object.keys(this.subquery)) {
+        // copy over all the extra keys we hacked onto the array
+        if (!subquery.hasOwnProperty(key)) subquery[key] = JSON.parse(JSON.stringify(this.subquery[key]));
+    }
+    const cloned = new Phrasematch(subquery, this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.non_overlapping_indexes, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.nearby_only, this.address);
     cloned.id = this.id;
     return cloned;
 };

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -297,9 +297,9 @@ module.exports = function phrasematch(source, query, options, callback) {
         // Set prefix to determine how carmen cache will handle autocomplete
         const prefix = subquery.ending_type;
         const phrase_id_range = subquery.phrase_id_range;
-        const extendedScan = partialNumber;
+        const nearbyOnly = partialNumber;
 
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, subquery.address));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, subquery.address));
     }
 
     return callback(null, phrasematches);
@@ -480,10 +480,10 @@ function coverGaps(masks, sq) {
  * @param {boolean} proxMatch whether the proximity point is inside the source bounds, or false if no proximity was specified
  * @param {boolean} catMatch whether the phrase matches any categories specified on the source index
  * @param {boolean} partialNumber whether the phrase is a number-only query
- * @param {boolean} extendedScan whether or not to do an extended scan
+ * @param {boolean} nearbyOnly whether or not to do an extended scan
  * @param {Number} address the address number that matches the query
  */
-function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, non_overlapping_indexes, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, extendedScan, address) {
+function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, non_overlapping_indexes, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, address) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -499,7 +499,7 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
     this.proxMatch = proxMatch || false;
     this.catMatch = catMatch || false;
     this.partialNumber = partialNumber || false;
-    this.extendedScan = extendedScan || false;
+    this.nearby_only = nearbyOnly || false;
     this.address = address || null;
     if (languages) {
         // carmen-cache gives special treatment to the "languages" property
@@ -522,7 +522,7 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
 }
 
 Phrasematch.prototype.clone = function() {
-    const cloned = new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.extendedScan, this.address);
+    const cloned = new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.nearby_only, this.address);
     cloned.id = this.id;
     return cloned;
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#0761df2014f5f4c2d32ae21b68ca25b0b09d50f7",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#ffe7cab3fdee516db67852896395e53e4115d1d9",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/unit/geocoder/phrasematch.test.js
+++ b/test/unit/geocoder/phrasematch.test.js
@@ -232,6 +232,9 @@ tape('fuzzyMatchWindows - removed term', (t) => {
             t.ok(expected.has(k), `has "${k}"`);
         });
         t.deepEqual(query, clone, 'replacements did not altery query');
+
+        t.deepEqual(results[0], results[0].clone(), 'phrasematch clone works');
+
         t.end();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#0761df2014f5f4c2d32ae21b68ca25b0b09d50f7":
-  version "0.1.1-treeify-stacks-maybe-like-12"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/0761df2014f5f4c2d32ae21b68ca25b0b09d50f7"
+"@mapbox/carmen-core@github:mapbox/carmen-core#26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991":
+  version "0.1.1-nearby-only-1"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991":
-  version "0.1.1-nearby-only-1"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/26a4ae25c4653bc3fdc7ec07a5f5fb5b0daf3991"
+"@mapbox/carmen-core@github:mapbox/carmen-core#ffe7cab3fdee516db67852896395e53e4115d1d9":
+  version "0.1.1-nearby-only-2"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/ffe7cab3fdee516db67852896395e53e4115d1d9"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This PR is the companion to mapbox/carmen-core#89 . It switches to pointing at that gitsha, and also now passes in a `nearbyOnly` property in numerical-autocomplete cases. Turns out we used to want to flag exactly these same cases with a property called `extendedScan` that doesn't do anything in carmen-core anymore (carmen-cache used it and it's now ignored), so I just renamed that.


### Summary of Changes
- [x] rename extendedScan to nearbyOnly
- [x] switch to carmen-core@nearby-only


### Next Steps
No


cc @mapbox/search
