### PR TITLE
Move where the ghost feature dedup happens in verifymatch

### DIFF
--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -524,20 +524,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
     // the best results at this point.
     result.sort(sortFeature);
 
-    // Eliminate any score < 0 results if there are better-scored results
-    // with identical text.
-    const filtered = [];
-    const byText = {};
-    for (let i = 0; i < result.length; i++) {
-        const feat = result[i];
-        const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
-        const text = languageText || feat.properties['carmen:text'];
-        if (feat.properties['carmen:scoredist'] >= 0 || !byText[text]) {
-            filtered.push(feat);
-            if (feat.properties['carmen:scoredist'] >= 0) byText[text] = true;
-        }
-    }
-    return filtered;
+    return result;
 }
 
 /**
@@ -668,7 +655,21 @@ function verifyContexts(contexts, sets, indexes, options, geocoder) {
         if (context._relevance > 0) out.push(context);
     }
     out.sort(sortContext);
-    return out;
+
+    // Eliminate any score < 0 results if there are better-scored results
+    // with identical text.
+    const filtered = [];
+    const byText = new Set();
+    for (let i = 0; i < out.length; i++) {
+        const feat = out[i][0];
+        const languageText = options.language ? closestLang(options.language[0], feat.properties, 'carmen:text_') : false;
+        const text = languageText || feat.properties['carmen:text'];
+        if (feat.properties['carmen:scoredist'] >= 0 || !byText.has(text)) {
+            filtered.push(out[i]);
+            if (feat.properties['carmen:scoredist'] >= 0) byText.add(text);
+        }
+    }
+    return filtered;
 }
 
 /**

--- a/test/acceptance/geocode-unit.score-dedupe.test.js
+++ b/test/acceptance/geocode-unit.score-dedupe.test.js
@@ -8,6 +8,7 @@ const queue = require('d3-queue').queue;
 const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
 const conf = {
+    region: new mem({ maxzoom: 6 }, () => {}),
     place: new mem({ maxzoom: 6 }, () => {})
 };
 const c = new Carmen(conf);
@@ -35,28 +36,75 @@ tape('index data', (t) => {
             id: 2,
             properties: {
                 'carmen:text': 'fake place 1',
-                'carmen:center': [0,1],
+                'carmen:center': [0,1.01],
                 'carmen:score': 1
             },
             geometry: {
                 type: 'Point',
-                coordinates: [0,1]
+                coordinates: [0,1.01]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.place,
+        {
+            id: 3,
+            properties: {
+                'carmen:text': 'fake place',
+                'carmen:center': [0,0],
+                'carmen:score': 1
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [0,0]
+            }
+        },
+        cb
+    ));
+    q.defer((cb) => queueFeature(
+        conf.region,
+        {
+            id: 10,
+            properties: {
+                'carmen:text': 'region',
+                'carmen:center': [0,0],
+                'carmen:score': 1
+            },
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]
             }
         },
         cb
     ));
 
-    q.defer((cb) => buildQueued(conf.place, cb));
+    q.defer((cb) => buildQueued(conf.place, () => buildQueued(conf.region, cb)));
 
     q.awaitAll(t.end);
 });
 
 tape('test deduping features with identical text preserving the feature with a higher score', (t) => {
     c.geocode('fake place 1', { limit_verify: 5 }, (err, res) => {
-        t.equals(res.features.length, 1, 'returned the feature with higher score');
-        t.equals(res.features[0].id, 'place.2', 'returned fake place 1 with id = place.2');
+        t.error(err);
+        t.equals(res.features.length, 2, 'returned two of the three features');
+        t.equals(res.features[0].id, 'place.2', 'returned fake place 1 with id = place.2 (the higher-scored one)');
         t.equals(res.features[0].place_name, 'fake place 1', 'returned fake place 1 feature with a higher score');
+        t.equals(res.features.filter((f) => f.id === 'place.1').length, 0, 'place.1 was deduped away and not returned');
         t.ifError(err);
+        t.end();
+    });
+});
+
+tape('test deduping features with identical text preserving the feature with a higher score', (t) => {
+    c.geocode('fake place 1 region', { limit_verify: 5 }, (err, res) => {
+        t.error(err);
+        t.equals(
+            res.features[0].id,
+            'place.1',
+            'ghost feature is not deduped away because it spatially aligns and non-ghost feature does not'
+        );
+        t.equals(res.features[0].relevance, 1, 'winning feature has full relevance');
         t.end();
     });
 });


### PR DESCRIPTION
### Context
Deduplication occurs at several points in Carmen. There's a deduplication operation specific to ghost features that happens in verifymatch. Currently it takes place after we've done coarse spatial alignment in carmen-core, but before we've done fine spatial alignment in verifymatch. A corner case exists where a ghost feature and a non-ghost feature could share a label, and the ghost feature could get deduplicated away, and then after that, the non-ghost feature could get rejected because it fails fine spatial alignment, such that neither feature makes it into the final result set even though the ghost feature might have been fine, and might have been better than any remaining features.

This PR swaps the order of those operations, so that we deduplicate only after fine spatial alignment has occurred, and if we throw out a ghost feature, we know it will be in favor of something that spatially aligns.

(Sidenote: I'm sort of skeptical that this deduplication operation is necessary at all, given that we have later deduplication operations as well, and those later ones take feature context into account, which this one does not. Still, this change seems like the least-invasive possible change, so it's good enough for now.)


### Summary of Changes
- [x] move where the ghost dedup happens in verifymatch
- [x] revamp ghost/dedup tests to cover this circumstance


### Next Steps
Nope


cc @mapbox/search
