### PR TITLE
Terminal word boundaries

### DIFF
--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -80,9 +80,19 @@ module.exports = function phrasematch(source, query, options, callback) {
         hypo.replaced = token.replaceToken(source.complex_query_replacer, hypo.query);
         hypo.gapExpansionMasks = gapMasks(hypo.replaced);
         hypo.normalized = termops.normalizeQuery(hypo.replaced);
-        hypo.endingType = options.autocomplete ?
-            (hypo.normalized.lastWord ? ENDING_TYPE.wordBoundaryPrefix : ENDING_TYPE.anyPrefix) :
-            ENDING_TYPE.nonPrefix;
+        if (options.autocomplete) {
+            const endsInBoundary = hypo.normalized.separators[hypo.normalized.separators.length - 1] !== '';
+            if (hypo.normalized.lastWord || endsInBoundary) {
+                // if it's autocomplete but either we token-replaced the last word, or
+                // the query ends with a word-boundary, only prefix-match whole-word prefixes
+                hypo.endingType = ENDING_TYPE.wordBoundaryPrefix;
+            } else {
+                // otherwise all prefixes, including partial-world ones, are fine
+                hypo.endingType = ENDING_TYPE.anyPrefix;
+            }
+        } else {
+            hypo.endingType = ENDING_TYPE.nonPrefix;
+        }
     }
 
     let subqueries;

--- a/lib/text-processing/termops.js
+++ b/lib/text-processing/termops.js
@@ -457,7 +457,7 @@ function getIndexableText(simpleReplacer, complexReplacer, globalReplacer, doc, 
 
         // Global replacements
         if (globalReplacer && globalReplacer.length) {
-            text = token.replaceGlobalTokens(globalReplacer, text);
+            text = token.replaceGlobalTokens(globalReplacer, text).trim();
         }
 
         if (intersections) {
@@ -570,7 +570,7 @@ function getMinimalIndexableText(simpleReplacer, complexReplacer, globalReplacer
         let text = texts[x];
         // Global replacements
         if (globalReplacer && globalReplacer.length) {
-            text = token.replaceGlobalTokens(globalReplacer, text);
+            text = token.replaceGlobalTokens(globalReplacer, text).trim();
         }
 
         const tokenized = token.replaceToken(complexReplacer, tokenize(text));

--- a/lib/text-processing/token.js
+++ b/lib/text-processing/token.js
@@ -409,7 +409,7 @@ module.exports.createGlobalReplacer = function(tokens) {
  */
 module.exports.replaceGlobalTokens = function(replacers, text) {
     for (const replacer of replacers) {
-        text = text.trim().replace(replacer.from, replacer.to);
+        text = text.replace(replacer.from, replacer.to);
     }
     return text;
 };

--- a/test/acceptance/geocode-unit.autocomplete-tokenized-final-term.test.js
+++ b/test/acceptance/geocode-unit.autocomplete-tokenized-final-term.test.js
@@ -57,13 +57,35 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
     tape('build', (assert) => { buildQueued(conf.poi, assert.end); });
 
-    tape('Search', (assert) => {
+    tape('Search "District"', (assert) => {
         c.geocode('District', { autocomplete: true }, (err, res) => {
             assert.ifError(err);
             assert.equal(res.features.length, 2, 'Don\'t return features where the token-replaced query is the beginning of another word');
             assert.deepEqual(res.features[0].place_name, 'District', 'Return features that exactly match the token-replaced query');
             assert.deepEqual(res.features[1].place_name, 'District Taco', 'Return features that autocomplete with a word boundary');
             assert.end();
+        });
+    });
+
+    tape('Search "dt"', (assert) => {
+        c.geocode('dt', { autocomplete: true }, (err, res) => {
+            assert.ifError(err);
+            assert.equal(res.features.length, 3, 'Return all features for a query of "dt" matching both abbreviated district and prefix-matching dtown');
+            assert.end();
+        });
+    });
+
+    tape('Search "dt "', (assert) => {
+        c.geocode('dt ', { autocomplete: true }, (err, res) => {
+            assert.ifError(err);
+            assert.equal(res.features.length, 2, 'With terminal space, only match full-word version, not dtown');
+            assert.deepEqual(res.features.map((feat) => feat.id), ['poi.2', 'poi.3'], 'Omit dtown party bus');
+
+            c.geocode('dt/', { autocomplete: true }, (err, slashRes) => {
+                assert.ifError(err);
+                assert.deepEqual(res, slashRes, 'whitespace and other boundaries behave the same');
+                assert.end();
+            });
         });
     });
 })();

--- a/test/acceptance/geocode-unit.tokens.test.js
+++ b/test/acceptance/geocode-unit.tokens.test.js
@@ -359,7 +359,7 @@ const addFeature = require('../../lib/indexer/addfeature'),
         });
     });
     tape('test token replacement', (t) => {
-        c.geocode('Tal st ', { limit_verify: 1, fuzzyMatch: 0 }, (err, res) => {
+        c.geocode('Tal st', { limit_verify: 1, fuzzyMatch: 0 }, (err, res) => {
             t.ifError(err);
             t.equals(res.features[0].relevance, 1.00, 'token replacement for str -> strasse');
             t.end();


### PR DESCRIPTION
### Context
This PR makes a change to how queries that end in word boundaries are handled. Previously, whitespace at the ends of queries was stripped, and other terminal word boundaries were ignored, which for autocomplete queries might mean that we might treat the final token in the query as being the prefix of a longer word, even though the user had an expressed an intent that that word was complete (by typing a space or other boundary character). We now preserve this terminal word boundary info, and if it's present, use the `WORD_BOUNDARY` prefix scanning mode instead of the regular prefix scanning mode in our fuzzy_phrase queries, which forces the final token to be treated as a complete word and limits phrase results accordingly.


### Summary of Changes
- [x] preserve terminal whitespace at query time (we still want to strip it at index time, so some calls to `.trim()` needed to be moved into indexing code and out of functions shared between indexing and querying to make this work)
- [x] use WORD_BOUNDARY fuzzy-phrase querying if terminal word boundary characters are present


### Next Steps
- [x] add a test or two to more explicitly test this new behavior


cc @mapbox/search
