### PR TITLE
Fix addresscluster regression

### DIFF
--- a/lib/geocoder/addresscluster.js
+++ b/lib/geocoder/addresscluster.js
@@ -86,6 +86,11 @@ function forward(feat, address, num = 10) {
                     // delete the worse ones
                     matchQuality = rank;
                     matchedAddressFeatures.length = 0;
+                } else if (rank === matchQuality && matchedAddressFeatures.length >= num) {
+                    // if we already have as many as we need, either bail if this is the best kind of match,
+                    // or skip in hopes of finding better ones
+                    if (matchQuality === 0) return matchedAddressFeatures;
+                    continue;
                 } else if (rank > matchQuality) {
                     continue;
                 }
@@ -103,9 +108,6 @@ function forward(feat, address, num = 10) {
                     ]
                 };
                 matchedAddressFeatures.push(featureClone);
-            }
-            if (matchedAddressFeatures.length >= num) {
-                return matchedAddressFeatures;
             }
         }
     }

--- a/test/unit/geocoder/address.test.js
+++ b/test/unit/geocoder/address.test.js
@@ -1095,3 +1095,67 @@ test('queens', (t) => {
     );
     t.end();
 });
+test('pre-hyphen matching', (t) => {
+    const feature = {
+        type: 'Feature',
+        properties: {
+            'carmen:addressnumber': [
+                Array.from(Array(100).keys()).map((num) => '99-' + (num + 1))
+            ],
+        },
+        geometry: {
+            type: 'GeometryCollection',
+            geometries: [{
+                type: 'MultiPoint',
+                coordinates: Array.from(Array(100).keys()).map((num) => [(num + 1), (num + 1)])
+            }]
+        }
+    };
+    t.deepEqual(
+        addressCluster.forward(feature, '99-1'),
+        [{
+            type: 'Feature',
+            properties: {
+                'carmen:addressnumber': feature.properties['carmen:addressnumber'],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [1,1]
+            }
+        }],
+        'Exactly match a hyphenated address'
+    );
+
+    const expected = [];
+    for (let i = 1; i <= 10; i++) {
+        const expectedFeat = JSON.parse(JSON.stringify(feature));
+        expectedFeat.geometry = {
+            type: 'Point',
+            coordinates: [i, i]
+        };
+        expected.push(expectedFeat);
+    }
+    const actual = addressCluster.forward(feature, '99');
+    t.deepEqual(
+        actual,
+        expected,
+        'Match features that have 99 before the hyphen'
+    );
+    t.equal(actual.length, 10, 'got limit of 10 matching features');
+
+    t.deepEqual(
+        addressCluster.forward(feature, '99-99'),
+        [{
+            type: 'Feature',
+            properties: {
+                'carmen:addressnumber': feature.properties['carmen:addressnumber'],
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [99,99]
+            }
+        }],
+        'Exactly match a hyphenated address'
+    );
+    t.end();
+});


### PR DESCRIPTION
### Context
#949 introduced a new way of matching address numbers in address clusters that had an unexpected interaction with a built-in cutoff in the address matcher in some circumstances.

OId logic, roughly:
- iterate through the address numbers in the cluster, and calculate a "match rank" for each that represented the quality of the match
- if a given number matched the query and had at least as good a rank as we'd seen so far, keep it
-  if the number had a *better* rank than any we'd seen so far, throw away all the earlier ones, and keep just this one (and any subsequent ones with at least as good a rank
- if at any point, the accumulated list of address numbers (all of which would have the same rank -- whatever the best rank we'd seen so far) reached 10 numbers long, return the list

The shortcoming here is that if we got to ten of a suboptimal kind of match, we might bail before ever seeing a better match further into the list. The 10-element limit predated the idea of match ranks, so at that time, there was never a reason not to bail, but now there is, and it got worse in some cases with the #949 change, if we encountered a cluster with lots of address numbers with the same prefix.

The new logic replaces the last step with:
- if at any point, the accumulated list of address numbers (all of which would have the same rank -- whatever the best rank we'd seen so far) reaches 10 numbers long, check if the currently accumulating rank is the best possible rank, and if so, return, otherwise skip. This way, we still return at most 10 elements (and so will stop accumulating more of the current rank if we keep encountering them), but might still find a better-ranked one later


### Summary of Changes
- [x] switch to new cluster matching logic, described above
- [x] add a test


### Next Steps
Nope


cc @mapbox/search
