### PR TITLE
Force geocoder_coalesce_radius to be a number

### DIFF
--- a/lib/indexer/index.js
+++ b/lib/indexer/index.js
@@ -230,7 +230,7 @@ function store(source, callback) {
         source._gridstore.reader = new carmenCore.GridStore(gridStoreFile, {
             zoom: source.zoom,
             type_id: source.ndx,
-            coalesce_radius: source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
+            coalesce_radius: +source.geocoder_coalesce_radius || constants.COALESCE_PROXIMITY_RADIUS,
             bboxes: source.tileBounds,
             max_score: +source.maxscore
         });


### PR DESCRIPTION
### Context

In some cases when reading metadata from mbtiles sources parameters that should be numeric, such as geocoder_coalesce_radius are converted to strings. This leads to errors like this when instantiating a GridStore:

    TypeError: invalid type: string "400", expected f64

The root problem of parameters changing types still needs to be tracked down, but this approach mitigates the problem for now.


### Summary of Changes
- [X] convert geocoder_coalesce_radius to a number


### Next Steps
n/a

cc @mapbox/search
