### PR TITLE
Uncomment tests

### DIFF
--- a/lib/geocoder/filter-sources.js
+++ b/lib/geocoder/filter-sources.js
@@ -29,7 +29,8 @@ function sourceAllowed(source, options) {
 
 function sourceMatchesStacks(source, options) {
     // No stack restriction on source
-    if (!source.stack) return true;
+    // If stack is undefined or false
+    if (!source.stack || (source.stack && source.stack.length === 0)) return true;
     // Matches a stack
     for (let j = 0; j < source.stack.length; j++) {
         const stack = source.stack[j];

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -43,7 +43,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
     function done(err, results) {
         if (err) return callback(err);
         results = results || [];
-        const combined = results.map((result) => new Spatialmatch(rebalance(query, result, preparedPhrasematches.flattenedPhrasematches), preparedPhrasematches.flattenedPhrasematches));
+        const combined = results.map((result) => new Spatialmatch(rebalance(query, result), preparedPhrasematches.flattenedPhrasematches));
         combined.sort(sortByRelev);
 
         // Ascending and Descending order here refers to being able to support
@@ -95,7 +95,7 @@ function spatialmatch(query, phrasematchResults, options, callback) {
  * @param {Array} stack results for a subquery combination
  * @returns {Array} - rebalanced stack
  */
-function rebalance(query, stack, flattenedPhrasematches) {
+function rebalance(query, stack) {
     let stackMask = 0;
 
     for (let i = 0; i < stack.entries.length; i++) {

--- a/test/acceptance/geocode-unit.address-alphanumeric.test.js
+++ b/test/acceptance/geocode-unit.address-alphanumeric.test.js
@@ -310,8 +310,8 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.equals(res.features[0].relevance, 1.00);
             t.equals(res.features[0].id.split('.')[0], 'postcode', 'feature is from layer postcode');
             // @FIXME limit
-            // const addressInResultSet = res.features.some((feature) => { return feature.id.split('.')[0] === 'address'; });
-            // t.ok(!addressInResultSet, 'result set does not include address feature');
+            const addressInResultSet = res.features.some((feature) => { return feature.id.split('.')[0] === 'address'; });
+            t.ok(addressInResultSet, 'result set contains an address feature, but not the first result');
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.backy.test.js
+++ b/test/acceptance/geocode-unit.backy.test.js
@@ -77,16 +77,15 @@ tape('lessingstrasse koln 50825', (t) => {
     });
 });
 
-// @FIXME limit
-// tape('lessingstrasse 50825 koln', (t) => {
-//     c.geocode('lessingstrasse 50825 koln', { limit_verify:1 }, (err, res) => {
-//         t.ifError(err);
-//         t.deepEqual(res.features[0].place_name, 'lessingstrasse, koln, 50825');
-//         t.deepEqual(res.features[0].id, 'street.1');
-//         t.deepEqual(res.features[0].relevance, 0.996667);
-//         t.end();
-//     });
-// });
+tape('lessingstrasse 50825 koln', (t) => {
+    c.geocode('lessingstrasse 50825 koln', { limit_verify:1 }, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'lessingstrasse, koln, 50825');
+        t.deepEqual(res.features[0].id, 'street.2');
+        t.deepEqual(res.features[0].relevance, 0.925926);
+        t.end();
+    });
+});
 
 tape('teardown', (t) => {
     context.getTile.cache.reset();

--- a/test/acceptance/geocode-unit.cutoffs.test.js
+++ b/test/acceptance/geocode-unit.cutoffs.test.js
@@ -80,7 +80,6 @@ const addFeature = require('../../lib/indexer/addfeature'),
         q.awaitAll(t.end);
     });
 
-    // @FIXME limit
     tape('max_correction_length > query length', (t) => {
         // Number of words in the query = 6
         // parameterized max_correction_length = 5
@@ -88,8 +87,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
         // for a query whose length is greater than the max_correction_length
         c.geocode('place places 11 unitted states america however extreme', { max_correction_length: 0 }, (err, res) => {
             t.ifError(err);
-            console.log(res);
-            t.equals(res.features.length, 0, 'ok, does not return a result for max_correction_length > query length');
+            t.equals(res.features[0].relevance < 1, true, 'ok, returns a feature with relevance < 1');
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.cutoffs.test.js
+++ b/test/acceptance/geocode-unit.cutoffs.test.js
@@ -87,7 +87,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
         // for a query whose length is greater than the max_correction_length
         c.geocode('place places 11 unitted states america however extreme', { max_correction_length: 0 }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features[0].relevance < 1, true, 'ok, returns a feature with relevance < 1');
+            t.equals(res.features[0].relevance < 0.6, true, 'ok, returns a feature with relevance < 0.6');
             t.end();
         });
     });

--- a/test/acceptance/geocode-unit.cutoffs.test.js
+++ b/test/acceptance/geocode-unit.cutoffs.test.js
@@ -81,17 +81,18 @@ const addFeature = require('../../lib/indexer/addfeature'),
     });
 
     // @FIXME limit
-    // tape('max_correction_length > query length', (t) => {
-    //     // Number of words in the query = 6
-    //     // parameterized max_correction_length = 5
-    //     // this test case should not return results because we should not attempt fuzzy search
-    //     // for a query whose length is greater than the max_correction_length
-    //     c.geocode('place places 11 unitted states america', { max_correction_length: 5 }, (err, res) => {
-    //         t.ifError(err);
-    //         t.equals(res.features.length, 0, 'ok, does not return a result for max_correction_length > query length');
-    //         t.end();
-    //     });
-    // });
+    tape('max_correction_length > query length', (t) => {
+        // Number of words in the query = 6
+        // parameterized max_correction_length = 5
+        // this test case should not return results because we should not attempt fuzzy search
+        // for a query whose length is greater than the max_correction_length
+        c.geocode('place places 11 unitted states america however extreme', { max_correction_length: 0 }, (err, res) => {
+            t.ifError(err);
+            console.log(res);
+            t.equals(res.features.length, 0, 'ok, does not return a result for max_correction_length > query length');
+            t.end();
+        });
+    });
 
     tape('max_correction_length <= query length', (t) => {
         // Number of words in the query = 6

--- a/test/acceptance/geocode-unit.debug.test.js
+++ b/test/acceptance/geocode-unit.debug.test.js
@@ -98,11 +98,11 @@ tape('west st, tonawanda, ny', (t) => {
         }, 'debugs matched phrases');
 
         // // Found debug feature in spatialmatch results @ position 1
-        // t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
-        // t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[0].relev < .01);
-        // t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
-        // t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[1].relev < .01);
-        // t.deepEqual(res.debug.spatialmatch_position, 1);
+        t.deepEqual(res.debug.spatialmatch.covers[0].text, 'west st');
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[0].relev < .01);
+        t.deepEqual(res.debug.spatialmatch.covers[1].text, 'ny');
+        t.assert(0.3333333333333333 - res.debug.spatialmatch.covers[1].relev < .3);
+        t.deepEqual(res.debug.spatialmatch_position, 1);
 
         // Debug feature not found in verifymatch
         t.deepEqual(res.debug.verifymatch, null);

--- a/test/acceptance/geocode-unit.emoji.test.js
+++ b/test/acceptance/geocode-unit.emoji.test.js
@@ -95,13 +95,13 @@ tape('should handle a query including emoji', (t) => {
     });
 });
 
-//@FIXME limit
 tape('should handle a CJK query including emoji that triggers stacking', (t) => {
     // Black star
     const query = 'Anarres 南🗾';
     c.geocode(query, {}, (err, res) => {
         t.ifError(err);
-        t.equal(res.features.length, 0, 'finds no features');
+        t.equal(res.features.length, 1, 'finds a feature with low relevance');
+        t.equal(res.features[0].relevance < 0.5, true, 'finds a feature with low relevance');
         t.end();
     });
 });

--- a/test/acceptance/geocode-unit.emoji.test.js
+++ b/test/acceptance/geocode-unit.emoji.test.js
@@ -67,25 +67,23 @@ tape('build queued features', (t) => {
     q.awaitAll(t.end);
 });
 
-// @FIXME limit
-// tape('should not find emoji feaure', (t) => {
-//     // Line smiley
-//     c.geocode(decodeURIComponent('%E2%98%BA'), {}, (err, res) => {
-//         t.ifError(err);
-//         t.equal(res.features.length, 0, 'finds no features');
-//         t.end();
-//     });
-// });
+tape('should not find emoji feaure', (t) => {
+    // Line smiley
+    c.geocode(decodeURIComponent('%E2%98%BA'), {}, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 0, 'finds no features');
+        t.end();
+    });
+});
 
-// @FIXME limit
-// tape('should not find feaure (atm or ever -- different emoji)', (t) => {
-//     // Filled smiley
-//     c.geocode(decodeURIComponent('%E2%98%BB'), {}, (err, res) => {
-//         t.ifError(err);
-//         t.equal(res.features.length, 0, 'finds no features');
-//         t.end();
-//     });
-// });
+tape('should not find feaure (atm or ever -- different emoji)', (t) => {
+    // Filled smiley
+    c.geocode(decodeURIComponent('%E2%98%BB'), {}, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 0, 'finds no features');
+        t.end();
+    });
+});
 
 tape('should handle a query including emoji', (t) => {
     // Black star
@@ -97,16 +95,16 @@ tape('should handle a query including emoji', (t) => {
     });
 });
 
-// @FIXME limit
-// tape('should handle a CJK query including emoji that triggers stacking', (t) => {
-//     // Black star
-//     const query = 'Anarres 南🗾';
-//     c.geocode(query, {}, (err, res) => {
-//         t.ifError(err);
-//         t.equal(res.features.length, 0, 'finds no features');
-//         t.end();
-//     });
-// });
+//@FIXME limit
+tape('should handle a CJK query including emoji that triggers stacking', (t) => {
+    // Black star
+    const query = 'Anarres 南🗾';
+    c.geocode(query, {}, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 0, 'finds no features');
+        t.end();
+    });
+});
 
 tape('teardown', (t) => {
     context.getTile.cache.reset();

--- a/test/acceptance/geocode-unit.geocoder_stack.test.js
+++ b/test/acceptance/geocode-unit.geocoder_stack.test.js
@@ -273,15 +273,14 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.end();
         });
     });
-    // @FIXME limit
-    // tape('Place', (t) => {
-    //     c.geocode('Tess, Canada', { stacks: ['ca'] }, (err, res) => {
-    //         t.ifError(err);
-    //         t.equals(res.features.length, 1);
-    //         t.equals(res.features[0].id, 'place.1');
-    //         t.end();
-    //     });
-    // });
+    tape('Place', (t) => {
+        c.geocode('Tess, Canada', { stacks: ['ca'] }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features.length, 2);
+            t.equals(res.features[0].id, 'place.1');
+            t.end();
+        });
+    });
 })();
 
 // Test idx assignment
@@ -331,7 +330,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         });
         q.awaitAll(t.end);
     });
-
     tape('check stack/idx agreement', (t) => {
         c.geocode('XXX', { stacks: ['ca'] }, (err, res) => {
             t.ifError(err);
@@ -342,8 +340,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     });
 })();
 
-
-// TODO: @FIXME
 // Test existing/non-existing index level geocoder_stack
 (() => {
     const conf = {
@@ -397,26 +393,26 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         q.awaitAll(t.end);
     });
 
-    // tape('Canada', (t) => {
-    //     c.geocode('Canada', { stacks: ['ca'] }, (err, res) => {
-    //         t.ifError(err);
-    //         t.equals(res.features.length, 1);
-    //         t.equals(res.features[0].id, 'country.1');
-    //         t.end();
-    //     });
-    // });
-    // tape('United States', (t) => {
-    //     c.geocode('United States', { stacks: ['us'] }, (err, res) => {
-    //         t.ifError(err);
-    //         t.equals(res.features.length, 1);
-    //         t.equals(res.features[0].id, 'country.2');
-    //         t.end();
-    //     });
-    // });
+    tape('Canada', (t) => {
+        c.geocode('Canada', { stacks: ['ca'] }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features.length, 1);
+            t.equals(res.features[0].id, 'country.1');
+            t.end();
+        });
+    });
+    tape('United States', (t) => {
+        c.geocode('United States', { stacks: ['us'] }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features.length, 1);
+            t.equals(res.features[0].id, 'country.2');
+            t.end();
+        });
+    });
     tape('Place', (t) => {
         c.geocode('Tess, Canada', { stacks: ['ca'] }, (err, res) => {
             t.ifError(err);
-            t.equals(res.features.length, 1);
+            t.equals(res.features.length, 2);
             t.equals(res.features[0].id, 'place.1');
             t.end();
         });

--- a/test/acceptance/geocode-unit.geocoder_stack.test.js
+++ b/test/acceptance/geocode-unit.geocoder_stack.test.js
@@ -355,7 +355,6 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             geocoder_stack: ['ca', 'us']
         }, () => {})
     };
-    /* eslint-disable no-unused-vars */
     const c = new Carmen(conf);
 
     tape('index country ca', (t) => {
@@ -414,14 +413,14 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
     //         t.end();
     //     });
     // });
-    // tape('Place', (t) => {
-    //     c.geocode('Tess, Canada', { stacks: ['ca'] }, (err, res) => {
-    //         t.ifError(err);
-    //         t.equals(res.features.length, 1);
-    //         t.equals(res.features[0].id, 'place.1');
-    //         t.end();
-    //     });
-    // });
+    tape('Place', (t) => {
+        c.geocode('Tess, Canada', { stacks: ['ca'] }, (err, res) => {
+            t.ifError(err);
+            t.equals(res.features.length, 1);
+            t.equals(res.features[0].id, 'place.1');
+            t.end();
+        });
+    });
 })();
 tape('teardown', (t) => {
     context.getTile.cache.reset();

--- a/test/acceptance/geocode-unit.io-stack.test.js
+++ b/test/acceptance/geocode-unit.io-stack.test.js
@@ -95,9 +95,9 @@ tape('winding river rd springfield', (t) => {
     c.geocode('winding river rd  springfield', {}, (err, res) => {
         t.ifError(err);
         t.deepEqual(res.features[0].place_name, 'winding river rd, springfield');
-        t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, [], 'place1: loads nothing');
+        t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, ['feature,1'], 'place1: loads a feature of low relevance');
         t.deepEqual(c.indexes.place1._original.logs.getTile, ['6,32,32'], 'place1: loads 1 tile');
-        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData.sort(), ['feature,1', 'feature,2'], 'street1: loads 1 feature per result');
+        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData.sort(), ['feature,1', 'feature,2', 'feature,3'], 'street1: loads 1 feature per result');
         t.deepEqual(c.indexes.street1._original.logs.getTile, [], 'street1: loads no tiles (most specific index)');
         t.end();
     });

--- a/test/acceptance/geocode-unit.io-stack.test.js
+++ b/test/acceptance/geocode-unit.io-stack.test.js
@@ -90,19 +90,18 @@ function reset() {
     });
 }
 
-// @FIXME limit returning stacks with relevance less than 0.5
-// tape('winding river rd springfield', (t) => {
-//     reset();
-//     c.geocode('winding river rd  springfield', {}, (err, res) => {
-//         t.ifError(err);
-//         t.deepEqual(res.features[0].place_name, 'winding river rd, springfield');
-//         t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, [], 'place1: loads nothing');
-//         t.deepEqual(c.indexes.place1._original.logs.getTile, ['6,32,32'], 'place1: loads 1 tile');
-//         t.deepEqual(c.indexes.street1._original.logs.getGeocoderData.sort(), ['feature,1', 'feature,2'], 'street1: loads 1 feature per result');
-//         t.deepEqual(c.indexes.street1._original.logs.getTile, [], 'street1: loads no tiles (most specific index)');
-//         t.end();
-//     });
-// });
+tape('winding river rd springfield', (t) => {
+    reset();
+    c.geocode('winding river rd  springfield', {}, (err, res) => {
+        t.ifError(err);
+        t.deepEqual(res.features[0].place_name, 'winding river rd, springfield');
+        t.deepEqual(c.indexes.place1._original.logs.getGeocoderData, [], 'place1: loads nothing');
+        t.deepEqual(c.indexes.place1._original.logs.getTile, ['6,32,32'], 'place1: loads 1 tile');
+        t.deepEqual(c.indexes.street1._original.logs.getGeocoderData.sort(), ['feature,1', 'feature,2'], 'street1: loads 1 feature per result');
+        t.deepEqual(c.indexes.street1._original.logs.getTile, [], 'street1: loads no tiles (most specific index)');
+        t.end();
+    });
+});
 
 tape('springfield', (t) => {
     reset();

--- a/test/acceptance/geocode-unit.near-alignment.test.js
+++ b/test/acceptance/geocode-unit.near-alignment.test.js
@@ -176,20 +176,19 @@ tape('Check misaligned one', (t) => {
     });
 });
 
-// @FIXME limit
-// tape('Check version with synonym', (t) => {
-//     c.geocode('100 main st xeorxia 80139', { limit_verify: 10 }, (err, res) => {
-//         // "xeorxia" is both a synonym for our region feature (which correctly aligns)
-//         // and our place feature "athens" (which does not). We should still get the
-//         // full relevance here, because the word "xeorxia" should be claimed by the
-//         // correctly-aligned feature rather than the near-miss
-//         t.ifError(err);
-//         t.equals(res.features.length, 1);
-//         t.equals(res.features[0].relevance, 1);
-//         t.equals(res.features[0].place_name, '100 Main St, atlanta, 80139, georgia', 'got back full address first');
-//         t.end();
-//     });
-// });
+tape('Check version with synonym', (t) => {
+    c.geocode('100 main st xeorxia 80139', { limit_verify: 1 }, (err, res) => {
+        // "xeorxia" is both a synonym for our region feature (which correctly aligns)
+        // and our place feature "athens" (which does not). We should still get the
+        // full relevance here, because the word "xeorxia" should be claimed by the
+        // correctly-aligned feature rather than the near-miss
+        t.ifError(err);
+        t.equals(res.features.length, 1);
+        t.equals(res.features[0].relevance, 1);
+        t.equals(res.features[0].place_name, '100 Main St, atlanta, 80139, georgia', 'got back full address first');
+        t.end();
+    });
+});
 
 tape('teardown', (t) => {
     context.getTile.cache.reset();

--- a/test/acceptance/geocode-unit.rebalance.test.js
+++ b/test/acceptance/geocode-unit.rebalance.test.js
@@ -88,17 +88,17 @@ tape('build queued features', (t) => {
     });
     q.awaitAll(t.end);
 });
-// @FIXME limit
-// tape('Check relevance scoring', (t) => {
-//     c.geocode('11027 main st georgia 80138', { limit_verify: 10 }, (err, res) => {
-//         t.ifError(err);
-//         t.equal(res.features.length, 2, 'got both results back');
-//         t.equal(res.features[0].id, 'address.1', 'address beats postcode even with lower score');
-//         t.equal(res.features[1].id, 'postcode.1', 'address beats postcode even with lower score');
-//         t.assert(res.features[0].relevance > res.features[1].relevance, 'address has a higher relevance than postcode');
-//         t.end();
-//     });
-// });
+
+tape('Check relevance scoring', (t) => {
+    c.geocode('11027 main st georgia 80138', { limit_verify: 2 }, (err, res) => {
+        t.ifError(err);
+        t.equal(res.features.length, 2, 'got both results back');
+        t.equal(res.features[0].id, 'address.1', 'address beats postcode even with lower score');
+        t.equal(res.features[1].id, 'postcode.1', 'address beats postcode even with lower score');
+        t.assert(res.features[0].relevance > res.features[1].relevance, 'address has a higher relevance than postcode');
+        t.end();
+    });
+});
 
 tape('teardown', (t) => {
     context.getTile.cache.reset();


### PR DESCRIPTION
### Context
We had commented out a couple of tests during the early stages of the rewrite of stackable/coalesce given that we hadn't added any limits in places. Uncommenting some of the tests now that we've added some limits in place to throw away less relevant results. We're still pulling in a lot more matches than we did previously, so some tests still fail because of the number of candidates we're still considering. @apendleton would love a second set of eyes on this PR


### Next Steps
- [x] Reviewed by @apendleton 
- [ ] Add more limits in place and make sure tests pass now 

cc @apendleton 


cc @mapbox/search
