### PR TITLE
Roll back explicit exit in carmen-index.js

### DIFF
--- a/bin/carmen-index.js
+++ b/bin/carmen-index.js
@@ -96,7 +96,6 @@ function index(err) {
     carmen.on('open', () => {
         carmen.index(process.stdin, conf.to, config, (err) => {
             if (err) throw err;
-            process.exit(0);
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "lint": "eslint index.js lib test bin",
     "test": "yarn run lint && (retire -n || echo 'WARNING: retire found insecure packages') && TESTING=true tape './test/**/*.js' && yarn run bench",
-    "coverage": "TESTING=true nyc tape 'test/**/*.js' && nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "coverage": "TESTING=true tape test/bin.test.js && nyc tape 'test/**/*.js' && nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "bench": "./test/run_all_benchmarks.sh",
     "build-docs": " $(yarn bin)/documentation build --config docs/documentation.yml --access public --github --format md --output docs/api.md index.js lib/**"
   },

--- a/test/acceptance/geocode-unit.relevance.test.js
+++ b/test/acceptance/geocode-unit.relevance.test.js
@@ -98,7 +98,11 @@ tape('Check relevance scoring', (t) => {
     c.geocode('11027 S. Pikes Peak Drive #201', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].relevance, 0.648148, 'Apt. number lowers relevance');
+        t.end();
     });
+});
+
+tape('Check relevance scoring #2', (t) => {
     c.geocode('11027 S. Pikes Peak Drive', { limit_verify: 1 }, (err, res) => {
         t.ifError(err);
         t.equal(res.features[0].relevance, 1.00, 'High relevance with no apartment number');

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -116,6 +116,11 @@ tape('bin/carmen-index', (t) => {
 });
 
 tape('bin/carmen-index', (t) => {
+    if (process.env.NYC_CWD) {
+        // there's a bug in nyc/istanbul that causes this test to crash, so skip it
+        // (we'll run it outside the coverage runner)
+        return t.end();
+    }
     exec(bin + '/carmen-index.js --config="' + __dirname + '/fixtures/index-bin-config.json" --tokens="' + __dirname + '/fixtures/tokens.js" --index="' + tmpindex3 + '" < ./test/fixtures/small-docs.jsonl', (err, stdout, stderr) => {
         t.ifError(err);
         t.end();

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -104,6 +104,11 @@ tape('bin/carmen-index', (t) => {
 });
 
 tape('bin/carmen-index', (t) => {
+    if (process.env.NYC_CWD) {
+        // there's a bug in nyc/istanbul that causes this test to crash, so skip it
+        // (we'll run it outside the coverage runner)
+        return t.end();
+    }
     exec(bin + '/carmen-index.js --config="' + __dirname + '/fixtures/index-bin-config.json" --tokens="' + __dirname + '/fixtures/tokens.json" --index="' + tmpindex2 + '" < ./test/fixtures/small-docs.jsonl', (err, stdout, stderr) => {
         t.ifError(err);
         t.end();


### PR DESCRIPTION
### Context
We use `nyc` to run coverage analysis in CI for Carmen. It intercepts imports of JS source files and instruments them for coverage. We optionally accept JS source files as command line arguments in our `carmen-index.js` process, and it turns out that something about doing this under `nyc` on Node 14 caused a segfault during runs. For #957, I added an explicit `process.exit(0)` at the end of the indexing process, which seemed to prevent the segfault. It now seems, however, that because we pass data from Carmen to subsequent indexing stages via STDOUT, this exit, while it takes place after all JS code has completed, can cause the process to terminate before the STDOUT buffer has been fully flushed, potentially resulting in features not being included in built tiles.

This branch rolls back that exit, and instead just skips the test that triggers the nyc/Node 14 bug altogether, by detecting whether or not we're running under the coverage runner. I added a naked call to `tape` just for that test as part of the `yarn coverage` routine, to ensure that this test still gets run on CI (just without coverage instrumentation).

I confirmed in a manual build of a large index that this fixes the issue.


### Summary of Changes
- [x] revert process.exit() change
- [x] skip test if running under nyc
- [x] explicitly run affected test without nyc


### Next Steps
No


cc @mapbox/search
