### PR TITLE
Speed improvements for stackable coalesce

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -28,6 +28,9 @@ module.exports = function phrasematch(source, query, options, callback) {
     let hasSingleCharPhrasematches = false;
     let hasNonSingleCharPhrasematches = false;
 
+    const hasCorrectlySpelled = new Map();
+    const misspelledShortCount = new Map();
+
     // if requested country isn't included, skip
     if (options.stacks) {
         const stackAllowed = filter.sourceMatchesStacks(source, options);
@@ -279,6 +282,12 @@ module.exports = function phrasematch(source, query, options, callback) {
                 .75
             );
             weight *= penalty;
+
+            if (subquery.length === 1 || phrase.length <= 6) {
+                misspelledShortCount.set(subquery.mask, (misspelledShortCount.get(subquery.mask) || 0) + 1);
+            }
+        } else {
+            hasCorrectlySpelled.set(subquery.mask, true);
         }
 
         // If the query matches an index with geocoder_categories set
@@ -321,6 +330,22 @@ module.exports = function phrasematch(source, query, options, callback) {
     if (source.zoom >= 14 && hasSingleCharPhrasematches && hasNonSingleCharPhrasematches && !partialNumber) {
         phrasematches = phrasematches.filter((pm) => pm.phrase.length > 1);
     }
+
+    if (misspelledShortCount.size) {
+        phrasematches = phrasematches.filter((pm) => {
+            if (
+                (misspelledShortCount.get(pm.mask) || 0) > 6 &&
+                hasCorrectlySpelled.get(pm.mask) &&
+                (pm.subquery.length === 1 || pm.phrase.length <= 6) &&
+                pm.subquery.edit_distance > 0
+            ) {
+                return false;
+            } else {
+                return true;
+            }
+        });
+    }
+
     return callback(null, phrasematches);
 };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#1bff85a80f79fc4094f79378656fd8bc9d7636ad",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#77b4c64e8d90229611625f32c6d7c9d5df86564e",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#8fbc7d4c8fb7bb40d99143cec0da470c0e62006e",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#1bff85a80f79fc4094f79378656fd8bc9d7636ad",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#1bff85a80f79fc4094f79378656fd8bc9d7636ad":
-  version "0.1.1-speed-tweaks-1"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/1bff85a80f79fc4094f79378656fd8bc9d7636ad"
+"@mapbox/carmen-core@github:mapbox/carmen-core#77b4c64e8d90229611625f32c6d7c9d5df86564e":
+  version "0.1.1-speed-tweaks-2"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/77b4c64e8d90229611625f32c6d7c9d5df86564e"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,9 +904,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#8fbc7d4c8fb7bb40d99143cec0da470c0e62006e":
-  version "0.1.1-flatbush-4"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/8fbc7d4c8fb7bb40d99143cec0da470c0e62006e"
+"@mapbox/carmen-core@github:mapbox/carmen-core#1bff85a80f79fc4094f79378656fd8bc9d7636ad":
+  version "0.1.1-speed-tweaks-1"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/1bff85a80f79fc4094f79378656fd8bc9d7636ad"
   dependencies:
     neon-cli "^0.2.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context
This branch adds a tweak for speed with stackable/coalesce


### Summary of Changes
- [x] this branch adds some tracking to phrasematch to deal with situations where we generate lots of spelling corrections, so that if there's a phrase that's either one word long (of any word length), or a phrase of <= 6 characters (any number of words, but in practice, two words of 2-3 characters each), keep track of how many things we matched for that particular mask (so, for that particular word or set of words in the source query). If we have a correctly spelled match **and** we have more than 6 incorrectly spelled matches, we remove the incorrectly spelled matches for that particular mask from the phrasematch list. This handles cases where a single word matches *lots* of possible spelling corrections, most of which are junk, because it's a short word or two *very* short words, which can be extremely match-y. "park" is particularly bad here: in some indexes it can produce 10+ matches for that single word.
- [x] switch to the carmen-core from https://github.com/mapbox/carmen-core/pull/97


### Next Steps
Nope


cc @mapbox/search
