### PR TITLE
Correctable routable point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 34.1.1
+
+- Add support for `carmen:routable_points` override to allow routable point correction.
+
 ## 34.1.0
 
 - Add support for `geocoder_stack_bounds` parameter to limit results to a stack's bounds during coalesce.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 34.1.1
 
-- Add support for `carmen:routable_points` override to allow routable point correction.
+- Add support for `carmen:routable_points` override to allow routable point corrections.
 
 ## 34.1.0
 

--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -100,6 +100,9 @@ can create clusters that follow this format.
     cannot follow the format as in the example above.
     - As per above, the `geometry.coordinates` array must be parallel to, and equal in length with
       the `properties.addressnumber` array.
+- `properties.carmen:routable_points`
+    - OPTIONAL: a flat array of address routable point objects `[{ coordinates: [1.111, 1.11] }]`, one address will have at most one routable point object for now.
+    - Routable points are calculated by default when routing flag is on. If a `properties.carmen:routable_points` is included in the address point, it will override the default routable point.
 
 ### Interpolation Lines
 

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -716,7 +716,8 @@ function fullFeature(source, feat, query, routing, callback) {
         }
 
         if (source.geocoder_routable && routing) {
-            loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded);
+            const carmenOverride = loaded.properties['carmen:routable_points']
+            loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded, carmenOverride);
         }
 
         return callback(null, loaded);

--- a/lib/geocoder/context.js
+++ b/lib/geocoder/context.js
@@ -716,7 +716,7 @@ function fullFeature(source, feat, query, routing, callback) {
         }
 
         if (source.geocoder_routable && routing) {
-            const carmenOverride = loaded.properties['carmen:routable_points']
+            const carmenOverride = loaded.properties['carmen:routable_points'];
             loaded.routable_points = routablePoints(loaded.geometry.coordinates, original_loaded, carmenOverride);
         }
 

--- a/lib/geocoder/routablepoint.js
+++ b/lib/geocoder/routablepoint.js
@@ -12,7 +12,7 @@ module.exports = routablePoints;
  * @param {!Object} feature Address feature with GeometryCollection of MultiPoint and LineStrings
  * @return {Array|null} Lon,lat coordinate array of the routable point
  */
-function routablePoints(point, feature) {
+function routablePoints(point, feature, routable_override) {
     const defaultResult = {
         points: null
     };
@@ -24,9 +24,9 @@ function routablePoints(point, feature) {
     // Skip if routable_points is not already set
     // TODO: Revisit what routable_points already being set will actually look like.
     // For now this assumes it's in properties['carmen:routable_points'] to signify that it was added at index time
-    if (feature.properties['carmen:routable_points']) {
+    if (routable_override) {
         return {
-            points: feature.properties['carmen:routable_points']
+            points: [{ coordinates: routable_override }]
         };
     }
 

--- a/lib/geocoder/routablepoint.js
+++ b/lib/geocoder/routablepoint.js
@@ -26,7 +26,7 @@ function routablePoints(point, feature, routable_override) {
     // For now this assumes it's in properties['carmen:routable_points'] to signify that it was added at index time
     if (routable_override) {
         return {
-            points: [{ coordinates: routable_override }]
+            points: routable_override
         };
     }
 

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -436,7 +436,7 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
                 if (addressPoints.length && feats.length) {
                     const newFeats = addressPoints.slice(0,10).map((addressPoint) => {
                         const addressFeat = JSON.parse(JSON.stringify(addressPoint));
-                        const carmenOverride = addressFeat.properties['carmen:routable_points']
+                        const carmenOverride = addressFeat.properties['carmen:routable_points'];
 
                         if (options.routing && source.geocoder_routable) {
                             const routPoints = routablePoints(addressFeat.geometry, feats[0], carmenOverride);

--- a/lib/geocoder/verifymatch.js
+++ b/lib/geocoder/verifymatch.js
@@ -436,9 +436,10 @@ function verifyFeatures(query, geocoder, spatialmatches, loaded, options, startP
                 if (addressPoints.length && feats.length) {
                     const newFeats = addressPoints.slice(0,10).map((addressPoint) => {
                         const addressFeat = JSON.parse(JSON.stringify(addressPoint));
+                        const carmenOverride = addressFeat.properties['carmen:routable_points']
 
                         if (options.routing && source.geocoder_routable) {
-                            const routPoints = routablePoints(addressFeat.geometry, feats[0]);
+                            const routPoints = routablePoints(addressFeat.geometry, feats[0], carmenOverride);
                             if (routPoints) {
                                 // For now, return nearestPointCoords as an object in an array
                                 // to support multiple routable points, with other meta info

--- a/lib/util/feature.js
+++ b/lib/util/feature.js
@@ -302,6 +302,7 @@ function storableProperties(properties, type) {
             case 'carmen:ltohn':
             case 'carmen:rtohn':
             case 'carmen:zxy':
+            case 'carmen:routable_points':
             case 'carmen:proximity_radius':
                 if (type !== 'vector') storable[k] = properties[k];
                 break;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "34.1.1-dev",
+  "version": "34.1.1",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "34.1.1",
+  "version": "34.1.1-dev",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/carmen",
   "description": "Mapnik vector-tile-based geocoder with support for swappable data sources.",
-  "version": "34.1.0",
+  "version": "34.1.1",
   "url": "http://github.com/mapbox/carmen",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "BSD-2-Clause",

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -75,6 +75,101 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 })();
 
 
+// Test non-interpolated address routable_points with override
+(() => {
+    const conf = {
+        address: new mem({ maxzoom: 6,  geocoder_address:1, geocoder_routable:1, geocoder_format: '{{address.number}} {{address.name}} {{place.name}}, {{region.name}} {{postcode.name}}, {{country.name}}' }, () => {}),
+    };
+    const c = new Carmen(conf);
+    tape('index address', (t) => {
+        const address = {
+            id:1,
+            properties: {
+                'carmen:text': 'fake street',
+                'carmen:center': [0,0], // not used
+                'carmen:addressnumber': [null, ['9','11','13']],
+                'carmen:types': ['address'],
+                "carmen:routable_points": [
+                    2.111,
+                    2.11
+                ],
+                "carmen:addressprops": {
+                    "carmen:routable_points": {
+                        "1": [
+                            3.111,
+                            3.11
+                        ],
+                        "2": null
+                    }
+                }
+            },
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [
+                    {
+                        type: 'MultiLineString',
+                        coordinates: [
+                            [
+                                [1.111, 1.11],
+                                [1.112, 1.11],
+                                [1.114, 1.11],
+                                [1.115, 1.11]
+                            ]
+                        ]
+                    },
+                    {
+                        type: 'MultiPoint',
+                        coordinates: [[1.111, 1.111], [1.113, 1.111], [1.115, 1.111]]
+                    }
+                ]
+            }
+        };
+        queueFeature(conf.address, address, () => { buildQueued(conf.address, t.end); });
+    });
+
+    tape('Forward search for non-interpolated address with override and return routable points', (t) => {
+        c.geocode('9 fake street', { debug: true, routing: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+                {
+                    points: [{ coordinates: [2.111, 2.11] }]
+                },
+                'Forward geocode of non-interpolated address result has correct routable_point');
+            t.end();
+        });
+    });
+
+    tape('Geocode for non-interpolated address with in-cluster routable points override', (t) => {
+        c.geocode('11 fake street', { debug: true, routing: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+                {
+                    points: [{ coordinates: [3.111, 3.11] }]
+                },
+                'Forward geocode of non-interpolated address result has correct routable_point');
+            t.end();
+        });
+    });
+
+    tape('Geocode for non-interpolated address with no routable points override', (t) => {
+        c.geocode('13 fake street', { debug: true, routing: true }, (err, res) => {
+            t.ifError(err);
+            t.deepEquals(res.features[0].routable_points,
+                {
+                    points: [{ coordinates: [1.115, 1.11] }]
+                },
+                'Forward geocode of non-interpolated address result has correct routable_point');
+            t.end();
+        });
+    });
+
+    tape('teardown', (t) => {
+        context.getTile.cache.reset();
+        t.end();
+    });
+})();
+
+
 // Test interpolated address
 (() => {
     const conf = {

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -89,17 +89,17 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'carmen:center': [0,0], // not used
                 'carmen:addressnumber': [null, ['9','11','13']],
                 'carmen:types': ['address'],
-                "carmen:routable_points": [
+                'carmen:routable_points': [
                     2.111,
                     2.11
                 ],
-                "carmen:addressprops": {
-                    "carmen:routable_points": {
-                        "1": [
+                'carmen:addressprops': {
+                    'carmen:routable_points': {
+                        '1': [
                             3.111,
                             3.11
                         ],
-                        "2": null
+                        '2': null
                     }
                 }
             },

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -452,17 +452,12 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'carmen:center': [0,0], // not used
                 'carmen:addressnumber': [null, ['9','11','13']],
                 'carmen:types': ['address'],
-                'carmen:routable_points': [
-                    2.111,
-                    2.11
-                ],
                 'carmen:addressprops': {
                     'carmen:routable_points': {
                         '1': [
                             3.111,
                             3.11
-                        ],
-                        '2': null
+                        ]
                     }
                 }
             },
@@ -495,7 +490,7 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
             t.ifError(err);
             t.deepEquals(res.features[0].routable_points,
                 {
-                    points: [{ coordinates: [2.111, 2.11] }]
+                    points: [{ coordinates: [1.111, 1.11] }]
                 },
                 'Reverse geocode with routing override'
             );

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -89,16 +89,10 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'carmen:center': [0,0], // not used
                 'carmen:addressnumber': [null, ['9','11','13']],
                 'carmen:types': ['address'],
-                'carmen:routable_points': [
-                    2.111,
-                    2.11
-                ],
+                'carmen:routable_points': [{ 'coordinates':[2.111, 2.11] }],
                 'carmen:addressprops': {
                     'carmen:routable_points': {
-                        '1': [
-                            3.111,
-                            3.11
-                        ],
+                        '1':[{ 'coordinates':[3.111, 3.11] }],
                         '2': null
                     }
                 }
@@ -454,10 +448,12 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
                 'carmen:types': ['address'],
                 'carmen:addressprops': {
                     'carmen:routable_points': {
-                        '1': [
-                            3.111,
-                            3.11
-                        ]
+                        '1': [{
+                            'coordinates':[
+                                3.111,
+                                3.11
+                            ]
+                        }]
                     }
                 }
             },

--- a/test/unit/geocoder/routablepoint.test.js
+++ b/test/unit/geocoder/routablepoint.test.js
@@ -526,7 +526,7 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
             coordinates: [-122.22083, 37.72139]
         }
     };
-    const carmenOverride = featureroutablePoints.properties['carmen:routable_points']
+    const carmenOverride = featureroutablePoints.properties['carmen:routable_points'];
     // TODO: Confirm these assumpitons - Both what routable_points looks like on the feature,
     // and the expected result of routablePoints if so.
     tape('routablePoints input validation: feature containing routable_points', (assert) => {

--- a/test/unit/geocoder/routablepoint.test.js
+++ b/test/unit/geocoder/routablepoint.test.js
@@ -519,20 +519,21 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
             'id': 6666777777982370,
             'carmen:types': ['poi'],
             'carmen:index': 'poi',
-            'carmen:routable_points': [{ coordinates: [-122.213550, 37.712913] }]
+            'carmen:routable_points': [-122.213550, 37.712913]
         },
         geometry: {
             type: 'Point',
             coordinates: [-122.22083, 37.72139]
         }
     };
+    const carmenOverride = featureroutablePoints.properties['carmen:routable_points']
     // TODO: Confirm these assumpitons - Both what routable_points looks like on the feature,
     // and the expected result of routablePoints if so.
     tape('routablePoints input validation: feature containing routable_points', (assert) => {
         assert.deepEquals(
-            routablePoints([-122, 37], featureroutablePoints),
+            routablePoints([-122, 37], featureroutablePoints, carmenOverride),
             {
-                points: featureroutablePoints.properties['carmen:routable_points']
+                points: [{ coordinates: featureroutablePoints.properties['carmen:routable_points'] }]
             },
             'features that already have routable_points should return existing routable points'
         );

--- a/test/unit/geocoder/routablepoint.test.js
+++ b/test/unit/geocoder/routablepoint.test.js
@@ -519,7 +519,7 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
             'id': 6666777777982370,
             'carmen:types': ['poi'],
             'carmen:index': 'poi',
-            'carmen:routable_points': [-122.213550, 37.712913]
+            'carmen:routable_points': [{ coordinates: [-122.213550, 37.712913] }]
         },
         geometry: {
             type: 'Point',
@@ -533,7 +533,7 @@ const routablePoints = require('../../../lib/geocoder/routablepoint.js');
         assert.deepEquals(
             routablePoints([-122, 37], featureroutablePoints, carmenOverride),
             {
-                points: [{ coordinates: featureroutablePoints.properties['carmen:routable_points'] }]
+                points: featureroutablePoints.properties['carmen:routable_points']
             },
             'features that already have routable_points should return existing routable points'
         );


### PR DESCRIPTION
### Context

This PR intends to make routable point a correctable properties from upstream, for both forward and backward search.


### Summary of Changes
- [x] Add routable point override
- [x] Add tests
- [ ] Bump carmen version


### Next Steps
- Bump carmen version in downstream repos


cc @mapbox/search
