### PR TITLE
Squishy context

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,11 +25,15 @@
         }],
         "valid-jsdoc": ["warn", {
             "requireReturn": false
-        }]
+        }],
+        "node/no-unsupported-features": [ "error", { "version": 10 } ]
     },
     "env": {
         "node": "true",
         "es6": "true"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2019
     },
     "extends": ["@mapbox/eslint-config-geocoding"]
 }

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -172,10 +172,12 @@ function Spatialmatch(cacheSpatialmatch, flattenedPhrasematches) {
     this.address = null;
     this.partialNumber = false;
     this.covers = [];
+    let idxTotal = 0;
     for (let i = 0; i < cacheSpatialmatch.entries.length; i++) {
         const cacheCover = cacheSpatialmatch.entries[i];
         const phrasematch = flattenedPhrasematches[cacheCover.phrasematch_id];
         this.covers.push(new Cover(cacheCover, phrasematch));
+        idxTotal += cacheCover.idx;
 
         // just do these once, for the sake of determinism
         if (!this.address) {
@@ -186,6 +188,8 @@ function Spatialmatch(cacheSpatialmatch, flattenedPhrasematches) {
         }
     }
     this.scoredist = this.covers[0].scoredist;
+    this.idxAverage = this.covers.length > 0 ? idxTotal / this.covers.length : 0;
+
     // this line artificially boosts scoredist for nearby partial-number matches
     // from address indexes, which may not have an informative score that would
     // otherwise allow them to be surfaced; the specific multiplier was determined
@@ -232,5 +236,6 @@ function sortByRelev(a, b) {
     return (b.relev - a.relev) ||
         (b.scoredist - a.scoredist) ||
         (a.covers[0].idx - b.covers[0].idx) ||
-        (b.address ? 1 : 0) - (a.address ? 1 : 0);
+        (b.address ? 1 : 0) - (a.address ? 1 : 0) ||
+        (b.idxAverage - a.idxAverage);
 }

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -788,7 +788,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
 
                 closeButNoCigar = true;
             } else {
-                if (contextSquishyTarget && !contextSquishy) {
+                if (contextSquishyTarget && !contextSquishy && indexes[feat.properties['carmen:index']].geocoder_grant_score) {
                     // this feature didn't directly match the query, but if it has the same name as a feature that *did* in the context already,
                     // take note to give a tiny boost (so, "main st new york" prefers "main st new york new york" over "main st albany new york"
                     // all else being equal)
@@ -823,7 +823,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         if (
             !contextSquishyTarget &&
             (c > 0) &&
-            indexes[feat.properties['carmen:index']].geocoder_grant_score &&
+            indexes[feat.properties['carmen:index']].geocoder_inherit_score &&
             !closeButNoCigar
         ) {
             contextSquishyTarget = feat.properties;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -17,6 +17,7 @@ module.exports = verifymatch;
 module.exports.verifyFeatures = verifyFeatures;
 module.exports.sortFeature = sortFeature;
 module.exports.sortContext = sortContext;
+module.exports.textAlike = textAlike;
 
 /**
 * verifymatch - results from spatialmatch are now verified by querying real geometries in vector tiles

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -759,6 +759,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         squishyTarget = context[0].properties;
     let contextSquishyTarget = false;
     let contextSquishy = false;
+    let contextSquishyLanguages = null;
 
     // keep track of which indexes came back from coalesce
     const strictByIdx = {};
@@ -792,7 +793,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
                     // this feature didn't directly match the query, but if it has the same name as a feature that *did* in the context already,
                     // take note to give a tiny boost (so, "main st new york" prefers "main st new york new york" over "main st albany new york"
                     // all else being equal)
-                    contextSquishy = textAlike(contextSquishyTarget, feat.properties);
+                    contextSquishy = textAlike(contextSquishyTarget, feat.properties, contextSquishyLanguages);
                 }
                 continue;
             }
@@ -827,6 +828,12 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
             !closeButNoCigar
         ) {
             contextSquishyTarget = feat.properties;
+
+            const targetIndex = indexes[feat.properties['carmen:index']];
+            const targetStack = feat.properties['carmen:geocoder_stack'];
+            if (targetStack && targetIndex.lang.autopopulate[targetStack]) {
+                contextSquishyLanguages = new Set(targetIndex.lang.autopopulate[targetStack]);
+            }
         }
 
         // If matched.mask is the same as as the OR'd together masks considered so far, continue
@@ -1057,13 +1064,16 @@ function sortContext(a, b) {
  * @param {object} candidate - properties object
  * @returns {boolean} true is the text is alike.
  */
-function textAlike(target, candidate) {
-    const pattern = /^carmen:text/;
-    const keys = Object.keys(target).filter(pattern.test.bind(pattern));
-    for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
+function textAlike(target, candidate, languages) {
+    const pattern = /carmen:text(_(?<lang>.*))?/;
+    for (const key of Object.keys(target)) {
+        const match = key.match(pattern);
+        if (!match) continue;
+        if (languages && match.groups.lang && !languages.has(match.groups.lang)) continue;
+
         if (typeof target[key] !== 'string' || !target[key]) continue;
         if (typeof candidate[key] !== 'string' || !candidate[key]) continue;
+
         const targetText = target[key].split(',')[0];
         const candidateText = candidate[key].split(',')[0];
         if (candidateText.indexOf(targetText) !== -1) return true;

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -289,6 +289,10 @@ function verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback
         // If there are no more potential candidates, return early
         if (verifyContextOpts.backfill.length === 0) {
             const result = verifyContextOpts.results.sort(sortContext).slice(0, options.limit_verify);
+
+            // clamp all relevances to 1 (but after the last sort, so higher contexts can help before they get clamped)
+            for (const context of verifyContextOpts.results) context._relevance = Math.min(context._relevance, 1);
+
             return callback(null, result);
         }
 
@@ -302,6 +306,10 @@ function verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback
             return verifyContextChunk(geocoder, verifyContextOpts, sets, options, callback);
         } else {
             const result = verifyContextOpts.results.sort(sortContext).slice(0, options.limit_verify);
+
+            // clamp all relevances to 1 (but after the last sort, so higher contexts can help before they get clamped)
+            for (const context of verifyContextOpts.results) context._relevance = Math.min(context._relevance, 1);
+
             return callback(null, result);
         }
     }
@@ -655,7 +663,6 @@ function verifyContexts(contexts, sets, indexes, options, geocoder) {
         const looseRelev = verifyContext(context, peers, verify, sets, indexes, options, geocoder);
         // round the relevance to six places to handle any accumulated rounding error
         context._relevance = roundTo(Math.max(strictRelev, looseRelev), 6);
-        context._relevance = Math.min(context._relevance, 1);
 
         if (context._relevance > 0) out.push(context);
     }
@@ -742,6 +749,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
     let lastmask = -1;
     let lastgroup = -1;
     let lastMatchedIndex;
+    let lastText = null;
     let relevance = 0;
     let closeRelevance = 0;
     let direction;
@@ -749,6 +757,8 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
     let squishyTarget = false;
     if (indexes[context[0].properties['carmen:index']].geocoder_inherit_score)
         squishyTarget = context[0].properties;
+    let contextSquishyTarget = false;
+    let contextSquishy = false;
 
     // keep track of which indexes came back from coalesce
     const strictByIdx = {};
@@ -761,6 +771,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         const feat = context[c];
 
         let matched = strict[feat.properties['carmen:tmpid']] || loose[feat.properties['carmen:tmpid']];
+
         // squishy and backy logic only applies to elements of the result
         // context that were matched by some substring of the query. If this
         // feature isn't one of the matches, then continue.
@@ -777,6 +788,12 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
 
                 closeButNoCigar = true;
             } else {
+                if (contextSquishyTarget && !contextSquishy) {
+                    // this feature didn't directly match the query, but if it has the same name as a feature that *did* in the context already,
+                    // take note to give a tiny boost (so, "main st new york" prefers "main st new york new york" over "main st albany new york"
+                    // all else being equal)
+                    contextSquishy = textAlike(contextSquishyTarget, feat.properties);
+                }
                 continue;
             }
         }
@@ -800,6 +817,18 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         ) {
             squishy += Math.max(peers.get(feat.properties['carmen:tmpid']).properties['carmen:score'] || 0, 0);
         }
+
+        // CONTEXT SQUISHY
+        // See if we'll want to detect name overlap in subsequent unmatched features
+        if (
+            !contextSquishyTarget &&
+            (c > 0) &&
+            indexes[feat.properties['carmen:index']].geocoder_grant_score &&
+            !closeButNoCigar
+        ) {
+            contextSquishyTarget = feat.properties;
+        }
+
         // If matched.mask is the same as as the OR'd together masks considered so far, continue
         // (note that we keep separate working masks for the things that actually algined and things that almost
         // aligned, so that we can let actually-aligned things take precedence ove almost-aligned ones)
@@ -842,7 +871,9 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         // BACKY
         // Now we check to see whether the actual ordering contradicts the
         // direction found in this or an earlier iteration. If so, then set `backy=true`.
-        if (lastgroup > -1) {
+        // (but don't bother if this feature and the last one had the same name -- then the order
+        // is arbitrary anyway)
+        if (lastgroup > -1 && matched.text !== lastText) {
             if (direction === 'ascending') {
                 backy = lastmask > matched.mask;
             } else if (direction === 'descending') {
@@ -857,6 +888,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         }
         lastmask = matched.mask;
         lastgroup = indexes[feat.properties['carmen:index']].ndx;
+        lastText = matched.text;
         lastMatchedIndex = feat.properties['carmen:index'];
 
         let penalty = 1;
@@ -868,7 +900,7 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         // elements in this iteration's comparison is from an index that has
         // `geocoder_ignore_order=true`.  In that case, don't apply the backy
         // penalty.
-        if  (backy && !ignoreOrder) penalty *= 0.5;
+        if (backy && !ignoreOrder) penalty *= 0.5;
         if (closeButNoCigar) {
             // we're not going to decide until after we've looked at everything
             // in the context whether to include the partial matches, so keep
@@ -917,6 +949,17 @@ function verifyContext(context, peers, strict, loose, indexes, options, geocoder
         } else {
             feat.properties['carmen:scoredist'] += squishy;
         }
+    }
+
+    // CONTEXT SQUISHY
+    // similar to the above, but rather than cases where a feature in the context
+    // matches the top-level feature, here we're dealing with cases where two
+    // features in the context match each other (but not the top-level feature)
+    // so, this is "broadway new york" where the "new york" might be doubled
+    // here, we can't do anything to the score, because the score doesn't matter
+    // since neither feature is top-level, so instead, nudge the relevance a tiny bit
+    if (contextSquishy) {
+        relevance += .01;
     }
 
     relevance = relevance > 0 ? relevance : 0;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "build-docs": " $(yarn bin)/documentation build --config docs/documentation.yml --access public --github --format md --output docs/api.md index.js lib/**"
   },
   "engines": {
-    "node": ">=6.x.x <=10.x.x"
+    "node": "10.x"
   },
   "repository": {
     "type": "git",

--- a/test/acceptance/geocode-unit.override.test.js
+++ b/test/acceptance/geocode-unit.override.test.js
@@ -212,7 +212,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
         c.geocode('9B FAKE STREET PARKER 20001', { limit_verify: 10 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].place_name, '9b fake street Parker 20002', 'found 9b fake street parker 20002 w/ 20001 query');
-            t.equals(res.features[0].relevance, 0.818519);
+            t.equals(res.features[0].relevance, 0.725926);
             t.deepEquals(res.features[0].context, [
                 { id: 'place.4', text: 'Parker' },
                 { id: 'postcode.5', text: '20002' }

--- a/test/fixtures/output.dev.geojson
+++ b/test/fixtures/output.dev.geojson
@@ -290,6 +290,8 @@
                 "carmen:position": 0,
                 "carmen:spatialmatch": {
                     "relev": 1,
+                    "address": null,
+                    "partialNumber": false,
                     "covers": [
                         {
                             "x": 39,
@@ -300,7 +302,7 @@
                             "tmpid": 67108865,
                             "distance": 0,
                             "score": 1,
-                            "scoredist":  1.0014224866118175,
+                            "scoredist": 1.0014224866118175,
                             "scorefactor": 1,
                             "matches_language": true,
                             "source_phrase_hash": 82,
@@ -310,9 +312,8 @@
                             "zoom": 6
                         }
                     ],
-                    "partialNumber": false,
-                    "address": null,
-                    "scoredist":  1.0014224866118175
+                    "scoredist": 1.0014224866118175,
+                    "idxAverage": 2
                 },
                 "carmen:relev": 1,
                 "carmen:geocoder_address_order": "ascending",

--- a/test/unit/geocoder/verifymatch.test.js
+++ b/test/unit/geocoder/verifymatch.test.js
@@ -111,3 +111,36 @@ tape('verifymatch.verifyFeatures', (t) => {
     t.end();
 
 });
+
+tape('verifymatch.textAlike', (t) => {
+    const feats = [
+        {
+            'carmen:text': 'Apple',
+            'carmen:text_fr': 'Orange',
+            'carmen:text_de': 'Pear',
+            'carmen:geocoder_stack': 'us'
+        },
+        {
+            'carmen:text': 'Grapefruit',
+            'carmen:text_fr': 'Lemon',
+            'carmen:text_de': 'Lime',
+            'carmen:geocoder_stack': 'us'
+        },
+        {
+            'carmen:text': 'Grapefruit',
+            'carmen:text_fr': 'Orange',
+            'carmen:text_de': 'Kumquat',
+            'carmen:geocoder_stack': 'us'
+        },
+    ];
+
+    const textAlike = verifymatch.textAlike;
+    t.assert(!textAlike(feats[0], feats[1]), 'Features with no shared text properties aren\'t alike');
+    t.assert(textAlike(feats[1], feats[2]), 'Features with shared default text are alike');
+    t.assert(textAlike(feats[1], feats[2], new Set(['sv'])), 'Features with shared default text are alike even if a language is specified that they don\'t share');
+    t.assert(textAlike(feats[0], feats[2]), 'Features with shared language-specific text are alike with no language specified');
+    t.assert(textAlike(feats[0], feats[2], new Set(['fr'])), 'Features with shared language-specific text are alike with shared language specified');
+    t.assert(!textAlike(feats[0], feats[2], new Set(['de'])), 'Features with shared language-specific text aren\'t alike with non-shared language specified');
+
+    t.end();
+});


### PR DESCRIPTION
### Context
This branch adds a new variant of the squishy bonus. In the original version, we look for candidate results where the result feature has a name that is the same as a feature in its context, and boost that result (so if you look for "new york," "new york new york" gets a boost). It doesn't do anything, though, for cases where both of the nested features are in the context, so for example, "1 main st new york" might match either "1 main st" features in NYC, or in other cities in New York, with equal weight. The earlier gappy penalty would have helped to prefer the address-in-city examples, but as that's no longer in place (and can't really be introduced because it caused lots of weird collateral behavior), we're out of luck here, especially when the scores of the results are tied.

This branch introduces a new mechanism that's like the Squishy bonus, but applied to contexts. We piggyback on the same Carmen setting (`geocoder_inherit_score`), and examine each context to see if any text-matched features have this property set. If they do, on subsequent (more general) features that we encounter while processing the context, we check to see if the name is similar to the name of the earlier-identified feature. We will only consider at most one feature as a candidate to be matched to, so whichever is the most specific wins. Also note: while the regular squishy bonus operates on score, context items don't contribute to score, so this bonus operate on relevance instead.

Because sometimes the winning features are all tied at 1.0, I made an additional tweak, to allow relevance values to temporarily exceed 1.0; they're still clamped to 1.0, but the clamping has now been moved to after the final sort, so that the temporary 1.01 relevance can allow the better features to float to the top before they become tied again.

Lastly: I added an additional sort criterion in spatialmatch for features coming out of coalesce on their way into verifymatch. In some cases with lots of tied matches, I was finding that the feature I wanted never had a chance to make it to the point where it would get the squishy bonus applied, because it wasn't making it over the verifymatch limit. I added an additional criterion for cases that are otherwise tied (same score, same relevance, same index) to prefer results whose average idx value (index ID) is higher -- this has the effect of preferring items whose text-matched context is more specific, because more specific indexes will have higher IDs. So if you have "1 main st new york," a candidate where "new york" is a city will have a higher average index ID than a candidate where "new york" is a state. Note that all of this will get sorted again in verifymatch anyway, so this only matters with respect to making it above or below the limit, not to the final relative order of features that both make it through.


### Summary of Changes
Nope


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/search
