### PR TITLE
Enable worldviews filter in carmen cli query

### DIFF
--- a/bin/carmen.js
+++ b/bin/carmen.js
@@ -73,7 +73,8 @@ if (argv.tokens) {
 }
 
 const carmen = new Carmen(opts, {
-    tokens: tokens
+    tokens: tokens,
+    worldviews: ['us', 'cn', 'in', 'jp']
 });
 
 if (argv.proximity) {


### PR DESCRIPTION
### Context

This PR adds ability to filter worldviews in the carmen cli query and is an extension of Worldviews work at https://github.com/mapbox/carmen/pull/918. 


### Summary of Changes
- [x] Updated `bin/carmen.js` file to add worldviews parameter and associated values


### Next Steps
- Review and merge
- Bump and release a version


cc @mapbox/search @apendleton @aarthykc 
