### PR TITLE
Fix template selection with per-feature overrides

### DIFF
--- a/lib/geocoder/format-features.js
+++ b/lib/geocoder/format-features.js
@@ -48,6 +48,19 @@ function getFormatString(context, format, language) {
  */
 function getPlaceName(context, formatString, language, languageMode, matched, source) {
     const feat = context[0];
+
+    if (Object.keys(feat.properties).filter((k) => k.match(/^carmen:format/)).length) {
+        const templateLang = language ? closestLang.closestLangLabel(language, feat.properties, 'carmen:format_') : undefined;
+        const template = templateLang ? feat.properties['carmen:format_' + templateLang] : feat.properties['carmen:format'];
+        if (template) {
+            try {
+                formatString = Handlebars.compile(template, { noEscape: true });
+            } catch (err) {
+                console.error('incorrect geocoder_format' + err);
+            }
+        }
+    }
+
     let place_name;
     // Use geocoder_format to format output if applicable
     if (!formatString || formatString === true || formatString === 1) {
@@ -84,21 +97,6 @@ function getPlaceName(context, formatString, language, languageMode, matched, so
             }
             num = (num || '').split(',')[0];
 
-            try {
-                for (const key in f.properties) {
-                    if (/^carmen:format_/.test(key)) {
-                        if (language === key.replace(/^carmen:format_/, '')) {
-                            formatString = Handlebars.compile(f.properties[key], { noEscape: true });
-                        }
-                    }
-                }
-                if (f.properties['carmen:format']) {
-                    formatString =  Handlebars.compile(f.properties['carmen:format'], { noEscape: true });
-                }
-            } catch (err) {
-                console.error('incorrect geocoder_format' + err);
-            }
-
             renderObj[carmenProp] = {
                 properties: f.properties,
                 name: val,
@@ -106,8 +104,7 @@ function getPlaceName(context, formatString, language, languageMode, matched, so
             };
         }
         // Handle any cases where context wasn't available by getting rid of curly braces, awkwards spaces/commas
-        formatString = formatString(renderObj, { helpers: source ? source.format_helpers : {} }).replace(/\{.+?\}/g, '').replace(/, \s*$/, '').replace(/ , /g,', ').replace(/ {2}/g,' ').replace(/, -/,',').replace(/, ,/g,'').replace(/^,/,'').replace(/,,/,',').trim().replace(/,$/,'');
-        place_name = formatString;
+        place_name = formatString(renderObj, { helpers: source ? source.format_helpers : {} }).replace(/\{.+?\}/g, '').replace(/, \s*$/, '').replace(/ , /g,', ').replace(/ {2}/g,' ').replace(/, -/,',').replace(/, ,/g,'').replace(/^,/,'').replace(/,,/,',').trim().replace(/,$/,'');
     }
 
     return place_name;

--- a/test/acceptance/geocode-unit.format-override.test.js
+++ b/test/acceptance/geocode-unit.format-override.test.js
@@ -1,0 +1,136 @@
+'use strict';
+// Alphanumeric and hyphenated housenumbers
+
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+
+const conf = {
+    country: new mem({ maxzoom: 6 }, () => {}),
+    postcode: new mem({ maxzoom: 6 }, () => {}),
+    address: new mem({ maxzoom: 6, geocoder_address: 1 }, () => {})
+};
+const c = new Carmen(conf);
+tape('index data', (t) => {
+    const q = queue(1);
+    q.defer((cb) => queueFeature(
+        conf.address,
+        {
+            id: 1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0],
+                'carmen:addressnumber': ['9B', '10C', '7'],
+                'carmen:format': 'X {{address.number}} {{address.name}}, {{postcode.name}}, {{country.name}}',
+                'carmen:format_en': 'Y {{address.number}} {{address.name}}, {{postcode.name}}, {{country.name}}'
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[0,0],[0,0]]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.address,
+        {
+            id: 2,
+            properties: {
+                'carmen:text': 'other street',
+                'carmen:center': [0,0],
+                'carmen:addressnumber': ['9B', '10C', '7']
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[0,0],[0,0]]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.postcode,
+        {
+            id: 3,
+            properties: {
+                'carmen:text': '12345',
+                'carmen:center': [0,0],
+                'carmen:format': 'Z {{postcode.name}}, {{country.name}}'
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.country,
+        {
+            id: 4,
+            properties: {
+                'carmen:text': 'america',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+
+    q.defer((cb) => buildQueued(conf.address, cb));
+    q.defer((cb) => buildQueued(conf.postcode, cb));
+    q.defer((cb) => buildQueued(conf.country, cb));
+
+    q.awaitAll(t.end);
+});
+
+tape('test address template', (t) => {
+    c.geocode('9b fake street', { limit_verify: 1 }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].place_name, 'X 9b fake street, 12345, america', 'overrode address template');
+        t.end();
+    });
+});
+
+tape('test regular address', (t) => {
+    c.geocode('9b other street', { limit_verify: 1 }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].place_name, '9b other street, 12345, america', 'didn\'t override address template');
+        t.end();
+    });
+});
+
+tape('test address template with language', (t) => {
+    c.geocode('9b fake street', { limit_verify: 1, language: 'en' }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].place_name, 'Y 9b fake street, 12345, america', 'overrode address template');
+        t.end();
+    });
+});
+
+tape('test address template with approximate language', (t) => {
+    c.geocode('9b fake street', { limit_verify: 1, language: 'en-US' }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].place_name, 'Y 9b fake street, 12345, america', 'overrode address template');
+        t.end();
+    });
+});
+
+tape('test postcode override', (t) => {
+    c.geocode('12345', { limit_verify: 1 }, (err, res) => {
+        t.ifError(err);
+        t.equals(res.features[0].place_name, 'Z 12345, america', 'overrode postcode template');
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});


### PR DESCRIPTION
### Context
#878 introduced a way for individual features to override their template for producing their `place_name` geocoder responses. It turns out there was a bug in the way this was implemented such that if a feature in the *context* of a result, rather than the result itself, had an overridden template, that template would be used to render the response even though it was for the wrong feature (for example, if you looked for an address and it had an overridden template on its postcode, the address would be rendered with the postcode's template, so you'd end up with a place name without an address in it).

While I was fixing that, I noticed some other tidbits we hadn't caught the first time around:
- if a feature had both a language-specific template and a generic one, we'd use the generic one instead of the language-specific one (but would render both, and through away the language-specific one)
- we'd only use language overrides for features from indexes that also had an index-wide template, but there doesn't seem to be a reason that'd be necessary
- we weren't using the `closestLang` mechanism for choosing which language-specific template to use, so e.g., if you were querying with language=en_US, we wouldn't use the en template.

This PR fixes all of that.

### Summary of Changes
- [x] pick one template before rendering rather than rendering multiple
- [x] pick using closestLang, and prefer language-specific over generic
- [x] do this regardless of whether or not the index has an index-wide template
- [x] add some more tests to cover these cases

### Next Steps
Nope


cc @mapbox/search
