### PR TITLE
Use only the best address matches

### DIFF
--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -143,7 +143,6 @@ function forwardPrefix(feature, address) {
             const featureMatchStrings = generateMatchStrings(cluster[c_it][addressIndex], [addressStyle]);
 
             const rank = matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle, true);
-            // console.log(queryMatchStrings, featureMatchStrings, rank);
             if (rank !== -1 && feature.geometry.geometries[c_it].type === 'MultiPoint') {
                 if (rank < matchQuality) {
                     // we got a better kind of match than we had seen so far;
@@ -372,7 +371,7 @@ function matchesStyle(queryMatchStringMaps, featureMatchStringMaps, style, prefi
  * @param {Map<String, String>} queryMatchStrings - Mapping from match string name to match string for the query
  * @param {Map<String, String>} featureMatchStrings - Mapping from match string name to match string for the feature
  * @param {boolean} prefixMatch - Whether to match on a partial result
- * @returns {boolean} - True if a match
+ * @returns {Number} - -1 if no match found; integer >= 0 if found a match, where lower is better
  */
 function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
     if (prefixMatch) {
@@ -392,7 +391,7 @@ function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMa
  * @param {Map<String, String>} queryMatchStrings - Mapping from match string name to match string for the query
  * @param {Map<String, String>} featureMatchStrings - Mapping from match string name to match string for the feature
  * @param {boolean} prefixMatch - Whether to match on a partial result
- * @returns {boolean} - True if a match
+ * @returns {Number} - -1 if no match found; integer >= 0 if found a match, where lower is better
  */
 function matchesQueensAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
     if (prefixMatch) {

--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -68,6 +68,7 @@ function forward(feat, address, num = 10) {
     const queryMatchStrings = generateMatchStrings(address, addressStyles);
 
     const matchedAddressFeatures = [];
+    let matchQuality = Number.MAX_SAFE_INTEGER;
 
     for (let c_it = 0; c_it < cluster.length; c_it++) {
         if (!cluster[c_it]) continue;
@@ -78,7 +79,17 @@ function forward(feat, address, num = 10) {
 
             const featureMatchStrings = generateMatchStrings(cluster[c_it][addressIndex], [addressStyle]);
 
-            if (matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle) && feat.geometry.geometries[c_it].type === 'MultiPoint') {
+            const rank = matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle);
+            if (rank !== -1 && feat.geometry.geometries[c_it].type === 'MultiPoint') {
+                if (rank < matchQuality) {
+                    // we got a better kind of match than we had seen so far;
+                    // delete the worse ones
+                    matchQuality = rank;
+                    matchedAddressFeatures.length = 0;
+                } else if (rank > matchQuality) {
+                    continue;
+                }
+
                 let featureClone = JSON.parse(JSON.stringify(feat));
                 featureClone = properties(featureClone, addressIndex);
                 if (addressOverideSet.has(addressStyle)) {
@@ -120,6 +131,7 @@ function forwardPrefix(feature, address) {
     const queryMatchStrings = generateMatchStrings(address, addressStyles);
 
     const matchedAddressFeatures = [];
+    let matchQuality = Number.MAX_SAFE_INTEGER;
 
     for (let c_it = 0; c_it < cluster.length; c_it++) {
         if (!cluster[c_it]) continue;
@@ -130,7 +142,18 @@ function forwardPrefix(feature, address) {
 
             const featureMatchStrings = generateMatchStrings(cluster[c_it][addressIndex], [addressStyle]);
 
-            if (matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle, true) && feature.geometry.geometries[c_it].type === 'MultiPoint') {
+            const rank = matchesStyle(queryMatchStrings, featureMatchStrings, addressStyle, true);
+            // console.log(queryMatchStrings, featureMatchStrings, rank);
+            if (rank !== -1 && feature.geometry.geometries[c_it].type === 'MultiPoint') {
+                if (rank < matchQuality) {
+                    // we got a better kind of match than we had seen so far;
+                    // delete the worse ones
+                    matchQuality = rank;
+                    matchedAddressFeatures.length = 0;
+                } else if (rank > matchQuality) {
+                    continue;
+                }
+
                 matchedAddressFeatures.push({
                     idx: addressIndex,
                     number: cluster[c_it][addressIndex],
@@ -353,11 +376,13 @@ function matchesStyle(queryMatchStringMaps, featureMatchStringMaps, style, prefi
  */
 function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
     if (prefixMatch) {
-        return featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))
-            || featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('numericAddress'));
+        if (featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))) return 0;
+        if (featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('numericAddress'))) return 1;
+        return -1;
     }
-    return (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')
-        || featureMatchStrings.get('rawAddress') === queryMatchStrings.get('numericAddress'));
+    if (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')) return 0;
+    if (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('numericAddress')) return 1;
+    return -1;
 }
 
 /**
@@ -371,11 +396,14 @@ function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMa
  */
 function matchesQueensAddress(queryMatchStrings, featureMatchStrings, prefixMatch = false) {
     if (prefixMatch) {
-        return featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))
-            || featureMatchStrings.get('hyphenatedAddress').startsWith(queryMatchStrings.get('hyphenatedAddress'))
-            || (featureMatchStrings.get('numericAddress').startsWith(queryMatchStrings.get('numericAddress')) && !queryMatchStrings.get('containsHyphen'));
+        if (featureMatchStrings.get('rawAddress').startsWith(queryMatchStrings.get('rawAddress'))) return 0;
+        if (featureMatchStrings.get('hyphenatedAddress').startsWith(queryMatchStrings.get('hyphenatedAddress'))) return 1;
+        if ((featureMatchStrings.get('numericAddress').startsWith(queryMatchStrings.get('numericAddress')) && !queryMatchStrings.get('containsHyphen'))) return 2;
+        return -1;
     }
-    return (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')
-        || featureMatchStrings.get('hyphenatedAddress') === queryMatchStrings.get('hyphenatedAddress'))
-        || (featureMatchStrings.get('numericAddress') === queryMatchStrings.get('numericAddress') && !queryMatchStrings.get('containsHyphen'));
+
+    if (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')) return 0;
+    if (featureMatchStrings.get('hyphenatedAddress') === queryMatchStrings.get('hyphenatedAddress')) return 1;
+    if (featureMatchStrings.get('numericAddress') === queryMatchStrings.get('numericAddress') && !queryMatchStrings.get('containsHyphen')) return 2;
+    return -1;
 }

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -939,7 +939,12 @@ test('queens', (t) => {
                 type: 'Point',
                 coordinates: [1,1]
             }
-        }, {
+        }],
+        'Retrieve Queens Address with Hyphen'
+    );
+    t.deepEqual(
+        addressCluster.forward(feature, '1010'),
+        [{
             type: 'Feature',
             properties: {
                 accuracy: 'building',
@@ -959,10 +964,53 @@ test('queens', (t) => {
                 coordinates: [6,6]
             }
         }],
-        'Retrieve Queens Address with Hyphen'
+        'Retrieve Queens Address without Hyphen'
+    );
+    t.deepEqual(
+        addressCluster.forward(feature, '10200'),
+        [{
+            type: 'Feature',
+            properties: {
+                accuracy: 'building',
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
+                'carmen:address_style': queensStyle,
+                'carmen:address_styles': [standardStyle, queensStyle],
+                'carmen:address': '10-200',
+                'carmen:addressprops': {
+                    'carmen:address_style': {
+                        0: queensStyle,
+                        2: queensStyle,
+                        6: queensStyle
+                    }
+                }
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [3,3]
+            }
+        }],
+        'Match hyphenated result to hyphen-less query'
     );
     t.deepEqual(
         addressCluster.forwardPrefix(feature, '10-'),
+        [
+            {
+                idx: 0,
+                number: '10-10',
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [1, 1] },
+            },
+            {
+                idx: 2,
+                number: '10-200',
+                numberAsInt: 10,
+                geometry: { type: 'Point', coordinates: [3, 3] },
+            }
+        ],
+        'Prefix on Queens Addresses with hyphen',
+    );
+    t.deepEqual(
+        addressCluster.forwardPrefix(feature, '10'),
         [
             {
                 idx: 0,
@@ -995,7 +1043,7 @@ test('queens', (t) => {
                 geometry: { type: 'Point', coordinates: [6, 6] },
             }
         ],
-        'Prefix on Queens Addresses',
+        'Prefix on Queens Addresses without hyphen',
     );
     t.deepEqual(
         addressCluster.forwardPrefix(feature, '10-1'),
@@ -1005,12 +1053,6 @@ test('queens', (t) => {
                 number: '10-10',
                 numberAsInt: 10,
                 geometry: { type: 'Point', coordinates: [1, 1] },
-            },
-            {
-                idx: 5,
-                number: 1010,
-                numberAsInt: 1010,
-                geometry: { type: 'Point', coordinates: [6, 6] },
             }
         ],
         'Prefix on Queens Addresses Hyphen in Correct Spot',
@@ -1018,12 +1060,6 @@ test('queens', (t) => {
     t.deepEqual(
         addressCluster.forwardPrefix(feature, '1-01'),
         [
-            {
-                idx: 5,
-                number: 1010,
-                numberAsInt: 1010,
-                geometry: { type: 'Point', coordinates: [6, 6] },
-            },
             {
                 idx: 6,
                 number: '1-010',


### PR DESCRIPTION
#896 refactored the mechanism by which addresses are identified in an address cluster to be returned, and somewhat altered the way multiple matches can be returned from the same query. We do some degree of partial matching, to ignore, e.g., added-on letters (so e.g., matching "12" when "12B" was requested). In the now-present logic, both exact and approximate matches are treated equally, and after later deduplication, sometimes partial matches can beat out perfect matches in the final results. This means on a block with addresses 1, 1A, 1B, 1C, etc., only the coordinates for "1" might be surfaceable.

The new logic assigns each prospective match a rank: 0 for perfect, >0 for some level of approximate, with higher numbers worse. As the cluster is processed, we keep track of the best rank we've seen so far, and we don't retain any matches that are worse-ranked than our current best. If we see one better than our current best, we throw away all the current matches (which all must be worse) and use the new rank as best from then on.

I've updated the tests that checked partial matching as well. They now conform to the new behavior, which only uses the fall-back/approximate-match logic on numbers if there isn't an exact match. The affected tests now typically return fewer results total (but there aren't many affected).

### Context
<!-- Background, if needed to explain the issue -->
<!-- with link to relevant ticket(s) or short description -->


### Summary of Changes
- [x] update the address cluster matching logic to differentiate between matches of differing quality
- [x] update tests


### Next Steps
Nope

cc @mapbox/search
