### PR TITLE
Assert routable array

### DIFF
--- a/lib/geocoder/routablepoint.js
+++ b/lib/geocoder/routablepoint.js
@@ -25,6 +25,9 @@ function routablePoints(point, feature, routable_override) {
     // Override all if there is a default routable point in provided routable_override
     // Otherwise calculate default routable point first, then concat all alternative routable points
     if (routable_override) {
+        if (typeof routable_override.find !== 'function' && routable_override.constructor === Object) {
+            routable_override = [routable_override];
+        }
         const default_routable_override = routable_override.find((o) => o.name === 'default_routable_point' | !o.name);
         if (default_routable_override) {
             default_routable_override.name = 'default_routable_point';

--- a/test/acceptance/geocode-unit.address-routable-point.test.js
+++ b/test/acceptance/geocode-unit.address-routable-point.test.js
@@ -76,7 +76,8 @@ const { queueFeature, buildQueued } = require('../../lib/indexer/addfeature');
 
 
 // Test non-interpolated address routable_points with override
-// with improperly formatted routable point
+// with improperly formatted routable point as a dict instead of a list
+// ie. 'carmen:routable_points': { 'name': 'default_routable_point', 'coordinates':[2.111, 2.11] },
 (() => {
     const conf = {
         address: new mem({ maxzoom: 6,  geocoder_address:1, geocoder_routable:1, geocoder_format: '{{address.number}} {{address.name}} {{place.name}}, {{region.name}} {{postcode.name}}, {{country.name}}' }, () => {}),


### PR DESCRIPTION

### Summary of Changes
- Ensure that routable points are an array. If not, make into an array before proceeding.


### Next Steps
<!-- if you're still working on it -->


cc @mapbox/search-addresses 