### PR TITLE
Add bounds filter for individual phrasematches

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ function Geocoder(indexes, options) {
             source.geocoder_expected_number_order = info.geocoder_expected_number_order || false;
             source.geocoder_intersection_token = info.geocoder_intersection_token || '';
             source.geocoder_coalesce_radius = info.geocoder_coalesce_radius;
+            source.geocoder_stack_bounds = info.geocoder_stack_bounds || {};
 
             source.geocoder_frequent_word_list = false;
             if (info.geocoder_frequent_word_list) {

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -38,10 +38,16 @@ module.exports = function phrasematch(source, query, options, callback) {
         const stackAllowed = filter.sourceMatchesStacks(source, options);
         if (!stackAllowed) return callback(null, []);
 
-        if (options.stack_bounds) {
+        if (source.geocoder_stack_bounds && Object.keys(source.geocoder_stack_bounds).length > 0) {
             bounds = options.stacks.reduce((acc, curr) => {
-                const b = options.stack_bounds[curr];
-                return acc ? bb.union(acc, b) : b;
+                const b = source.geocoder_stack_bounds[curr];
+                if (acc && b) {
+                    return bb.union(acc, b);
+                } else if (b) {
+                    return b;
+                } else {
+                    return acc;
+                }
             }, undefined);
         }
     }
@@ -577,10 +583,10 @@ function coverGaps(masks, sq) {
  * @param {Number} weight the weight of the match
  * @param {Number} mask bitmask
  * @param {string} phrase matched phrase
- * @param {Number} phrase_id_range 
+ * @param {Number} phrase_id_range range of matched phrases
  * @param {Number} scorefactor the number the score is scaled against
  * @param {Number} idx id of the source index
- * @param {Number} non_overlapping_indexes 
+ * @param {Number} non_overlapping_indexes mask of all indexes that their geocoder_stacks do not intersect with
  * @param {Object} store carmen-cache grid
  * @param {Number} zoom zoom of the source
  * @param {Number} radius proximity radius of the source to use in coalesce
@@ -638,7 +644,7 @@ Phrasematch.prototype.clone = function() {
         // copy over all the extra keys we hacked onto the array
         if (!subquery.hasOwnProperty(key)) subquery[key] = JSON.parse(JSON.stringify(this.subquery[key]));
     }
-    const cloned = new Phrasematch(subquery, this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.non_overlapping_indexes, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.nearby_only, this.address);
+    const cloned = new Phrasematch(subquery, this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.non_overlapping_indexes, this.store, this.zoom, this.radius, this.prefix, this.languages, this.proxMatch, this.catMatch, this.partialNumber, this.nearby_only, this.bounds, this.address);
     cloned.id = this.id;
     return cloned;
 };

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -32,10 +32,18 @@ module.exports = function phrasematch(source, query, options, callback) {
     const hasCorrectlySpelled = new Map();
     const misspelledShortCount = new Map();
 
+    let bounds = undefined;
     // if requested country isn't included, skip
     if (options.stacks) {
         const stackAllowed = filter.sourceMatchesStacks(source, options);
         if (!stackAllowed) return callback(null, []);
+
+        if (options.stack_bounds) {
+            bounds = options.stacks.reduce((acc, curr) => {
+                const b = options.stack_bounds[curr];
+                return acc ? bb.union(acc, b) : b;
+            }, undefined);
+        }
     }
 
     // if not in bbox, skip
@@ -379,7 +387,7 @@ module.exports = function phrasematch(source, query, options, callback) {
             hasNonSingleCharPhrasematches = true;
         }
 
-        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, subquery.partial_number || false, nearbyOnly, subquery.address));
+        phrasematches.push(new Phrasematch(subquery, weight, subquery.mask, phrase, phrase_id_range, scorefactor, source.idx, source.non_overlapping_indexes, source._gridstore.reader, source.zoom, source.geocoder_coalesce_radius, prefix, languages, proxMatch, catMatch, subquery.partial_number || false, nearbyOnly, bounds, subquery.address));
     }
 
     if (source.zoom >= 14 && hasSingleCharPhrasematches && hasNonSingleCharPhrasematches && !anyPartialNumber) {
@@ -569,20 +577,23 @@ function coverGaps(masks, sq) {
  * @param {Number} weight the weight of the match
  * @param {Number} mask bitmask
  * @param {string} phrase matched phrase
+ * @param {Number} phrase_id_range 
  * @param {Number} scorefactor the number the score is scaled against
  * @param {Number} idx id of the source index
- * @param {Object} cache carmen-cache grid
+ * @param {Number} non_overlapping_indexes 
+ * @param {Object} store carmen-cache grid
  * @param {Number} zoom zoom of the source
  * @param {Number} radius proximity radius of the source to use in coalesce
  * @param {Number} prefix the ending type of the match - nonPrefix: 0, anyPrefix: 1, wordBoundaryPrefix: 2
- * @param {Array} languages langagues matched
+ * @param {Array} languages languages matched
  * @param {boolean} proxMatch whether the proximity point is inside the source bounds, or false if no proximity was specified
  * @param {boolean} catMatch whether the phrase matches any categories specified on the source index
  * @param {boolean} partialNumber whether the phrase is a number-only query
  * @param {boolean} nearbyOnly whether or not to do an extended scan
+ * @param {Array} bounds bounding box to limit results to
  * @param {Number} address the address number that matches the query
  */
-function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, non_overlapping_indexes, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, address) {
+function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefactor, idx, non_overlapping_indexes, store, zoom, radius, prefix, languages, proxMatch, catMatch, partialNumber, nearbyOnly, bounds, address) {
     this.subquery = subquery;
     this.weight = weight;
     this.mask = mask;
@@ -599,6 +610,7 @@ function Phrasematch(subquery, weight, mask, phrase, phrase_id_range, scorefacto
     this.catMatch = catMatch || false;
     this.partialNumber = partialNumber || false;
     this.nearby_only = nearbyOnly || false;
+    this.bounds = bounds;
     this.address = address || null;
     if (languages) {
         // carmen-cache gives special treatment to the "languages" property

--- a/lib/geocoder/phrasematch.js
+++ b/lib/geocoder/phrasematch.js
@@ -40,11 +40,11 @@ module.exports = function phrasematch(source, query, options, callback) {
 
         if (source.geocoder_stack_bounds && Object.keys(source.geocoder_stack_bounds).length > 0) {
             bounds = options.stacks.reduce((acc, curr) => {
-                const b = source.geocoder_stack_bounds[curr];
-                if (acc && b) {
-                    return bb.union(acc, b);
-                } else if (b) {
-                    return b;
+                const currBounds = source.geocoder_stack_bounds[curr];
+                if (acc && currBounds) {
+                    return bb.union(acc, currBounds);
+                } else if (currBounds) {
+                    return currBounds;
                 } else {
                     return acc;
                 }

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -138,6 +138,7 @@ function rebalance(query, stack) {
 function preparePhrasematches(phrasematchResults) {
     let id = 0;
     const flattened = [];
+    const boundsIds = [];
     let maxZoom = 0;
 
     for (let i = 0; i < phrasematchResults.length; i++) {
@@ -147,9 +148,15 @@ function preparePhrasematches(phrasematchResults) {
 
             if (phrasematch.zoom > maxZoom) maxZoom = phrasematch.zoom;
 
+            if (phrasematch.bounds) boundsIds.push(id);
+
             flattened[id] = phrasematch;
             id++;
         }
+    }
+
+    for (let i = 0; i < boundsIds.length; i++) {
+        flattened[i].bounds = bbox.insideTile(flattened[i].bounds, maxZoom).slice(1);
     }
 
     return {

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -148,7 +148,7 @@ function preparePhrasematches(phrasematchResults) {
             if (phrasematch.zoom > maxZoom) maxZoom = phrasematch.zoom;
 
             if (phrasematch.bounds) {
-                phrasematch.bounds = bbox.insideTile(phrasematch.bounds, phrasematch.zoom).slice(1);
+                phrasematch.bounds = bbox.insideTile(bbox.bboxSpan(phrasematch.bounds), phrasematch.zoom).slice(1);
             }
 
             flattened[id] = phrasematch;

--- a/lib/geocoder/spatialmatch.js
+++ b/lib/geocoder/spatialmatch.js
@@ -138,7 +138,6 @@ function rebalance(query, stack) {
 function preparePhrasematches(phrasematchResults) {
     let id = 0;
     const flattened = [];
-    const boundsIds = [];
     let maxZoom = 0;
 
     for (let i = 0; i < phrasematchResults.length; i++) {
@@ -148,15 +147,13 @@ function preparePhrasematches(phrasematchResults) {
 
             if (phrasematch.zoom > maxZoom) maxZoom = phrasematch.zoom;
 
-            if (phrasematch.bounds) boundsIds.push(id);
+            if (phrasematch.bounds) {
+                phrasematch.bounds = bbox.insideTile(phrasematch.bounds, phrasematch.zoom).slice(1);
+            }
 
             flattened[id] = phrasematch;
             id++;
         }
-    }
-
-    for (let i = 0; i < boundsIds.length; i++) {
-        flattened[i].bounds = bbox.insideTile(flattened[i].bounds, maxZoom).slice(1);
     }
 
     return {

--- a/lib/util/bbox.js
+++ b/lib/util/bbox.js
@@ -11,6 +11,7 @@ module.exports.inside = inside;
 module.exports.insideTile = insideTile;
 module.exports.intersect = intersect;
 module.exports.intersection = intersection;
+module.exports.union = union;
 module.exports.crossAntimeridian = crossAntimeridian;
 module.exports.clipBBox = clipBBox;
 module.exports.amDecompose = amDecompose;
@@ -73,6 +74,21 @@ function intersection(bbox1, bbox2) {
     } else {
         return false;
     }
+}
+
+/**
+ * union - Return a bounding box representing the union of the two bounding box inputs.
+ * @param {Array} bbox1 - A bounding box array in the format [minX, minY, maxX, maxY]
+ * @param {Array} bbox2 - A bounding box array in the format [minX, minY, maxX, maxY]
+ * @returns {Array} A bounding box array in the format [minX, minY, maxX, maxY]
+ */
+function union(bbox1, bbox2) {
+    return [
+        Math.min(bbox1[0], bbox2[0]),
+        Math.min(bbox1[1], bbox2[1]),
+        Math.max(bbox1[2], bbox2[2]),
+        Math.max(bbox1[3], bbox2[3])
+    ];
 }
 
 /**

--- a/lib/util/bbox.js
+++ b/lib/util/bbox.js
@@ -14,6 +14,7 @@ module.exports.intersection = intersection;
 module.exports.union = union;
 module.exports.crossAntimeridian = crossAntimeridian;
 module.exports.clipBBox = clipBBox;
+module.exports.bboxSpan = bboxSpan;
 module.exports.amDecompose = amDecompose;
 module.exports.amIntersect = amIntersect;
 module.exports.amInside = amInside;
@@ -136,6 +137,21 @@ function clipBBox(bbox) {
     } else {
         bbox[2] = 179.9;
     }
+    return bbox;
+}
+
+/**
+ * bboxSpan - For bboxes that cross the antimeridian, return a bbox that spans the entire
+ * globe longitudinally.
+ * @param {Array} bbox A bounding box array in the format [minX, minY, maxX, maxY]
+ * @return {Array} A bounding box array in the format [minX, minY, maxX, maxY]
+ */
+function bboxSpan(bbox) {
+    if (bbox[0] < bbox[2]) return bbox;
+
+    bbox[0] = -180;
+    bbox[2] = 180;
+
     return bbox;
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "0.3.0",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#e27d445f498d50eda406c5d8ff2ba349a60ce3ed",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "0.3.0-bounds",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#e27d445f498d50eda406c5d8ff2ba349a60ce3ed",
+    "@mapbox/carmen-core": "github:mapbox/carmen-core#96f8af332bc5f28d69a3131628a3ad912b1e1871",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3",
+    "@mapbox/carmen-core": "0.4.0",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@mapbox/carmen-core": "github:mapbox/carmen-core#96f8af332bc5f28d69a3131628a3ad912b1e1871",
+    "@mapbox/carmen-core": "0.3.0-bounds",
     "@mapbox/geojsonhint": "^2.0.1",
     "@mapbox/locking": "^3.0.0",
     "@mapbox/mbtiles": "^0.12.1",

--- a/test/unit/geocoder/phrasematch.test.js
+++ b/test/unit/geocoder/phrasematch.test.js
@@ -677,3 +677,39 @@ tape('fuzzyMatchMulti - masks for intersection queries', (t) => {
         t.end();
     });
 });
+
+tape('stackBounds', (t) => {
+    const c = fakeCarmen({
+        fuzzyMatchWindows: (a, b, c, d) => {
+            return [
+                { start_position: 0, phrase: ['query'], edit_distance: 0, ending_type: 0, phrase_id_range: [0, 0] }
+            ];
+        }
+    });
+    c.geocoder_stack_bounds = {
+        at: [9.530734, 46.372056, 17.158411, 49.020374],
+        ch: [5.955907, 45.817981, 10.492063, 47.808454]
+    };
+    c.geocoder_stack = ['at', 'ch'];
+
+    t.plan(8);
+    phrasematch(c, termops.tokenize('query'), { stacks: ['at', 'ch'] }, (err, results, source) => {
+        t.deepEquals(results[0].bounds, [5.955907, 45.817981, 17.158411, 49.020374]);
+        t.error(err);
+    });
+
+    phrasematch(c, termops.tokenize('query'), { stacks: ['at'] }, (err, results, source) => {
+        t.deepEquals(results[0].bounds, [9.530734, 46.372056, 17.158411, 49.020374]);
+        t.error(err);
+    });
+
+    phrasematch(c, termops.tokenize('query'), { stacks: ['ch', 'zz'] }, (err, results, source) => {
+        t.deepEquals(results[0].bounds, [5.955907, 45.817981, 10.492063, 47.808454]);
+        t.error(err);
+    });
+
+    phrasematch(c, termops.tokenize('query'), { stacks: ['aa', 'zz'] }, (err, results, source) => {
+        t.deepEquals(results[0].bounds, undefined);
+        t.error(err);
+    });
+});

--- a/test/unit/geocoder/phrasematch.test.js
+++ b/test/unit/geocoder/phrasematch.test.js
@@ -693,22 +693,22 @@ tape('stackBounds', (t) => {
     c.geocoder_stack = ['at', 'ch'];
 
     t.plan(8);
-    phrasematch(c, termops.tokenize('query'), { stacks: ['at', 'ch'] }, (err, results, source) => {
+    phrasematch(c, termops.tokenize('main'), { stacks: ['at', 'ch'] }, (err, results, source) => {
         t.deepEquals(results[0].bounds, [5.955907, 45.817981, 17.158411, 49.020374]);
         t.error(err);
     });
 
-    phrasematch(c, termops.tokenize('query'), { stacks: ['at'] }, (err, results, source) => {
+    phrasematch(c, termops.tokenize('main'), { stacks: ['at'] }, (err, results, source) => {
         t.deepEquals(results[0].bounds, [9.530734, 46.372056, 17.158411, 49.020374]);
         t.error(err);
     });
 
-    phrasematch(c, termops.tokenize('query'), { stacks: ['ch', 'zz'] }, (err, results, source) => {
+    phrasematch(c, termops.tokenize('main'), { stacks: ['ch', 'zz'] }, (err, results, source) => {
         t.deepEquals(results[0].bounds, [5.955907, 45.817981, 10.492063, 47.808454]);
         t.error(err);
     });
 
-    phrasematch(c, termops.tokenize('query'), { stacks: ['aa', 'zz'] }, (err, results, source) => {
+    phrasematch(c, termops.tokenize('main'), { stacks: ['aa', 'zz'] }, (err, results, source) => {
         t.deepEquals(results[0].bounds, undefined);
         t.error(err);
     });

--- a/test/unit/geocoder/phrasematch.test.js
+++ b/test/unit/geocoder/phrasematch.test.js
@@ -682,7 +682,7 @@ tape('stackBounds', (t) => {
     const c = fakeCarmen({
         fuzzyMatchWindows: (a, b, c, d) => {
             return [
-                { start_position: 0, phrase: ['query'], edit_distance: 0, ending_type: 0, phrase_id_range: [0, 0] }
+                { start_position: 0, phrase: ['main'], edit_distance: 0, ending_type: 0, phrase_id_range: [0, 0] }
             ];
         }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,10 +1119,9 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@mapbox/carmen-core@0.3.0":
+"@mapbox/carmen-core@github:mapbox/carmen-core#e27d445f498d50eda406c5d8ff2ba349a60ce3ed":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/carmen-core/-/carmen-core-0.3.0.tgz#a74e443ce064e219ee48b1ae3b219b29eeec34ff"
-  integrity sha512-adbxSM175EgIdUmPg1gSuyiVkCgdtVi26wm23Ak5ogMikm3ghl7ftSp2peivXkA/NpeNdCwT0bNwMj1GA+jhcQ==
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/e27d445f498d50eda406c5d8ff2ba349a60ce3ed"
   dependencies:
     neon-cli "^0.7.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,9 +1119,9 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#96f8af332bc5f28d69a3131628a3ad912b1e1871":
-  version "0.3.0"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/96f8af332bc5f28d69a3131628a3ad912b1e1871"
+"@mapbox/carmen-core@github:mapbox/carmen-core#1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3":
+  version "0.3.0-bounds"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3"
   dependencies:
     neon-cli "^0.7.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,9 +1119,9 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#e27d445f498d50eda406c5d8ff2ba349a60ce3ed":
+"@mapbox/carmen-core@github:mapbox/carmen-core#96f8af332bc5f28d69a3131628a3ad912b1e1871":
   version "0.3.0"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/e27d445f498d50eda406c5d8ff2ba349a60ce3ed"
+  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/96f8af332bc5f28d69a3131628a3ad912b1e1871"
   dependencies:
     neon-cli "^0.7.0"
     node-pre-gyp "~0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,9 +1119,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@mapbox/carmen-core@github:mapbox/carmen-core#1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3":
-  version "0.3.0-bounds"
-  resolved "https://codeload.github.com/mapbox/carmen-core/tar.gz/1e7ef013c7e8ca1ab039154d85fcd8c8d26b8eb3"
+"@mapbox/carmen-core@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/carmen-core/-/carmen-core-0.4.0.tgz#c77badb2662c87f85f039def1de0f90a844829d9"
+  integrity sha512-uvo4N/pt7voavmenzaL1XExDC5oJG2/+3MC3HL0U8AszCRd02tPrBJnZ977XQ9izVkS+kllEEwTo9TDg7MtPsQ==
   dependencies:
     neon-cli "^0.7.0"
     node-pre-gyp "~0.13.0"


### PR DESCRIPTION
### Context

This PR pulls in the carmen-core work that enabled a `bounds` param for individual phrasematches: https://github.com/mapbox/carmen-core/pull/102.

This limits results fetched during coalesce to just those within the `bounds` attached to the phrasematch. This can be useful for indexes that have features from multiple stacks when the query contains stack filters - adding a bounds param ensures only candidates from the filtered stack are considered during spatialmatch.

### Summary of Changes
- Checks for stack specific bounds on an index when there are stack filters, unions those bounds and attaches the resulting bbox to the phrasematch object.

### Next Steps
- [x] Tests

