### PR TITLE
Reverse only property, minor bug fix

### DIFF
--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -158,7 +158,7 @@ function getSubtypeLookup(types) {
 }
 
 /**
- * Stack features into a contect array
+ * Stack features into a context array
  *
  * @param {Object} geocoder - geocoder instance
  * @param {Array<object>} loaded - features
@@ -493,6 +493,7 @@ function processVtQueryResults(results, source, lon, lat,  full, matched, langua
         if (results[i].tilequery.distance > dist) continue;
 
         attr = results[i].properties;
+        if (attr['carmen:forward_geocode_override']) continue;
 
         // If geojson has an id in properties use that otherwise use VT id
         attr.id = attr.id || results[i].id;

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -493,7 +493,6 @@ function processVtQueryResults(results, source, lon, lat,  full, matched, langua
         if (results[i].tilequery.distance > dist) continue;
 
         attr = results[i].properties;
-        if (attr['carmen:forward_geocode_override']) continue;
 
         // If geojson has an id in properties use that otherwise use VT id
         attr.id = attr.id || results[i].id;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -460,6 +460,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
         }
 
         for (const feat of feats) {
+            if (feat.properties['carmen:forward_geocode_override']) continue;
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
 
@@ -524,7 +525,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
         const text = languageText || feat.properties['carmen:text'];
         if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
             filtered.push(feat);
-            byText[text] = true;
+            if (feat.properties['carmen:scoredist'] >= 0) byText[text] = true;
         }
     }
     return filtered;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -460,7 +460,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
         }
 
         for (const feat of feats) {
-            if (feat.properties['carmen:forward_geocode_override']) continue;
+            if (feat.properties['carmen:reverse_only']) continue;
             // checks if the feature falls within the bbox specified as a part of the options
             if (options.bbox && !bbox.inside(feat.properties['carmen:center'], options.bbox)) continue;
 

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -282,6 +282,7 @@ function storableProperties(properties, type) {
         }
         // keep only known remaining whitelisted carmen:* properties
         switch (k) {
+            case 'carmen:forward_geocode_override':
             case 'carmen:score':
             case 'carmen:types':
             case 'carmen:center':

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -282,7 +282,7 @@ function storableProperties(properties, type) {
         }
         // keep only known remaining whitelisted carmen:* properties
         switch (k) {
-            case 'carmen:forward_geocode_override':
+            case 'carmen:reverse_only':
             case 'carmen:score':
             case 'carmen:types':
             case 'carmen:center':

--- a/test/acceptance/geocode-unit.forward-geocode-override.test.js
+++ b/test/acceptance/geocode-unit.forward-geocode-override.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+const conf = {
+    country: new mem({ maxzoom: 6 }, () => {}),
+    place: new mem({ maxzoom: 6 }, () => {}),
+    address: new mem({ maxzoom: 6 }, () => {})
+};
+const c = new Carmen(conf);
+tape('index data', (t) => {
+    const q = queue(1);
+    q.defer((cb) => queueFeature(
+        conf.country,
+        {
+            id: 1,
+            properties: {
+                'carmen:text': 'america',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.place,
+        {
+            id: 3,
+            properties: {
+                'carmen:text': 'some place',
+                'carmen:center': [0,0],
+                'carmen:forward_geocode_override': true
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.address,
+        {
+            id: 1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0]
+            },
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[0,0],[0,0],[0,0]]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => buildQueued(conf.address, cb));
+    q.defer((cb) => buildQueued(conf.place, cb));
+    q.defer((cb) => buildQueued(conf.country, cb));
+
+    q.awaitAll(t.end);
+});
+
+tape('test [\'carmen:forward_geocode_override\']', (t) => {
+    c.geocode('some place', { limit_verify: 1 }, (err, res) => {
+        t.equals(res.features.length, 0, 'does not return a feature with property carmen:forward_geocode_override');
+        t.ifError(err);
+        t.end();
+    });
+});
+
+tape('test [\'carmen:forward_geocode_override\'] for a feature with the same carmen:text', (t) => {
+    c.geocode('some place, america', { limit_verify: 1 }, (err, res) => {
+        t.equals(res.features[0].place_name, 'america', 'does not return top level some place');
+        t.equals(res.features[0].id, 'country.1', 'returned country');
+        t.ifError(err);
+        t.end();
+    });
+});
+tape('test [\'carmen:forward_geocode_override\'] for a feature with the same carmen:text', (t) => {
+    c.geocode('fake street, some place', { limit_verify: 5 }, (err, res) => {
+        t.equals(res.features[0].place_name, 'fake street, some place, america', 'returned some place as a part of the context');
+        t.equals(res.features[0].id, 'address.1', 'returned some place as a part of the context');
+        t.ifError(err);
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});

--- a/test/acceptance/geocode-unit.reverse-only.test.js
+++ b/test/acceptance/geocode-unit.reverse-only.test.js
@@ -37,7 +37,7 @@ tape('index data', (t) => {
             properties: {
                 'carmen:text': 'some place',
                 'carmen:center': [0,0],
-                'carmen:forward_geocode_override': true
+                'carmen:reverse_only': true
             },
             geometry: {
                 type: 'Point',
@@ -68,7 +68,7 @@ tape('index data', (t) => {
     q.awaitAll(t.end);
 });
 
-tape('test [\'carmen:forward_geocode_override\']', (t) => {
+tape('test [\'carmen:reverse_only\']', (t) => {
     c.geocode('some place', { limit_verify: 1 }, (err, res) => {
         t.equals(res.features.length, 0, 'does not return a feature with property carmen:forward_geocode_override');
         t.ifError(err);
@@ -76,7 +76,7 @@ tape('test [\'carmen:forward_geocode_override\']', (t) => {
     });
 });
 
-tape('test [\'carmen:forward_geocode_override\'] for a feature with the same carmen:text', (t) => {
+tape('test [\'carmen:reverse_only\'] for a feature with the same carmen:text', (t) => {
     c.geocode('some place, america', { limit_verify: 1 }, (err, res) => {
         t.equals(res.features[0].place_name, 'america', 'does not return top level some place');
         t.equals(res.features[0].id, 'country.1', 'returned country');
@@ -84,7 +84,7 @@ tape('test [\'carmen:forward_geocode_override\'] for a feature with the same car
         t.end();
     });
 });
-tape('test [\'carmen:forward_geocode_override\'] for a feature with the same carmen:text', (t) => {
+tape('test [\'carmen:reverse_only\'] for a feature with the same carmen:text', (t) => {
     c.geocode('fake street, some place', { limit_verify: 5 }, (err, res) => {
         t.equals(res.features[0].place_name, 'fake street, some place, america', 'returned some place as a part of the context');
         t.equals(res.features[0].id, 'address.1', 'returned some place as a part of the context');

--- a/test/acceptance/geocode-unit.score-dedupe.test.js
+++ b/test/acceptance/geocode-unit.score-dedupe.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const tape = require('tape');
+const Carmen = require('../..');
+const context = require('../../lib/geocoder/context');
+const mem = require('../../lib/sources/api-mem');
+const queue = require('d3-queue').queue;
+const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
+
+const conf = {
+    place: new mem({ maxzoom: 6 }, () => {})
+};
+const c = new Carmen(conf);
+tape('index data', (t) => {
+    const q = queue(1);
+    q.defer((cb) => queueFeature(
+        conf.place,
+        {
+            id: 1,
+            properties: {
+                'carmen:text': 'fake place 1',
+                'carmen:center': [0,0],
+                'carmen:score': -1
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.place,
+        {
+            id: 2,
+            properties: {
+                'carmen:text': 'fake place 1',
+                'carmen:center': [0,1],
+                'carmen:score': 1
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,1]
+            }
+        },
+        cb
+    ));
+
+    q.defer((cb) => buildQueued(conf.place, cb));
+
+    q.awaitAll(t.end);
+});
+
+tape('test deduping features with identical text preserving the feature with a higher score', (t) => {
+    c.geocode('fake place 1', { limit_verify: 5 }, (err, res) => {
+        t.equals(res.features.length, 1, 'returned the feature with higher score');
+        t.equals(res.features[0].id, 'place.2', 'returned fake place 1 with id = place.2');
+        t.equals(res.features[0].place_name, 'fake place 1', 'returned fake place 1 feature with a higher score');
+        t.ifError(err);
+        t.end();
+    });
+});
+
+tape('teardown', (t) => {
+    context.getTile.cache.reset();
+    t.end();
+});


### PR DESCRIPTION
### Context
This PR fixes a bug where we want to preserve a feature with a higher score, when there are two features with identical text. Currently, we're not checking for the score and are throwing away features with score <= 0 if it shares identical text to another feature, however, we should only do so if there is a feature with a higher score as the comment 

> // Eliminate any score < 0 results if there are better-scored results
>  // with identical text.

suggests.

This PR also adds the ability to hide a feature from showing up in forward search as the top level feature while still allowing surfacing it as a part of reverse geocoding. It will also allow the feature to be a part of the context, just removing it from forward search only when it's the top level feature. 

### Summary of Changes
- [ ] Changes to verifymatch
- [ ] Adds acceptance tests for both changes

### Next Steps
- [x] Reviewed by @apendleton 
- [ ] Merge
- [ ] Cut new release

cc @mapbox/search
