### PR TITLE
Decomposed bbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,13 +245,7 @@ function Geocoder(indexes, options) {
             source.ndx = names.indexOf(name);
             source.bounds = info.bounds || [-180, -85, 180, 85];
 
-            if (source.bounds[0] < source.bounds[2]) {
-                source.tileBounds = bbox.insideTile(source.bounds, source.zoom).slice(1);
-            } else {
-                // this index crosses the antemeridian; just blow it out around the earth
-                const blownBounds = [-180, source.bounds[1], 180, source.bounds[3]];
-                source.tileBounds = bbox.insideTile(blownBounds, source.zoom).slice(1);
-            }
+            source.tileBounds = bbox.amInsideTile(source.bounds, source.zoom).slice(1);
 
             // arrange languages into something presentable
             const lang = {};
@@ -363,7 +357,7 @@ function Geocoder(indexes, options) {
                             zoom: source.zoom,
                             type_id: source.ndx,
                             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
-                            bbox: source.tileBounds
+                            bboxes: source.tileBounds
                         }),
                         writer: null
                     };

--- a/index.js
+++ b/index.js
@@ -357,7 +357,8 @@ function Geocoder(indexes, options) {
                             zoom: source.zoom,
                             type_id: source.ndx,
                             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
-                            bboxes: source.tileBounds
+                            bboxes: source.tileBounds,
+                            max_score: +source.maxscore
                         }),
                         writer: null
                     };

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -23,7 +23,10 @@ module.exports = function phrasematch(source, query, options, callback) {
     options.autocomplete = !!(options.autocomplete || false);
     options.bbox = options.bbox || false;
     options.fuzzyMatch = options.fuzzyMatch === undefined ? true : !!options.fuzzyMatch;
+
     let partialNumber = false;
+    let hasSingleCharPhrasematches = false;
+    let hasNonSingleCharPhrasematches = false;
 
     // if requested country isn't included, skip
     if (options.stacks) {
@@ -248,7 +251,7 @@ module.exports = function phrasematch(source, query, options, callback) {
     // cross-index comparisons.
     const scorefactor = source.maxscore || 1;
 
-    const phrasematches = [];
+    let phrasematches = [];
 
     for (const subquery of subqueries) {
         const phrase = subquery.join(' ');
@@ -299,9 +302,21 @@ module.exports = function phrasematch(source, query, options, callback) {
         const phrase_id_range = subquery.phrase_id_range;
         const nearbyOnly = partialNumber;
 
+        if (phrase.length == 1) {
+            hasSingleCharPhrasematches = true;
+        } else {
+            hasNonSingleCharPhrasematches = true;
+        }
+
         phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, subquery.address));
+        if (source.id.match(/us_/)) console.log(source.id, phrasematches[phrasematches.length - 1].subquery);
     }
 
+    if (source.zoom >= 14 && hasSingleCharPhrasematches && hasNonSingleCharPhrasematches && !partialNumber) {
+        const startLen = phrasematches.length;
+        phrasematches = phrasematches.filter((pm) => pm.phrase.length > 1);
+        console.log(source.id, startLen, phrasematches.length);
+    }
     return callback(null, phrasematches);
 };
 

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -302,20 +302,17 @@ module.exports = function phrasematch(source, query, options, callback) {
         const phrase_id_range = subquery.phrase_id_range;
         const nearbyOnly = partialNumber;
 
-        if (phrase.length == 1) {
+        if (phrase.length === 1) {
             hasSingleCharPhrasematches = true;
         } else {
             hasNonSingleCharPhrasematches = true;
         }
 
         phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, subquery.address));
-        if (source.id.match(/us_/)) console.log(source.id, phrasematches[phrasematches.length - 1].subquery);
     }
 
     if (source.zoom >= 14 && hasSingleCharPhrasematches && hasNonSingleCharPhrasematches && !partialNumber) {
-        const startLen = phrasematches.length;
         phrasematches = phrasematches.filter((pm) => pm.phrase.length > 1);
-        console.log(source.id, startLen, phrasematches.length);
     }
     return callback(null, phrasematches);
 };

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -232,7 +232,8 @@ function store(source, callback) {
             zoom: source.zoom,
             type_id: source.ndx,
             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
-            bboxes: source.tileBounds
+            bboxes: source.tileBounds,
+            max_score: +source.maxscore
         });
 
         callback();

--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -232,7 +232,7 @@ function store(source, callback) {
             zoom: source.zoom,
             type_id: source.ndx,
             coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
-            bbox: source.tileBounds
+            bboxes: source.tileBounds
         });
 
         callback();

--- a/lib/util/bbox.js
+++ b/lib/util/bbox.js
@@ -16,6 +16,8 @@ module.exports.clipBBox = clipBBox;
 module.exports.amDecompose = amDecompose;
 module.exports.amIntersect = amIntersect;
 module.exports.amInside = amInside;
+module.exports.amInsideTile = amInsideTile;
+
 /**
 * inside - Return whether a coordinate is inside a bounding box.
 * @param {Array} coordinates A lon/lat array
@@ -166,4 +168,20 @@ function amInside(coordinates, bbox) {
             (coordinates[0] >= bbox[0] || coordinates[0] <= bbox[2]) // longitude for AM-crossing bbox
         )
     );
+}
+
+
+/**
+* amInsideTile - like the insideTile function, but supports AM-crossing bboxes (note: leaves the box decomposed)
+* @param {Array} coordinates A lon/lat array
+* @param {Array} bbox An array of one or more bounding boxes array in the format [zoom, [minX, minY, maxX, maxY], ...]
+* @return {boolean} Is the point inside the bbox
+*/
+function amInsideTile(bbox, zoom) {
+    const bboxes = amDecompose(bbox);
+    const out = [zoom];
+    for (const box of bboxes) {
+        out.push(insideTile(box, zoom).slice(1));
+    }
+    return out;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#c93c1e06423c1ad43a24c1581db2b717a166834e",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#8fbc7d4c8fb7bb40d99143cec0da470c0e62006e",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#f1cb0fb697389af76e8a0e856ab638be40b2dde5",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#c93c1e06423c1ad43a24c1581db2b717a166834e",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/test/acceptance/geocode-unit.reverse-scoredist.test.js
+++ b/test/acceptance/geocode-unit.reverse-scoredist.test.js
@@ -60,7 +60,7 @@ tape('add POIs', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'c',
-            'carmen:score':'10000',
+            'carmen:score': 10000,
             'carmen:zxy':['6/32/31'],
             'carmen:center':[1.005,1.005]
         },
@@ -78,7 +78,7 @@ tape('add POIs', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'d',
-            'carmen:score':'10',
+            'carmen:score': 10,
             'carmen:zxy':['6/32/31'],
             'carmen:center':[1.006,1.006]
         },
@@ -96,7 +96,7 @@ tape('add address', (t) => {
         type: 'Feature',
         properties: {
             'carmen:text':'e',
-            'carmen:score':'1',
+            'carmen:score': 1,
             'carmen:zxy':['6/32/31'],
             'carmen:center':[1.0071,1.0071]
         },

--- a/test/acceptance/geocode-unit.zeroscore.test.js
+++ b/test/acceptance/geocode-unit.zeroscore.test.js
@@ -12,7 +12,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
 
 const conf = {
     // make maxscore a string to simulate how carmen will encounter it after pulling it from the meta table in an mbtiles file
-    place: new mem({ geocoder_name: 'place', maxzoom: 6, minscore: '0', maxscore: '0', geocoder_stack: 'us' }, () => {}),
+    place: new mem({ geocoder_name: 'place', maxzoom: 6, minscore: 0, maxscore: 0, geocoder_stack: 'us' }, () => {}),
 };
 
 const c = new Carmen(conf);

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#f1cb0fb697389af76e8a0e856ab638be40b2dde5":
-  version "0.1.1-bbox-aware-coalesce-3"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/f1cb0fb697389af76e8a0e856ab638be40b2dde5"
+"@mapbox/carmen-core@github:mapbox/carmen-core#15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5":
+  version "0.1.1-flatbush-2"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#c93c1e06423c1ad43a24c1581db2b717a166834e":
-  version "0.1.1-flatbush-3"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/c93c1e06423c1ad43a24c1581db2b717a166834e"
+"@mapbox/carmen-core@github:mapbox/carmen-core#8fbc7d4c8fb7bb40d99143cec0da470c0e62006e":
+  version "0.1.1-flatbush-4"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/8fbc7d4c8fb7bb40d99143cec0da470c0e62006e"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5":
-  version "0.1.1-flatbush-2"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/15dba64d040bb434b4ba6e1c2adac6eb2d22d0e5"
+"@mapbox/carmen-core@github:mapbox/carmen-core#c93c1e06423c1ad43a24c1581db2b717a166834e":
+  version "0.1.1-flatbush-3"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/c93c1e06423c1ad43a24c1581db2b717a166834e"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This PR has several changes designed to improve stackable/coalesce performance, specifically related to single-character autocomplete queries.


### Summary of Changes
- [x] use the flatbush-ified smarter coalesce stacking from https://github.com/mapbox/carmen-core/pull/94
- [x] filter out single-character phrasematches on high-zoom indexes if those indexes also have multi-character phrasematches
- [x] decompose bounding boxes that cross the antemeridian: see mapbox/carmen-core#94 for more info, but essentially this allows for a much more compact representation of bounding boxes for indexes that cross the antemeridian, which lets the bbox-aware coalesce mechanism in the latest carmen-core work more efficiently with, e.g., the US or Russia, which previously had bounding boxes that had to wrap the world
- [x] pass index max scores into gridstores at instantiation time, which allows for smarter ordering of processing during coalesce
- [x] make a bunch of the scores in our tests that were previously strings into numbers, now that carmen-core cares about scores


### Next Steps
- [ ] merge mapbox/carmen-core#94


cc @mapbox/search
