### PR TITLE
switch to carmen-core@bbox-aware-coalesce

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,12 +247,10 @@ function Geocoder(indexes, options) {
 
             if (source.bounds[0] < source.bounds[2]) {
                 source.tileBounds = bbox.insideTile(source.bounds, source.zoom).slice(1);
-                //console.log("no am", source.tileBounds);
             } else {
                 // this index crosses the antemeridian; just blow it out around the earth
                 const blownBounds = [-180, source.bounds[1], 180, source.bounds[3]];
                 source.tileBounds = bbox.insideTile(blownBounds, source.zoom).slice(1);
-                console.log("yes am", source.tileBounds);
             }
 
             // arrange languages into something presentable

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -231,7 +231,8 @@ function store(source, callback) {
         source._gridstore.reader = new carmenCore.GridStore(gridStoreFile, {
             zoom: source.zoom,
             type_id: source.ndx,
-            coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS
+            coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
+            bbox: source.tileBounds
         });
 
         callback();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#934f5639eb6c8364a5a16bd6afb1a22bdbf20992",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#f1cb0fb697389af76e8a0e856ab638be40b2dde5",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#ffe7cab3fdee516db67852896395e53e4115d1d9",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#934f5639eb6c8364a5a16bd6afb1a22bdbf20992",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/acceptance/geocode-unit.address-partial-number.js
+++ b/test/acceptance/geocode-unit.address-partial-number.js
@@ -27,13 +27,13 @@ const us_sample = {
     id:1,
     properties: {
         'carmen:text':'Evergreen Terrace',
-        'carmen:center':[0,0],
+        'carmen:center':[-121,40],
         'carmen:geocoder_stack': 'us',
         'carmen:addressnumber': ['742']
     },
     geometry: {
         type: 'MultiPoint',
-        coordinates: [[0,0]]
+        coordinates: [[-121,40]]
     }
 };
 
@@ -55,16 +55,16 @@ const us_itp = {
         geometries: [{
             type:'MultiLineString',
             coordinates:[
-                [[0,0],[0,10]],
-                [[0,40],[0,50]]
+                [[-121,40],[-121,41]],
+                [[-121,45],[-121,46]]
             ]
         }]
     }
 };
 
 const fr_extent = extent(fr_sample);
-// pad the us extent to give us room to play with bboxes inside
-const us_extent = cheapRuler(0, 'miles').bufferPoint([0, 0], 20);
+// the actual bounds of part of the US (note: this is an antemeridian-crossing bounding box)
+const us_extent = [173.1329215, 18.9198449, -101.696897, 71.3567692];
 
 const conf = {
     fr_address: new mem({ maxzoom: 6, geocoder_address: 1, geocoder_name:'address', bounds: fr_extent }, () => {}),
@@ -101,7 +101,7 @@ tape('geocode with in-index prox for france', (t) => {
 });
 
 tape('geocode with in-index prox for us', (t) => {
-    c.geocode('7', { proximity: [0,0] }, (err, res) => {
+    c.geocode('7', { proximity: [-121,40] }, (err, res) => {
         t.ifError(err);
         t.equal(res.features.length, 1, 'only one result returned');
         t.equal(res.features[0].id, 'address.1', 'result was from expected index');
@@ -112,7 +112,7 @@ tape('geocode with in-index prox for us', (t) => {
 
 tape('geocode with in-index prox for us plus bbox', (t) => {
     c.geocode('7', {
-        proximity: [0,0],
+        proximity: [-121,40],
         bbox: cheapRuler(0, 'miles').bufferPoint([us_extent[0], us_extent[1]], 1)
     }, (err, res) => {
         t.ifError(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#ffe7cab3fdee516db67852896395e53e4115d1d9":
-  version "0.1.1-nearby-only-2"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/ffe7cab3fdee516db67852896395e53e4115d1d9"
+"@mapbox/carmen-core@github:mapbox/carmen-core#934f5639eb6c8364a5a16bd6afb1a22bdbf20992":
+  version "0.1.1-bbox-aware-coalesce-2"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/934f5639eb6c8364a5a16bd6afb1a22bdbf20992"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#934f5639eb6c8364a5a16bd6afb1a22bdbf20992":
-  version "0.1.1-bbox-aware-coalesce-2"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/934f5639eb6c8364a5a16bd6afb1a22bdbf20992"
+"@mapbox/carmen-core@github:mapbox/carmen-core#f1cb0fb697389af76e8a0e856ab638be40b2dde5":
+  version "0.1.1-bbox-aware-coalesce-3"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/f1cb0fb697389af76e8a0e856ab638be40b2dde5"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This PR is the companion to mapbox/carmen-core#91 . It switches to pointing at that gitsha, and now calculates a zxy bounding box for each index at carmen start time, and passes that bounding box into the gridstore of the index at instantiation, so that it can be used in coalesce.


### Summary of Changes
- [x] switch to carmen-core@bbox-aware-coalesce
- [x] calculate an index's bounding box in tile coordinates, and pass it into the gridstore


### Next Steps
Currently this is PR'ed against nearby-only since it includes that branch's work as well, but I will probably retarget once that branch lands.

Also: currently for indexes whose bounds cross the antemeridian, a tile-oriented bounding box is calculated that includes all latitudes. It might be better to instead either add support for AM-crossing bounding boxes to carmen-core, or to add support for including multiple bounding boxes to carmen-core, and decompose an index's bounding box into per-hemisphere components before instantiation. I'm leaving this to a possible follow-up PR, however.

cc @mapbox/search
