### PR TITLE
Multi word single character fix

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -86,6 +86,8 @@ module.exports = function phrasematch(source, query, options, callback) {
                 }
             }
 
+            // for multi word queries that end in a single character
+            // we don't match everything that starts with the character just the exact match
             if (source.zoom >= 14 && subquery.original_phrase[0].length === 1) {
                 if (subquery.original_phrase[0] !== match.phrase[0]) continue;
             }

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -85,6 +85,9 @@ module.exports = function phrasematch(source, query, options, callback) {
                     continue;
                 }
             }
+
+            if (subquery.original_phrase[0].length === 1 && subquery.original_phrase[0] !== match.phrase[0]) continue;
+
             subquery.ending_type = match.ending_type;
             subquery.phrase_id_range = match.phrase_id_range;
 

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -86,7 +86,9 @@ module.exports = function phrasematch(source, query, options, callback) {
                 }
             }
 
-            if (subquery.original_phrase[0].length === 1 && subquery.original_phrase[0] !== match.phrase[0]) continue;
+            if (source.zoom >= 14 && subquery.original_phrase[0].length === 1) {
+                if (subquery.original_phrase[0] !== match.phrase[0]) continue;
+            }
 
             subquery.ending_type = match.ending_type;
             subquery.phrase_id_range = match.phrase_id_range;


### PR DESCRIPTION
### Context
With the new carmen-core, we saw that queries which are multi word and end with a single letter are particularly slow. This is because on the carmen side, for a single character like `S` it ends up prefix matching second, seventh etc. This ends up being very expensive especially for large/heavy indexes. This PR throws such matches especially for large indexes (zoom >=14) and makes sure that for a multi word query that ends in a single character, we throw away matches that aren't the single character.

### Summary of Changes
- [ ] Changes to pharsematch.js

### Next Steps
- [ ] Review
- [ ] Merge into "master" carmen-core branch

@apendleton I think right now it has your decompose-bbox changes as well, does it make sense then to have it branched off of decomposed-bbox?

cc @mapbox/search
