### PR TITLE
Better address number matching if unit numbers are present

### DIFF
--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -317,9 +317,14 @@ function generateStandardAddressMatchStrings(address) {
     const numericAddress = typeof address === 'string'
         ? address.replace(/[^\d]/, '')
         : address.toString();
+    // A numeric version of just the part of the query preceding the first non-numeric character (e.g., for "7-1", this will be "7")
+    const initialNumericAddress = typeof address === 'string'
+        ? address.replace(/^(\d+)([^\d].*)/, '$1')
+        : address.toString();
     return new Map([
         ['rawAddress', rawAddress],
-        ['numericAddress', numericAddress]
+        ['numericAddress', numericAddress],
+        ['initialNumericAddress', initialNumericAddress]
     ]);
 }
 
@@ -381,6 +386,11 @@ function matchesStandardAddress(queryMatchStrings, featureMatchStrings, prefixMa
     }
     if (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('rawAddress')) return 0;
     if (featureMatchStrings.get('rawAddress') === queryMatchStrings.get('numericAddress')) return 1;
+    if (
+        featureMatchStrings.get('initialNumericAddress') &&
+        featureMatchStrings.get('initialNumericAddress') &&
+        featureMatchStrings.get('initialNumericAddress') === queryMatchStrings.get('initialNumericAddress')
+    ) return 2;
     return -1;
 }
 

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -898,7 +898,7 @@ test('queens', (t) => {
         type: 'Feature',
         properties: {
             accuracy: 'building',
-            'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
+            'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010', '30-10']],
             'carmen:address_style': standardStyle,
             'carmen:address_styles': [standardStyle, queensStyle],
             'carmen:addressprops': {
@@ -913,7 +913,7 @@ test('queens', (t) => {
             type: 'GeometryCollection',
             geometries: [{
                 type: 'MultiPoint',
-                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7]]
+                coordinates: [[1,1],[2,2],[3,3],[4,4],[5,5],[6,6],[7,7],[8,8]]
             }]
         }
     };
@@ -923,7 +923,7 @@ test('queens', (t) => {
             type: 'Feature',
             properties: {
                 accuracy: 'building',
-                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010', '30-10']],
                 'carmen:address_style': queensStyle,
                 'carmen:address_styles': [standardStyle, queensStyle],
                 'carmen:address': '10-10',
@@ -948,7 +948,7 @@ test('queens', (t) => {
             type: 'Feature',
             properties: {
                 accuracy: 'building',
-                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010', '30-10']],
                 'carmen:address_style': standardStyle,
                 'carmen:address_styles': [standardStyle, queensStyle],
                 'carmen:addressprops': {
@@ -972,7 +972,7 @@ test('queens', (t) => {
             type: 'Feature',
             properties: {
                 accuracy: 'building',
-                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010']],
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010', '30-10']],
                 'carmen:address_style': queensStyle,
                 'carmen:address_styles': [standardStyle, queensStyle],
                 'carmen:address': '10-200',
@@ -990,6 +990,30 @@ test('queens', (t) => {
             }
         }],
         'Match hyphenated result to hyphen-less query'
+    );
+    t.deepEqual(
+        addressCluster.forward(feature, '30'),
+        [{
+            type: 'Feature',
+            properties: {
+                accuracy: 'building',
+                'carmen:addressnumber': [['10-10', 200, '10-200', 10, 100, 1010, '1-010', '30-10']],
+                'carmen:address_style': standardStyle,
+                'carmen:address_styles': [standardStyle, queensStyle],
+                'carmen:addressprops': {
+                    'carmen:address_style': {
+                        0: queensStyle,
+                        2: queensStyle,
+                        6: queensStyle
+                    }
+                }
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [8,8]
+            }
+        }],
+        'Match just the pre-hyphen part for non-queens addresses if that\'s the best we can do'
     );
     t.deepEqual(
         addressCluster.forwardPrefix(feature, '10-'),


### PR DESCRIPTION
### Context
For standard (non-Queens) address numbers, currently the two strategies we have in place to match the number from a query with the number in the address are exact matching, and matching of versions of each where all the non-numeric characters are stripped out (so, "7-1" becomes "71," and we can match that if "71" was queried). We've noticed a common pattern in Europe where address numbers might include some unit information, and queries might omit that information, so, "7-1" might get searched for as "7." Our current strategy doesn't handle that case.

This PR adds a third strategy, which is to only include all of the numeric characters until we encounter the first non-numeric one (so, for "7-1," we'd produce "7"). This strategy is lower-ranked than either of the first two strategies, so if there are successful matches using either of those, they'll be preferred. This kind of matching is preferred over interpolation, if both are possible.

### Summary of Changes
- [x] add new house number matching strategy
- [x] add unit test for this strategy


### Next Steps
Nope


cc @mapbox/search
